### PR TITLE
MODUL-198 Problème d'alignement du dropdown sur le chargement de plusieurs éléments

### DIFF
--- a/src/components/popper/popper.ts
+++ b/src/components/popper/popper.ts
@@ -117,11 +117,9 @@ export class MPopper extends ModulVue implements PortalMixinImpl {
     }
 
     public update(): void {
-        this.$nextTick(() => {
-            if (this.popper !== undefined) {
-                this.popper.update();
-            }
-        });
+        if (this.popper !== undefined) {
+            this.popper.scheduleUpdate();
+        }
     }
 
     protected mounted(): void {

--- a/src/components/popper/popper.ts
+++ b/src/components/popper/popper.ts
@@ -117,9 +117,11 @@ export class MPopper extends ModulVue implements PortalMixinImpl {
     }
 
     public update(): void {
-        if (this.popper !== undefined) {
-            this.popper.update();
-        }
+        this.$nextTick(() => {
+            if (this.popper !== undefined) {
+                this.popper.update();
+            }
+        });
     }
 
     protected mounted(): void {


### PR DESCRIPTION
When there is a lot of items or loading the items of the dropdown is long, the left positionning of the list isn't correct on the first opening.

It's okay on second opening and after that.

The first call to popper.js update() seem to append to early.

https://jira.dti.ulaval.ca/browse/MODUL-198
https://jira.dti.ulaval.ca/browse/AEL-206

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
<!-- Description here... -->
- [x] Include links to issues
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

