### PR TITLE
MODUL-63 Prevenir propagation du click sur les boutons enregistrer et annuler

### DIFF
--- a/src/components/inplace-edit/inplace-edit.html
+++ b/src/components/inplace-edit/inplace-edit.html
@@ -24,7 +24,7 @@
         </transition>
     </template>
     <template v-if="!isMqMinS">
-        <m-dialog :title="dialogTitle" :open="propEditMode" @close="cancel">
+        <m-dialog :title="title" :open="propEditMode" @close="cancel">
             <form>
                 <slot name="editMode"></slot>
                 <div class="m-inplace-edit__buttons">

--- a/src/components/inplace-edit/inplace-edit.html
+++ b/src/components/inplace-edit/inplace-edit.html
@@ -11,10 +11,10 @@
                     <div class="m-inplace-edit__buttons-wrap"
                             v-if="propEditMode">
                         <div class="m-inplace-edit__buttons">
-                            <m-button :waiting="submitted" ref="confirm-control" skin="primary" @click="confirm">
+                            <m-button :waiting="submitted" ref="confirm-control" skin="primary" @click.stop="confirm">
                                 <m-i18n k="m-inplace-edit:save"></m-i18n>
                             </m-button>
-                            <m-button :disabled="submitted" ref="cancel-control" skin="secondary" @click="cancel">
+                            <m-button :disabled="submitted" ref="cancel-control" skin="secondary" @click.stop="cancel">
                                 <m-i18n k="m-inplace-edit:cancel"></m-i18n>
                             </m-button>
                         </div>

--- a/src/components/inplace-edit/inplace-edit.spec.ts
+++ b/src/components/inplace-edit/inplace-edit.spec.ts
@@ -40,7 +40,7 @@ describe('Component inplace-edit - Element wrapper edition inline with default v
 
     it('must use default value for dialog title',() => {
 
-        expect(inplaceEdit.dialogTitle).toEqual(inplaceEdit.$i18n.translate('m-inplace-edit:modify'));
+        expect(inplaceEdit.title).toEqual(inplaceEdit.$i18n.translate('m-inplace-edit:modify'));
     });
 
     describe('when defining title prop', () => {
@@ -48,7 +48,7 @@ describe('Component inplace-edit - Element wrapper edition inline with default v
             let titleProp = 'myTitle';
             inplaceEdit.title = titleProp;
 
-            expect(inplaceEdit.dialogTitle).toEqual(titleProp);
+            expect(inplaceEdit.title).toEqual(titleProp);
         });
     });
 });

--- a/src/components/inplace-edit/inplace-edit.ts
+++ b/src/components/inplace-edit/inplace-edit.ts
@@ -2,7 +2,7 @@ import { MediaQueries } from '../../mixins/media-queries/media-queries';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { INPLACE_EDIT } from '../component-names';
 import WithRender from './inplace-edit.html?style=./inplace-edit.scss';
-import { PluginObject } from 'vue';
+import Vue, { PluginObject } from 'vue';
 import I18nPlugin from '../i18n/i18n';
 import MediaQueriesPlugin from '../../utils/media-queries/media-queries';
 import IconButtonPlugin from '../icon-button/icon-button';
@@ -21,7 +21,9 @@ export class MInplaceEdit extends ModulVue {
     @Prop()
     public editMode: boolean;
 
-    @Prop()
+    @Prop({
+        default: () => (Vue.prototype as any).$i18n.translate('m-inplace-edit:modify')
+    })
     public title: string;
 
     @Prop()
@@ -32,13 +34,6 @@ export class MInplaceEdit extends ModulVue {
     private internalEditMode: boolean = false;
 
     private submitted: boolean = false;
-
-    public get dialogTitle(): string {
-        if (!this.title) {
-            return this.$i18n.translate('m-inplace-edit:modify');
-        }
-        return this.title;
-    }
 
     public get isError(): boolean {
         return this.error;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Empêcher la propagation de l'événement lors du click sur les boutons enregistrer et supprimer pour éviter d'interragir avec les autres éléments pouvant écouter sur le click.
- [x] Include links to issues
MODUL-63

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
BUGFIX - propagaiton du click sur les boutons enregistrer et annuler dans l'édition sur place
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
