### PR TITLE
Fix tslint;remove es6 promise & replace with es6 Typescript lib

### DIFF
--- a/conf/tslint/funcMethodReturnTypeRule.ts
+++ b/conf/tslint/funcMethodReturnTypeRule.ts
@@ -12,27 +12,29 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class MustHaveReturnTypeWalker extends Lint.RuleWalker {
-    public visitMethodDeclaration(node: ts.MethodDeclaration) {
+    public visitMethodDeclaration(node: ts.MethodDeclaration): void {
         if (!node.type) {
             this.reportMissingReturnType(node, node.body);
         }
     }
 
-    public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+    public visitFunctionDeclaration(node: ts.FunctionDeclaration): void {
         if (!node.type) {
             this.reportMissingReturnType(node, node.body);
         }
     }
 
-    private reportMissingReturnType(node: ts.Node, body: ts.FunctionBody) {
-        const fix = Lint.Replacement.appendText(body.pos, ': void');
-        this.addFailure(
-            this.createFailure(
-                node.getStart(),
-                node.getWidth(),
-                FAILURE_STRING,
-                fix
-            )
-        );
+    private reportMissingReturnType(node: ts.Node, body: ts.FunctionBody | undefined): void {
+        if (body) {
+            const fix = Lint.Replacement.appendText(body.pos, ': void');
+            this.addFailure(
+                this.createFailure(
+                    node.getStart(),
+                    node.getWidth(),
+                    FAILURE_STRING,
+                    fix
+                )
+            );
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,12 +61,6 @@
                 }
             }
         },
-        "@types/es6-promise": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.33.tgz",
-            "integrity": "sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw==",
-            "dev": true
-        },
         "@types/filesize": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/@types/filesize/-/filesize-3.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
         "vue-touch": "^2.0.0-beta.4"
     },
     "devDependencies": {
-        "@types/es6-promise": "^0.0.33",
         "@types/filesize": "^3.6.0",
         "@types/jest": "^22.1.1",
         "@types/node": "^8.0.54",

--- a/src/utils/file/file.ts
+++ b/src/utils/file/file.ts
@@ -213,6 +213,7 @@ class FileStore {
                     file.status = axios.isCancel(ex)
                         ? MFileStatus.CANCELED
                         : MFileStatus.FAILED;
+                    throw new Error(ex);
                 }
             )
             .then<AxiosResponse<T>>(value => {

--- a/tests/app/router.ts
+++ b/tests/app/router.ts
@@ -41,7 +41,7 @@ const routerFactory = () => {
     let router: Router = new Router({
         mode: 'history',
         routes: componentRoutes,
-        scrollBehavior(to, from, savedPosition) {
+        scrollBehavior: (to, from, savedPosition) => {
             if (savedPosition) {
                 return savedPosition;
             }

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -2,13 +2,15 @@
     "compilerOptions": {
         "baseUrl": ".",
         "target": "es5",
+        "lib": [
+            "es5", "es6", "dom"
+        ],
         "module": "es2015",
         "moduleResolution": "node",
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
         "strictNullChecks": true,
         "types": [
-            "es6-promise",
             "node",
             "jest"
         ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,15 @@
         "rootDir": "src",
         "declaration": true,
         "target": "es5",
+        "lib": [
+            "es5", "es6", "dom"
+        ],
         "module": "es2015",
         "moduleResolution": "node",
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
         "strictNullChecks": true,
         "types": [
-            "es6-promise",
             "node",
             "jest"
         ],


### PR DESCRIPTION
Jeff, est-ce que tu peux valider que la modification que j'ai fait dans file.ts tient la route?

J'ai fixé le linter qui s'auto-lintait. Par contre, je me suis mis à avoir des problèmes avec une référence sur node_modules/tslint/lib/configuration.d.ts qui utilise des "Map" (es6). Avec un peu d'explorations, j'ai flushé le module @types/es6-promise pour utiliser ceux qui viennent avec Typescript (modifs dans tsconfig.json)... de là ma modification dans le retour de le promesse.