### PR TITLE
MODUL-204 - quick fix emit "sortable:add" event

### DIFF
--- a/src/utils/vue/directive.ts
+++ b/src/utils/vue/directive.ts
@@ -11,10 +11,12 @@ interface VueElement extends HTMLElement {
 }
 export const dispatchEvent: (element: HTMLElement, eventName: string, eventData: any) => any = (element: HTMLElement, eventName: string, eventData: any): any => {
     const vueElement: VueElement = element as VueElement;
-    if (vueElement.__vue__ &&
-        vueElement.__vue__.$listeners[eventName]) {
-        return vueElement.__vue__.$emit(eventName, eventData);
-    } else {
-        return element.dispatchEvent(eventData);
+    if (vueElement.__vue__) {
+        if (vueElement.__vue__.$listeners[eventName]) {
+            return vueElement.__vue__.$emit(eventName, eventData);
+        } else if (vueElement.__vue__.$children.length > 0 && vueElement.__vue__.$children[0].$el === vueElement && vueElement.__vue__.$children[0].$listeners[eventName]) {
+            return vueElement.__vue__.$children[0].$emit(eventName, eventData);
+        }
     }
+    return element.dispatchEvent(eventData);
 };


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
The "sortable:add" event is not always fired when a draggable item is dropped into a dynamically added sortable list. The item which has the sortable:add event duplicate itself in the virtual DOM as a child of itself and the listeners are moved onto the child. So an additional check is made to emit the event from the child item to cover this strange case.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-204
<!-- Links here... -->
- [x] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
