### PR TITLE
Textarea - code review

### DIFF
--- a/src/components/input-style/input-style.ts
+++ b/src/components/input-style/input-style.ts
@@ -91,7 +91,7 @@ export class MInputStyle extends ModulVue {
         return !!this.$slots.default;
     }
 
-    private hasAdjustWidthAutoSlot(): boolean {
+    private get hasAdjustWidthAutoSlot(): boolean {
         return !!this.$slots['adjust-width-auto'];
     }
 

--- a/src/components/textarea-resize/textarea-resize.ts
+++ b/src/components/textarea-resize/textarea-resize.ts
@@ -40,7 +40,7 @@ export class MTextareaResize extends ModulVue {
 
 const TextareaResizePlugin: PluginObject<any> = {
     install(v, options): void {
-        console.warn(TEXTAREA_RESIZE_NAME + ' is not ready for production');
+        console.error(TEXTAREA_RESIZE_NAME + ' is deprecated');
         v.component(TEXTAREA_RESIZE_NAME, MTextareaResize);
     }
 };

--- a/src/components/textarea/__snapshots__/textarea.spec.ts.snap
+++ b/src/components/textarea/__snapshots__/textarea.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`MTextArea should render correctly 1`] = `
     <div class="m-input-style" style="width:undefined;">
         <div class="m-input-style__body">
             <div class="m-input-style__body__left">
-                <m-textarea-resize rows="1" class="m-textarea__input"></m-textarea-resize>
+                <textarea rows="1" class="m-textarea-resize m-textarea__input"></textarea>
             </div>
             <div class="m-input-style__body__right"></div>
         </div>

--- a/src/components/textarea/__snapshots__/textarea.spec.ts.snap
+++ b/src/components/textarea/__snapshots__/textarea.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`MTextArea max-length should render correctly state when text length is 
     <div class="m-input-style m--has-value" style="width:undefined;">
         <div class="m-input-style__body">
             <div class="m-input-style__body__left">
-                <textarea rows="1" class="m-textarea-resize m-textarea__input">1</textarea>
+                <textarea rows="1" class="m-textarea__input">1</textarea>
             </div>
             <div class="m-input-style__body__right"></div>
         </div>
@@ -22,7 +22,7 @@ exports[`MTextArea max-length should render invalid state when text length is gr
     <div class="m-input-style m--has-error m--has-value" style="width:undefined;">
         <div class="m-input-style__body">
             <div class="m-input-style__body__left">
-                <textarea rows="1" class="m-textarea-resize m-textarea__input">123456789</textarea>
+                <textarea rows="1" class="m-textarea__input">123456789</textarea>
             </div>
             <div class="m-input-style__body__right"></div>
         </div>
@@ -39,7 +39,7 @@ exports[`MTextArea should render correctly 1`] = `
     <div class="m-input-style" style="width:undefined;">
         <div class="m-input-style__body">
             <div class="m-input-style__body__left">
-                <textarea rows="1" class="m-textarea-resize m-textarea__input"></textarea>
+                <textarea rows="1" class="m-textarea__input"></textarea>
             </div>
             <div class="m-input-style__body__right"></div>
         </div>

--- a/src/components/textarea/__snapshots__/textarea.spec.ts.snap
+++ b/src/components/textarea/__snapshots__/textarea.spec.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MTextArea max-length should render correctly state when text length is lesser than max length 1`] = `
+<div class="m-textarea" style="width:100%;max-width:288px;">
+    <div class="m-input-style m--has-value" style="width:undefined;">
+        <div class="m-input-style__body">
+            <div class="m-input-style__body__left">
+                <textarea rows="1" class="m-textarea-resize m-textarea__input">1</textarea>
+            </div>
+            <div class="m-input-style__body__right"></div>
+        </div>
+    </div>
+    <div class="m-textarea__validation">
+        <div class="m-textarea__validation__maxlenght">
+            1<strong>/8</strong></div>
+    </div>
+</div>
+`;
+
+exports[`MTextArea max-length should render invalid state when text length is greater than max length 1`] = `
+<div class="m-textarea m--has-error" style="width:100%;max-width:288px;">
+    <div class="m-input-style m--has-error m--has-value" style="width:undefined;">
+        <div class="m-input-style__body">
+            <div class="m-input-style__body__left">
+                <textarea rows="1" class="m-textarea-resize m-textarea__input">123456789</textarea>
+            </div>
+            <div class="m-input-style__body__right"></div>
+        </div>
+    </div>
+    <div class="m-textarea__validation">
+        <div class="m-textarea__validation__maxlenght">
+            9<strong>/8</strong></div>
+    </div>
+</div>
+`;
+
 exports[`MTextArea should render correctly 1`] = `
 <div class="m-textarea" style="width:100%;max-width:288px;">
     <div class="m-input-style" style="width:undefined;">

--- a/src/components/textarea/__snapshots__/textarea.spec.ts.snap
+++ b/src/components/textarea/__snapshots__/textarea.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MTextArea should render correctly 1`] = `
+<div class="m-textarea" style="width:100%;max-width:288px;">
+    <div class="m-input-style" style="width:undefined;">
+        <div class="m-input-style__body">
+            <div class="m-input-style__body__left">
+                <m-textarea-resize rows="1" class="m-textarea__input"></m-textarea-resize>
+            </div>
+            <div class="m-input-style__body__right"></div>
+        </div>
+    </div>
+    <div class="m-textarea__validation"> </div>
+</div>
+`;

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -1,8 +1,8 @@
 <div class="m-textarea"
      :class="{ 'm--is-disabled' : isDisabled,
                'm--is-waiting' : isWaiting,
-               'm--has-error' : textareaError,
-               'm--is-valid' : textareaValid,
+               'm--has-error' : hasTextAreaError,
+               'm--is-valid' : isTextAreaValid,
                'm--is-focus' : isFocus,
                'm--has-icon' : hasIcon,
                'm--has-label': hasLabel }"
@@ -10,8 +10,8 @@
      :style="{ width: inputWidth, maxWidth: inputMaxWidth }">
     <m-input-style :disabled="isDisabled"
                    :waiting="isWaiting"
-                   :error="textareaError"
-                   :valid="isValid"
+                   :error="hasTextAreaError"
+                   :valid="isTextAreaValid"
                    :label="label"
                    :focus="isFocus"
                    :empty="isEmpty"
@@ -19,21 +19,21 @@
                    :required-marker="requiredMarker">
 
                 <textarea class="m-textarea-resize m-textarea__input"
-                :class="{ 'm--is-diabled' : disabled,
-                        'm--is-readonly': readonly,
-                        'm--is-focus': isFocus }"
-                :disabled="!active"
-                :placeholder="placeholder"
-                :readonly="readonly"
-                rows="1"
-                @focus="onFocus"
-                @blur="onBlur"
-                @change="onChange"
-                @keyup="onKeyup"
-                @keydown="onKeydown"
-                @paste="onPaste"
-                ref="input"
-                v-model="model"></textarea>
+                            :class="{ 'm--is-diabled' : disabled,
+                                    'm--is-readonly': readonly,
+                                    'm--is-focus': isFocus }"
+                            :disabled="!active"
+                            :placeholder="placeholder"
+                            :readonly="readonly"
+                            rows="1"
+                            @focus="onFocus"
+                            @blur="onBlur"
+                            @change="onChange"
+                            @keyup="onKeyup"
+                            @keydown="onKeydown"
+                            @paste="onPaste"
+                            ref="input"
+                            v-model="model"></textarea>
 
     </m-input-style>
     <div class="m-textarea__validation">
@@ -41,12 +41,12 @@
             class="m-textarea__validation__message"
             :disabled="isDisabled"
             :waiting="isWaiting"
-            :error="textareaError"
+            :error="hasTextAreaError"
             :error-message="errorMessage"
             :valid-message="validMessage"
             :helper-message="helperMessage"></m-validation-message>
-        <div class="m-textarea__validation__maxlenght" v-if="hasMaxlenght">
-            {{ valueLenght }}<strong>/{{ maxlength }}</strong>
+        <div class="m-textarea__validation__maxlenght" v-if="hasMaxLength">
+            {{ valueLength }}<strong>/{{ maxLength }}</strong>
         </div>
     </div>
 </div>

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -18,6 +18,7 @@
                    :icon-name="iconName"
                    :required-marker="requiredMarker">
         <textarea v-m-textarea-auto-height
+                  ref="input"
                   class="m-textarea__input"
                   :class="{ 'm--is-diabled' : disabled,
                             'm--is-readonly': readonly,

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -17,20 +17,24 @@
                    :empty="isEmpty"
                    :icon-name="iconName"
                    :required-marker="requiredMarker">
-        <m-textarea-resize class="m-textarea__input"
-                  :disabled="!active"
-                  :placeholder="placeholder"
-                  :readonly="readonly"
-                  rows="1"
-                  :focus="focus"
-                  @focus="onFocus"
-                  @blur="onBlur"
-                  @change="onChange"
-                  @keyup="onKeyup"
-                  @keydown="onKeydown"
-                  @paste="onPaste"
-                  ref="textarea"
-                  v-model="model"></m-textarea-resize>
+
+                <textarea class="m-textarea-resize m-textarea__input"
+                :class="{ 'm--is-diabled' : disabled,
+                        'm--is-readonly': readonly,
+                        'm--is-focus': isFocus }"
+                :disabled="!active"
+                :placeholder="placeholder"
+                :readonly="readonly"
+                rows="1"
+                @focus="onFocus"
+                @blur="onBlur"
+                @change="onChange"
+                @keyup="onKeyup"
+                @keydown="onKeydown"
+                @paste="onPaste"
+                ref="input"
+                v-model="model"></textarea>
+
     </m-input-style>
     <div class="m-textarea__validation">
         <m-validation-message

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -17,24 +17,23 @@
                    :empty="isEmpty"
                    :icon-name="iconName"
                    :required-marker="requiredMarker">
-
-                <textarea class="m-textarea-resize m-textarea__input"
-                            :class="{ 'm--is-diabled' : disabled,
-                                    'm--is-readonly': readonly,
-                                    'm--is-focus': isFocus }"
-                            :disabled="!active"
-                            :placeholder="placeholder"
-                            :readonly="readonly"
-                            rows="1"
-                            @focus="onFocus"
-                            @blur="onBlur"
-                            @change="onChange"
-                            @keyup="onKeyup"
-                            @keydown="onKeydown"
-                            @paste="onPaste"
-                            ref="input"
-                            v-model="model"></textarea>
-
+        <textarea v-m-textarea-auto-height
+                  class="m-textarea__input"
+                  :class="{ 'm--is-diabled' : disabled,
+                            'm--is-readonly': readonly,
+                            'm--is-focus': isFocus }"
+                  :disabled="!active"
+                  :placeholder="placeholder"
+                  :readonly="readonly"
+                  rows="1"
+                  @focus="onFocus"
+                  @blur="onBlur"
+                  @change="onChange"
+                  @keyup="onKeyup"
+                  @keydown="onKeydown"
+                  @paste="onPaste"
+                  v-model="model">
+        </textarea>
     </m-input-style>
     <div class="m-textarea__validation">
         <m-validation-message

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -32,7 +32,6 @@
                   ref="textarea"
                   v-model="model"></m-textarea-resize>
     </m-input-style>
-    </template>
     <div class="m-textarea__validation">
         <m-validation-message
             class="m-textarea__validation__message"

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -46,3 +46,9 @@
         width: 100%;
     }
 }
+
+.m-textarea-resize {
+    outline: none;
+    resize: none;
+    overflow: hidden;
+}

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -46,9 +46,3 @@
         width: 100%;
     }
 }
-
-.m-textarea-resize {
-    outline: none;
-    resize: none;
-    overflow: hidden;
-}

--- a/src/components/textarea/textarea.spec.ts
+++ b/src/components/textarea/textarea.spec.ts
@@ -15,4 +15,32 @@ describe('MTextArea', () => {
 
         return expect(renderComponent(txtarea.vm)).resolves.toMatchSnapshot();
     });
+
+    describe('max-length', () => {
+        it('should render correctly state when text length is lesser than max length', () => {
+            const txtarea = mount(MTextarea, {
+                propsData: {
+                    maxLength: 8,
+                    value: '1'
+                }
+            });
+
+            return expect(
+                renderComponent(txtarea.vm)
+            ).resolves.toMatchSnapshot();
+        });
+
+        it('should render invalid state when text length is greater than max length', () => {
+            const txtarea = mount(MTextarea, {
+                propsData: {
+                    maxLength: 8,
+                    value: '123456789'
+                }
+            });
+
+            return expect(
+                renderComponent(txtarea.vm)
+            ).resolves.toMatchSnapshot();
+        });
+    });
 });

--- a/src/components/textarea/textarea.spec.ts
+++ b/src/components/textarea/textarea.spec.ts
@@ -1,0 +1,18 @@
+import { mount } from '@vue/test-utils';
+import Vue from 'vue';
+
+import { renderComponent } from '../../../tests/helpers/render';
+import TextareaPlugin from '../../components/textarea/textarea';
+import { MTextarea } from './textarea';
+
+describe('MTextArea', () => {
+    beforeEach(() => {
+        Vue.use(TextareaPlugin);
+    });
+
+    it('should render correctly', () => {
+        const txtarea = mount(MTextarea);
+
+        return expect(renderComponent(txtarea.vm)).resolves.toMatchSnapshot();
+    });
+});

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -71,6 +71,7 @@ const TextareaPlugin: PluginObject<any> = {
         console.warn(TEXTAREA_NAME + ' is not ready for production');
         v.use(InputStyle);
         v.use(ValidationMesagePlugin);
+        v.use(TextareaResizePlugin);
         v.component(TEXTAREA_NAME, MTextarea);
     }
 };

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -1,18 +1,18 @@
-import { ModulVue } from '../../utils/vue/vue';
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
-import WithRender from './textarea.html?style=./textarea.scss';
-import { TEXTAREA_NAME } from '../component-names';
-import { KeyCode } from '../../utils/keycode/keycode';
-import InputStyle from '../input-style/input-style';
-import ValidationMesagePlugin from '../validation-message/validation-message';
-import { InputWidth, InputMaxWidth } from '../../mixins/input-width/input-width';
-import { InputState } from '../../mixins/input-state/input-state';
-import { InputManagement } from '../../mixins/input-management/input-management';
-import { InputLabel } from '../../mixins/input-label/input-label';
+
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
-import { MTextareaResize } from '../textarea-resize/textarea-resize';
+import { InputLabel } from '../../mixins/input-label/input-label';
+import { InputManagement } from '../../mixins/input-management/input-management';
+import { InputState } from '../../mixins/input-state/input-state';
+import { InputWidth } from '../../mixins/input-width/input-width';
+import { ModulVue } from '../../utils/vue/vue';
+import { TEXTAREA_NAME } from '../component-names';
+import InputStyle from '../input-style/input-style';
+import TextareaResizePlugin, { MTextareaResize } from '../textarea-resize/textarea-resize';
+import ValidationMesagePlugin from '../validation-message/validation-message';
+import WithRender from './textarea.html?style=./textarea.scss';
 
 @WithRender
 @Component({
@@ -36,7 +36,7 @@ export class MTextarea extends ModulVue {
     }
 
     protected beforeDestroy(): void {
-        this.as<ElementQueries>().$off('resize',this.resizeInput);
+        this.as<ElementQueries>().$off('resize', this.resizeInput);
     }
 
     private get valueLenght(): number {

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -4,7 +4,7 @@ import { Prop } from 'vue-property-decorator';
 
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { InputLabel } from '../../mixins/input-label/input-label';
-import { InputManagement } from '../../mixins/input-management/input-management';
+import { InputManagement, InputManagementData } from '../../mixins/input-management/input-management';
 import { InputState } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
 import { ModulVue } from '../../utils/vue/vue';
@@ -24,46 +24,45 @@ import WithRender from './textarea.html?style=./textarea.scss';
         ElementQueries
     ]
 })
-export class MTextarea extends ModulVue {
+export class MTextarea extends ModulVue implements InputManagementData {
     @Prop()
-    public maxlength: number;
+    public maxLength?: number;
 
-    private internalTextareaError: boolean = false;
-    private textareaHeight: string;
+    readonly internalValue: string;
 
-    protected mounted(): void {
-        this.as<ElementQueries>().$on('resize', this.resizeInput);
+    // protected mounted(): void {
+        // this.as<ElementQueries>().$on('resize', this.resizeInput);
+    // }
+
+    // protected beforeDestroy(): void {
+        // this.as<ElementQueries>().$off('resize', this.resizeInput);
+    // }
+
+    private get valueLength(): number {
+        return this.internalValue.length;
     }
 
-    protected beforeDestroy(): void {
-        this.as<ElementQueries>().$off('resize', this.resizeInput);
+    public get hasMaxLength(): boolean {
+        return this.maxLength ? this.maxLength > 0 : false;
     }
 
-    private get valueLenght(): number {
-        let lenght: number = this.as<InputManagement>().internalValue.length;
-        if (lenght > this.maxlength) {
-            this.internalTextareaError = true;
-        } else {
-            this.internalTextareaError = false;
-        }
-        return lenght;
+    private get hasTextAreaError(): boolean {
+        return !this.isLengthValid || this.as<InputState>().hasError;
     }
 
-    private get hasMaxlenght(): boolean {
-        return this.maxlength > 0;
+    private get isTextAreaValid(): boolean {
+        return this.isLengthValid && this.as<InputState>().isValid;
     }
 
-    private get textareaError(): boolean {
-        return this.internalTextareaError || this.as<InputState>().hasError;
+    private get isLengthValid(): boolean {
+        return this.maxLength
+            ? this.internalValue.length < this.maxLength
+            : true;
     }
 
-    private get textareaValid(): boolean {
-        return !this.textareaError && this.as<InputState>().isValid;
-    }
-
-    private resizeInput(): void {
-      //  (this.$refs.textarea as MTextareaResize).resize();
-    }
+    // private resizeInput(): void {
+        //  (this.$refs.textarea as MTextareaResize).resize();
+    // }
 }
 
 const TextareaPlugin: PluginObject<any> = {

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -2,6 +2,7 @@ import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 
+import TextAreaAutoHeightPlugin from '../../directives/textarea-auto-height/textarea-auto-height';
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputManagement, InputManagementData } from '../../mixins/input-management/input-management';
@@ -10,7 +11,6 @@ import { InputWidth } from '../../mixins/input-width/input-width';
 import { ModulVue } from '../../utils/vue/vue';
 import { TEXTAREA_NAME } from '../component-names';
 import InputStyle from '../input-style/input-style';
-import TextareaResizePlugin from '../textarea-resize/textarea-resize';
 import ValidationMesagePlugin from '../validation-message/validation-message';
 import WithRender from './textarea.html?style=./textarea.scss';
 
@@ -29,14 +29,6 @@ export class MTextarea extends ModulVue implements InputManagementData {
     public maxLength?: number;
 
     readonly internalValue: string;
-
-    // protected mounted(): void {
-        // this.as<ElementQueries>().$on('resize', this.resizeInput);
-    // }
-
-    // protected beforeDestroy(): void {
-        // this.as<ElementQueries>().$off('resize', this.resizeInput);
-    // }
 
     private get valueLength(): number {
         return this.internalValue.length;
@@ -59,10 +51,6 @@ export class MTextarea extends ModulVue implements InputManagementData {
             ? this.internalValue.length < this.maxLength
             : true;
     }
-
-    // private resizeInput(): void {
-        //  (this.$refs.textarea as MTextareaResize).resize();
-    // }
 }
 
 const TextareaPlugin: PluginObject<any> = {
@@ -70,7 +58,7 @@ const TextareaPlugin: PluginObject<any> = {
         console.warn(TEXTAREA_NAME + ' is not ready for production');
         v.use(InputStyle);
         v.use(ValidationMesagePlugin);
-        v.use(TextareaResizePlugin);
+        v.use(TextAreaAutoHeightPlugin);
         v.component(TEXTAREA_NAME, MTextarea);
     }
 };

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -10,7 +10,7 @@ import { InputWidth } from '../../mixins/input-width/input-width';
 import { ModulVue } from '../../utils/vue/vue';
 import { TEXTAREA_NAME } from '../component-names';
 import InputStyle from '../input-style/input-style';
-import TextareaResizePlugin, { MTextareaResize } from '../textarea-resize/textarea-resize';
+import TextareaResizePlugin from '../textarea-resize/textarea-resize';
 import ValidationMesagePlugin from '../validation-message/validation-message';
 import WithRender from './textarea.html?style=./textarea.scss';
 
@@ -62,7 +62,7 @@ export class MTextarea extends ModulVue {
     }
 
     private resizeInput(): void {
-        (this.$refs.textarea as MTextareaResize).resize();
+      //  (this.$refs.textarea as MTextareaResize).resize();
     }
 }
 

--- a/src/directives/directive-names.ts
+++ b/src/directives/directive-names.ts
@@ -2,3 +2,4 @@ export const RIPPLE_EFFECT_NAME: string = 'm-ripple-effect';
 export const SCROLL_TO_NAME: string = 'm-scroll-to';
 export const POPUP_NAME: string = 'm-popup';
 export const FILE_DROP_NAME: string = 'm-file-drop';
+export const TEXTAREA_AUTO_HEIGHT: string = 'm-textarea-auto-height';

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -1,9 +1,10 @@
 import Vue, { PluginObject } from 'vue';
 
+import FileDropPlugin from './file-drop/file-drop';
 import PopupPlugin from './popup/popup';
 import RippleEffectPlugin from './ripple-effect/ripple-effect';
 import ScrollToPlugin from './scroll-to/scroll-to';
-import FileDropPlugin from './file-drop/file-drop';
+import TextAreaAutoHeightPlugin from './textarea-auto-height/textarea-auto-height';
 
 const DirectivesPlugin: PluginObject<any> = {
     install(v, options): void {
@@ -11,6 +12,7 @@ const DirectivesPlugin: PluginObject<any> = {
         Vue.use(RippleEffectPlugin);
         Vue.use(ScrollToPlugin);
         Vue.use(FileDropPlugin);
+        Vue.use(TextAreaAutoHeightPlugin);
     }
 };
 

--- a/src/directives/textarea-auto-height/textarea-auto-height.spec.ts
+++ b/src/directives/textarea-auto-height/textarea-auto-height.spec.ts
@@ -1,0 +1,82 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+
+import { resetModulPlugins } from '../../../tests/helpers/component';
+import TextAreaAutoHeightPlugin from './textarea-auto-height';
+
+describe('MTextAreaAutoSizeDirective', () => {
+    let textarea: Wrapper<Vue>;
+
+    beforeEach(() => {
+        resetModulPlugins();
+        Vue.use(TextAreaAutoHeightPlugin);
+
+        textarea = mount(
+            {
+                props: ['content'],
+                template:
+                    '<textarea v-model="content" v-m-textarea-auto-height></textarea>'
+            },
+            { localVue: Vue }
+        );
+
+        Object.defineProperty(textarea.vm.$el, 'scrollHeight', {
+            get: jest.fn()
+        });
+    });
+
+    it('it should disable resize and overflow on bind', () => {
+        expect(textarea.vm.$el.style.outline).toEqual('none');
+        expect(textarea.vm.$el.style.resize).toEqual('none');
+        expect(textarea.vm.$el.style.overflow).toEqual('hidden');
+    });
+
+    it('it should adjust height when value change', () => {
+        mockScrollHeight(100);
+
+        textarea.setProps({
+            content: 'text'
+        });
+
+        expect(textarea.vm.$el.style.height).toEqual('100px');
+    });
+
+    it('it should adjust height when component is resized', () => {
+        mockScrollHeight(100);
+
+        textarea.vm.$emit('resize');
+
+        expect(textarea.vm.$el.style.height).toEqual('100px');
+    });
+
+    it('it should adjust height only when value is different from last update', () => {
+        mockScrollHeight(100);
+        textarea.setProps({
+            content: 'text'
+        });
+
+        mockScrollHeight(150);
+        textarea.update();
+
+        expect(textarea.vm.$el.style.height).toEqual('100px');
+    });
+
+    it('it should remove event listener at unbind', () => {
+        textarea.vm.$off = jest.fn();
+
+        textarea.vm.$destroy();
+
+        expect((textarea.vm.$off as jest.Mock).mock.calls[0][0]).toEqual(
+            'resize'
+        );
+    });
+
+    const mockScrollHeight = (value: number) => {
+        const desc = Object.getOwnPropertyDescriptor(
+            textarea.vm.$el,
+            'scrollHeight'
+        );
+
+        (desc.get as jest.Mock).mockReturnValue(value);
+    };
+});

--- a/src/directives/textarea-auto-height/textarea-auto-height.ts
+++ b/src/directives/textarea-auto-height/textarea-auto-height.ts
@@ -1,0 +1,78 @@
+import { DirectiveOptions, PluginObject, VNode, VNodeDirective } from 'vue';
+
+import { TEXTAREA_AUTO_HEIGHT } from '../directive-names';
+
+interface HTMLTextAreaElementExt extends HTMLTextAreaElement {
+    mTextAreaAutoSizeData: MTextAreaAutoSizeData;
+}
+
+interface MTextAreaAutoSizeData {
+    lastValue: string;
+    cleanup: () => void;
+}
+
+const resizeHeight = (el: HTMLTextAreaElement) => {
+    el.style.height = 'auto';
+    if (el.value && el.scrollHeight != 0) {
+        el.style.height = el.scrollHeight + 'px';
+    }
+};
+
+const MTextAreaAutoSizeDirective: DirectiveOptions = {
+    bind(
+        el: HTMLTextAreaElementExt,
+        binding: VNodeDirective,
+        vnode: VNode,
+        oldVnode: VNode
+    ): void {
+        const windowResize = () => {
+            resizeHeight(el);
+        };
+
+        el.style.outline = 'none';
+        el.style.resize = 'none';
+        el.style.overflow = 'hidden';
+
+        if (vnode.context) {
+            vnode.context.$on('resize', windowResize);
+        }
+
+        el.mTextAreaAutoSizeData = {
+            lastValue: '',
+            cleanup() {
+                if (vnode.context) {
+                    vnode.context.$off('resize', windowResize);
+                }
+            }
+        };
+
+        window.addEventListener('resize', windowResize);
+    },
+    unbind(
+        el: HTMLTextAreaElementExt,
+        binding: VNodeDirective,
+        vnode: VNode,
+        oldVnode: VNode
+    ): void {
+        el.mTextAreaAutoSizeData.cleanup();
+    },
+    componentUpdated(
+        el: HTMLTextAreaElementExt,
+        binding: VNodeDirective,
+        vnode: VNode,
+        oldVnode: VNode
+    ): void {
+        if (el.value != el.mTextAreaAutoSizeData.lastValue) {
+            el.mTextAreaAutoSizeData.lastValue = el.value;
+            resizeHeight(el);
+        }
+    }
+};
+
+const TextAreaAutoHeightPlugin: PluginObject<any> = {
+    install(v, options): void {
+        v.directive(TEXTAREA_AUTO_HEIGHT, MTextAreaAutoSizeDirective);
+    }
+};
+
+export default TextAreaAutoHeightPlugin;

--- a/src/directives/textarea-auto-height/textarea-auto-height.ts
+++ b/src/directives/textarea-auto-height/textarea-auto-height.ts
@@ -13,7 +13,7 @@ interface MTextAreaAutoSizeData {
 
 const resizeHeight = (el: HTMLTextAreaElement) => {
     el.style.height = 'auto';
-    if (el.value && el.scrollHeight != 0) {
+    if (el.scrollHeight != 0) {
         el.style.height = el.scrollHeight + 'px';
     }
 };
@@ -45,8 +45,6 @@ const MTextAreaAutoSizeDirective: DirectiveOptions = {
                 }
             }
         };
-
-        window.addEventListener('resize', windowResize);
     },
     unbind(
         el: HTMLTextAreaElementExt,

--- a/src/mixins/input-management/input-management.ts
+++ b/src/mixins/input-management/input-management.ts
@@ -1,12 +1,22 @@
-import { ModulVue } from '../../utils/vue/vue';
-import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
-import { Prop, Model, Watch } from 'vue-property-decorator';
+import { Model, Prop, Watch } from 'vue-property-decorator';
+
 import { InputStateMixin } from '../../mixins/input-state/input-state';
-import { KeyCode } from '../../utils/keycode/keycode';
+import { ModulVue } from '../../utils/vue/vue';
+export interface InputManagementProps {
+    value: string;
+    placeholder: string;
+    readonly: boolean;
+    focus: boolean;
+}
+
+export interface InputManagementData {
+    internalValue: string;
+}
 
 @Component
-export class InputManagement extends ModulVue {
+export class InputManagement extends ModulVue
+    implements InputManagementProps, InputManagementData {
     @Prop()
     @Model('input')
     public value: string;
@@ -20,7 +30,11 @@ export class InputManagement extends ModulVue {
     public internalValue: string = '';
     private internalIsFocus: boolean = false;
 
-    protected mounted(): void {
+    private beforeMount(): void {
+        this.internalValue = this.value ? this.value : '';
+    }
+
+    private mounted(): void {
         if (this.focus) {
             this.focusChanged(this.focus);
         }


### PR DESCRIPTION
BREAKING CHANGES

- maxlength is now maxLength so attribute can be written as "max-length"
- textarea-resize is deprecated. Should use directive v-m-textarea-auto-height directly on a native textarea element