### PR TITLE
Avoid unnecessary line break for inline radio group on Safari

### DIFF
--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -29,10 +29,6 @@
             + .m-radio {
                 margin-left: $m-padding--s;
             }
-
-            &-group__body {
-                display: inline-block;
-            }
         }
     }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Removed display: inline-block on ul element of radio group to avoid unnecessary line break on Safari.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-69
<!-- Links here... -->

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
