### PR TITLE
charactercount => display an error when maxlength is not provided

### DIFF
--- a/src/components/character-count/__snapshots__/character-count.spec.ts.snap
+++ b/src/components/character-count/__snapshots__/character-count.spec.ts.snap
@@ -17,11 +17,3 @@ exports[`MCharacterCount should render correctly when transition props is false 
     </div>
 </m-accordion-transition>
 `;
-
-exports[`MCharacterCount should render correctly when valueLenght prop is set 1`] = `
-<m-accordion-transition transition="true">
-    <div>
-        <div aria-hidden="true" class="m-character-count">20<strong>/Infinity</strong></div>
-    </div>
-</m-accordion-transition>
-`;

--- a/src/components/character-count/__snapshots__/character-count.spec.ts.snap
+++ b/src/components/character-count/__snapshots__/character-count.spec.ts.snap
@@ -1,19 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MCharacterCount should render correctly 1`] = `<m-accordion-transition transition="true"></m-accordion-transition>`;
+exports[`MCharacterCount should render correctly 1`] = `""`;
 
 exports[`MCharacterCount should render correctly when maxLength prop is set 1`] = `
-<m-accordion-transition transition="true">
-    <div>
-        <div aria-hidden="true" class="m-character-count">20<strong>/40</strong></div>
-    </div>
-</m-accordion-transition>
+<div>
+    <div aria-hidden="true" class="m-character-count">20<strong>/40</strong></div>
+</div>
 `;
 
 exports[`MCharacterCount should render correctly when transition props is false 1`] = `
-<m-accordion-transition>
-    <div>
-        <div aria-hidden="true" class="m-character-count">20<strong>/40</strong></div>
-    </div>
-</m-accordion-transition>
+<div>
+    <div aria-hidden="true" class="m-character-count">20<strong>/40</strong></div>
+</div>
 `;

--- a/src/components/character-count/character-count.spec.ts
+++ b/src/components/character-count/character-count.spec.ts
@@ -16,16 +16,6 @@ describe('MCharacterCount', () => {
         return expect(renderComponent(component.vm)).resolves.toMatchSnapshot();
     });
 
-    it('should render correctly when valueLenght prop is set', () => {
-        const chkbox: Wrapper<MCharacterCount> = mount(MCharacterCount, {
-            localVue: Vue,
-            propsData: {
-                valueLength: 20
-            }
-        });
-        return expect(renderComponent(chkbox.vm)).resolves.toMatchSnapshot();
-    });
-
     it('should render correctly when maxLength prop is set', () => {
         const chkbox: Wrapper<MCharacterCount> = mount(MCharacterCount, {
             localVue: Vue,

--- a/src/components/character-count/character-count.ts
+++ b/src/components/character-count/character-count.ts
@@ -11,7 +11,13 @@ export class MCharacterCount extends Vue {
 
     @Prop()
     public valueLength: number;
-    @Prop({ default: Infinity })
+    @Prop({ required: true, validator: value => {
+        if (value === undefined) {
+            console.error('character-count component expects prop maxLength to be defined.');
+        }
+
+        return value !== undefined;
+    }})
     public maxLength: number;
     @Prop({ default: 0 })
     public threshold: number;

--- a/src/components/character-count/character-count.ts
+++ b/src/components/character-count/character-count.ts
@@ -2,6 +2,7 @@ import Vue, { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 
+import AccordionTransitionPlugin from '../accordion/accordion-transition';
 import { CHARACTER_COUNT_NAME } from '../component-names';
 import WithRender from './character-count.html?style=./character-count.scss';
 
@@ -32,6 +33,7 @@ export class MCharacterCount extends Vue {
 const CharacterCountPlugin: PluginObject<any> = {
     install(v, options): void {
         v.prototype.$log.debug(CHARACTER_COUNT_NAME, 'plugin.install');
+        v.use(AccordionTransitionPlugin);
         v.component(CHARACTER_COUNT_NAME, MCharacterCount);
     }
 };

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -52,6 +52,6 @@
             :valid="isTextareaValid"
             :valid-message="validMessage"
             :helper-message="helperMessage"></m-validation-message>
-        <m-character-count v-if="characterCount" :valueLength="valueLength" :maxLength="maxLength" :threshold="threshold" :transition="hasCounterTransition"></m-character-count>
+        <m-character-count v-if="characterCount" :value-length="valueLength" :max-length="maxLength" :threshold="characterCountThreshold" :transition="hasCounterTransition"></m-character-count>
     </div>
 </div>

--- a/src/components/textarea/textarea.sandbox.html
+++ b/src/components/textarea/textarea.sandbox.html
@@ -27,26 +27,26 @@
         <li>Dépassement autorisé : Oui</li>
     </ul>
     <h6>Affichage du compteur : à partir de 25 caractères</h6>
-    <m-textarea :character-count="true" max-length="30" :length-overflow="true" threshold="25">
+    <m-textarea :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="25">
     </m-textarea>
 
     <h6>Affichage du compteur : à partir de 0 caractère (en tout temps)</h6>
     <br>
-    <m-textarea :character-count="true" max-length="30" :length-overflow="true" threshold="0">
+    <m-textarea :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="0">
     </m-textarea>
 
     <h6>Affichage du compteur : à partir de 30 caractères (une fois la limite atteinte)</h6>
     <br>
-    <m-textarea :character-count="true" max-length="30" :length-overflow="true" threshold="30">
+    <m-textarea :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="30">
     </m-textarea>
 
     <h6>Affichage du compteur : à partir de 35 caractères (seuil supérieur à la limite)</h6>
     <br>
-    <m-textarea :character-count="true" max-length="30" :length-overflow="true" threshold="35">
+    <m-textarea :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="35">
     </m-textarea>
 
     <h6>Affichage du compteur : à partir de -5 caractères (seuil inférieur à 0)</h6>
-    <m-textarea :character-count="true" max-length="30" :length-overflow="true" threshold="-5">
+    <m-textarea :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="-5">
     </m-textarea>
 
     <h4>
@@ -72,8 +72,8 @@
     <p class="m-u--typo--precision">180 car. : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla risus ex, dignissim scelerisque vehicula eu,
         tempor at massa. Cras ut orci ut ligula iaculis faucibus non a volutpat.</p>
     <br>
-    <m-textarea placeholder="Je suis un sous-titre" :character-count="true" max-length="200" threshold="180" max-width="medium"
-        :length-overflow="true">
+    <m-textarea placeholder="Je suis un sous-titre" :character-count="true" max-length="200" character-count-threshold="180" max-width="medium"
+        :length-overflow="true" v-model="test4Model" :error="test4Model.length > 200 ? true : false">
     </m-textarea>
 
     <!-- Sandbox template -->

--- a/src/components/textarea/textarea.sandbox.html
+++ b/src/components/textarea/textarea.sandbox.html
@@ -69,12 +69,20 @@
         <li>Dépassement autorisé : oui</li>
         <li>Affichage du compteur : à partir de 180 caractères</li>
     </ul>
-    <p class="m-u--typo--precision">180 car. : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla risus ex, dignissim scelerisque vehicula eu,
-        tempor at massa. Cras ut orci ut ligula iaculis faucibus non a volutpat.</p>
+    <p class="m-u--typo--precision">176 car. : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla risus ex, dignissim scelerisque vehicula, mempor. Saisir quelques caractères pour faire apparaître le compteur...</p>
     <br>
     <m-textarea placeholder="Je suis un sous-titre" :character-count="true" max-length="200" character-count-threshold="180" max-width="medium"
         :length-overflow="true" v-model="test4Model" :error="test4Model.length > 200 ? true : false">
     </m-textarea>
+
+    <h3>Test 5 : Ne pas afficher un compteur sur un champ de saisie sans limite de caractères</h3>
+    <p class="m-u--margin-bottom">
+        Lorsque qu'on ajoute un compteur sur un champ sans limite de caractère, le compteur doit être masqué. Nous n'avons pas de cas d'utilisation de compteur de mots sans imposer de limite.
+    </p>
+    <p>
+        <m-textfield :character-count="true" character-counter-threshold="20">
+        </m-textfield>
+    </p>
 
     <!-- Sandbox template -->
     <h3>Test Title</h3>

--- a/src/components/textarea/textarea.sandbox.ts
+++ b/src/components/textarea/textarea.sandbox.ts
@@ -7,6 +7,7 @@ import WithRender from './textarea.sandbox.html';
 @WithRender
 @Component
 export class MTextareaSandbox extends Vue {
+    public test4Model: string = '';
 }
 
 const TextareaSandboxPlugin: PluginObject<any> = {

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -1,17 +1,19 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
+
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputManagement, InputManagementData } from '../../mixins/input-management/input-management';
 import { InputState } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
+import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
 import { TEXTAREA_NAME } from '../component-names';
 import InputStyle from '../input-style/input-style';
 import ValidationMesagePlugin from '../validation-message/validation-message';
 import WithRender from './textarea.html?style=./textarea.scss';
-import uuid from '../../utils/uuid/uuid';
+
 @WithRender
 @Component({
     mixins: [
@@ -25,12 +27,12 @@ import uuid from '../../utils/uuid/uuid';
 export class MTextarea extends ModulVue implements InputManagementData {
     @Prop()
     public characterCount: boolean;
-    @Prop({ default: Infinity })
+    @Prop()
     public maxLength: number;
     @Prop({ default: true })
     public lengthOverflow: boolean;
     @Prop({ default: 0 })
-    public threshold: number;
+    public characterCountThreshold: number;
 
     readonly internalValue: string;
     private internalTextareaHeight: string = '0';

--- a/src/components/textfield/textfield.html
+++ b/src/components/textfield/textfield.html
@@ -56,6 +56,6 @@
             :valid="isTextfieldValid"
             :valid-message="validMessage"
             :helper-message="helperMessage"></m-validation-message>
-        <m-character-count v-if="characterCount" :valueLength="valueLength" :maxLength="maxLength" :threshold="threshold" :transition="hasCounterTransition"></m-character-count>
+        <m-character-count v-if="characterCount" :value-length="valueLength" :max-length="maxLength" :threshold="characterCountThreshold" :transition="hasCounterTransition"></m-character-count>
     </div>
 </div>

--- a/src/components/textfield/textfield.sandbox.html
+++ b/src/components/textfield/textfield.sandbox.html
@@ -27,26 +27,26 @@
         <li>Dépassement autorisé : Oui</li>
     </ul>
     <h6>Affichage du compteur : à partir de 25 caractères</h6>
-    <m-textfield :character-count="true" max-length="30" :length-overflow="true" threshold="25">
+    <m-textfield :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="25">
     </m-textfield>
 
     <h6>Affichage du compteur : à partir de 0 caractère (en tout temps)</h6>
     <br>
-    <m-textfield :character-count="true" max-length="30" :length-overflow="true" threshold="0">
+    <m-textfield :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="0">
     </m-textfield>
 
     <h6>Affichage du compteur : à partir de 30 caractères (une fois la limite atteinte)</h6>
     <br>
-    <m-textfield :character-count="true" max-length="30" :length-overflow="true" threshold="30">
+    <m-textfield :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="30">
     </m-textfield>
 
     <h6>Affichage du compteur : à partir de 35 caractères (seuil supérieur à la limite)</h6>
     <br>
-    <m-textfield :character-count="true" max-length="30" :length-overflow="true" threshold="35">
+    <m-textfield :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="35">
     </m-textfield>
 
     <h6>Affichage du compteur : à partir de -5 caractères (seuil inférieur à 0)</h6>
-    <m-textfield :character-count="true" max-length="30" :length-overflow="true" threshold="-5">
+    <m-textfield :character-count="true" max-length="30" :length-overflow="true" character-count-threshold="-5">
     </m-textfield>
 
     <h4>
@@ -73,8 +73,8 @@
     <p class="m-u--typo--precision">180 car. : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla risus ex, dignissim scelerisque vehicula eu,
         tempor at massa. Cras ut orci ut ligula iaculis faucibus non a volutpat.</p>
     <br>
-    <m-textfield placeholder="Je suis un sous-titre" :character-count="true" max-length="200" threshold="180" max-width="medium"
-        :length-overflow="true">
+    <m-textfield placeholder="Je suis un sous-titre" :character-count="true" max-length="200" character-count-threshold="180" max-width="medium"
+        :length-overflow="true" v-model="test4Model" :error="test4Model.length > 200 ? true : false">
     </m-textfield>
 
     <!-- Sandbox template -->

--- a/src/components/textfield/textfield.sandbox.html
+++ b/src/components/textfield/textfield.sandbox.html
@@ -70,12 +70,20 @@
         <li>Dépassement autorisé : oui</li>
         <li>Affichage du compteur : à partir de 180 caractères</li>
     </ul>
-    <p class="m-u--typo--precision">180 car. : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla risus ex, dignissim scelerisque vehicula eu,
-        tempor at massa. Cras ut orci ut ligula iaculis faucibus non a volutpat.</p>
+    <p class="m-u--typo--precision">176 car. : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla risus ex, dignissim scelerisque vehicula, mempor. Saisir quelques caractères pour faire apparaître le compteur...</p>
     <br>
     <m-textfield placeholder="Je suis un sous-titre" :character-count="true" max-length="200" character-count-threshold="180" max-width="medium"
         :length-overflow="true" v-model="test4Model" :error="test4Model.length > 200 ? true : false">
     </m-textfield>
+
+    <h3>Test 5 : Ne pas afficher un compteur sur un champ de saisie sans limite de caractères</h3>
+    <p class="m-u--margin-bottom">
+        Lorsque qu'on ajoute un compteur sur un champ sans limite de caractère, le compteur doit être masqué. Nous n'avons pas de cas d'utilisation de compteur de mots sans imposer de limite.
+    </p>
+    <p>
+        <m-textfield :character-count="true" character-counter-threshold="20">
+        </m-textfield>
+    </p>
 
     <!-- Sandbox template -->
     <h3>Test Title</h3>
@@ -86,9 +94,9 @@
             -->
     </p>
     <p>
-        <m-checkbox>
+        <m-textfield>
             <!-- Test case -->
-        </m-checkbox>
+        </m-textfield>
     </p>
 
 </div>

--- a/src/components/textfield/textfield.sandbox.ts
+++ b/src/components/textfield/textfield.sandbox.ts
@@ -7,7 +7,7 @@ import WithRender from './textfield.sandbox.html';
 @WithRender
 @Component
 export class MTextfieldSandbox extends Vue {
-    public someData: number = 1;
+    public test4Model: string = '';
 }
 
 const TextfieldSandboxPlugin: PluginObject<any> = {

--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -1,17 +1,18 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
+
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputManagement, InputManagementData } from '../../mixins/input-management/input-management';
 import { InputState } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
+import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
 import ButtonPlugin from '../button/button';
 import { TEXTFIELD_NAME } from '../component-names';
 import InputStyle from '../input-style/input-style';
 import ValidationMesagePlugin from '../validation-message/validation-message';
 import WithRender from './textfield.html?style=./textfield.scss';
-import uuid from '../../utils/uuid/uuid';
 
 export enum MTextfieldType {
     Text = 'text',
@@ -49,12 +50,12 @@ export class MTextfield extends ModulVue implements InputManagementData {
     public passwordIcon: boolean;
     @Prop()
     public characterCount: boolean;
-    @Prop({ default: Infinity })
+    @Prop()
     public maxLength: number;
     @Prop({ default: true })
     public lengthOverflow: boolean;
     @Prop({ default: 0 })
-    public threshold: number;
+    public characterCountThreshold: number;
 
     readonly internalValue: string;
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
character-count will now display an error when max-length is not provided
text-area threshold prop renamed to character-count-threshold
text-field threshold prop renamed to character-count-threshold
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-75
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
- text-area threshold prop renamed to character-count-threshold
- text-field threshold prop renamed to character-count-threshold
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
