### PR TITLE
Feature/default table

### DIFF
--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -172,66 +172,67 @@
 }
 
 @mixin m-table() {
+    &,
     table {
         width: 100%;
         border-collapse: collapse;
         table-layout: fixed; // AEL-33
+    }
 
-        th {
-            padding: 0 $m-padding--s $m-margin--s;
-            font-weight: $m-font-weight--bold;
-            color: $m-color--black;
-            border-bottom: 2px solid $m-color--border;
-            text-align: left;
+    th {
+        padding: 0 $m-padding--s $m-margin--s;
+        font-weight: $m-font-weight--bold;
+        color: $m-color--black;
+        border-bottom: 2px solid $m-color--border;
+        text-align: left;
 
-            &:first-child {
-                padding-left: 0;
-            }
-
-            &:last-child {
-                padding-right: 0;
-            }
+        &:first-child {
+            padding-left: 0;
         }
 
-        tbody {
-            tr {
-                border-bottom: 1px solid $m-color--border;
-            }
+        &:last-child {
+            padding-right: 0;
+        }
+    }
+
+    tbody {
+        tr {
+            border-bottom: 1px solid $m-color--border;
+        }
+    }
+
+    td {
+        padding: $m-padding $m-padding--s;
+        margin: 1px 0;
+        vertical-align: top;
+        text-align: left;
+
+        &:first-child {
+            padding-left: 0;
         }
 
+        &:last-child {
+            padding-right: 0;
+        }
+    }
+
+    &.m-u--has-icon {
+        th,
         td {
-            padding: $m-padding $m-padding--s;
-            margin: 1px 0;
-            vertical-align: top;
-            text-align: left;
-
-            &:first-child {
-                padding-left: 0;
-            }
-
-            &:last-child {
-                padding-right: 0;
+            &:last-child:not(:only-child) {
+                padding: 0;
+                width: 44px;
+                text-align: center;
+                vertical-align: middle;
             }
         }
+    }
 
-        &.m-u--has-icon {
-            th,
-            td {
-                &:last-child:not(:only-child) {
-                    padding: 0;
-                    width: 44px;
-                    text-align: center;
-                    vertical-align: middle;
-                }
-            }
-        }
-
-        // when inside a m-panel component
-        .m-panel & {
-            tbody {
-                tr:last-child {
-                    border-bottom: 0;
-                }
+    // when inside a m-panel component
+    .m-panel & {
+        tbody {
+            tr:last-child {
+                border-bottom: 0;
             }
         }
     }

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -172,64 +172,66 @@
 }
 
 @mixin m-table() {
-    width: 100%;
-    border-collapse: collapse;
-    table-layout: fixed; // AEL-33
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        table-layout: fixed; // AEL-33
 
-    th {
-        padding: 0 $m-padding--s $m-margin--s;
-        font-weight: $m-font-weight--bold;
-        color: $m-color--black;
-        border-bottom: 2px solid $m-color--border;
-        text-align: left;
+        th {
+            padding: 0 $m-padding--s $m-margin--s;
+            font-weight: $m-font-weight--bold;
+            color: $m-color--black;
+            border-bottom: 2px solid $m-color--border;
+            text-align: left;
 
-        &:first-child {
-            padding-left: $m-padding;
-        }
+            &:first-child {
+                padding-left: 0;
+            }
 
-        &:last-child {
-            padding-right: $m-padding;
-        }
-    }
-
-    tbody {
-        tr {
-            border-bottom: 1px solid $m-color--border;
-        }
-    }
-
-    td {
-        padding: $m-padding $m-padding--s;
-        margin: 1px 0;
-        vertical-align: top;
-        text-align: left;
-
-        &:first-child {
-            padding-left: $m-padding;
-        }
-
-        &:last-child {
-            padding-right: $m-padding;
-        }
-    }
-
-    &.m-u--has-icon {
-        th,
-        td {
-            &:last-child:not(:only-child) {
-                padding: 0;
-                width: 44px;
-                text-align: center;
-                vertical-align: middle;
+            &:last-child {
+                padding-right: 0;
             }
         }
-    }
 
-    // when inside a m-panel component
-    .m-panel & {
         tbody {
-            tr:last-child {
-                border-bottom: 0;
+            tr {
+                border-bottom: 1px solid $m-color--border;
+            }
+        }
+
+        td {
+            padding: $m-padding $m-padding--s;
+            margin: 1px 0;
+            vertical-align: top;
+            text-align: left;
+
+            &:first-child {
+                padding-left: $m-padding;
+            }
+
+            &:last-child {
+                padding-right: $m-padding;
+            }
+        }
+
+        &.m-u--has-icon {
+            th,
+            td {
+                &:last-child:not(:only-child) {
+                    padding: 0;
+                    width: 44px;
+                    text-align: center;
+                    vertical-align: middle;
+                }
+            }
+        }
+
+        // when inside a m-panel component
+        .m-panel & {
+            tbody {
+                tr:last-child {
+                    border-bottom: 0;
+                }
             }
         }
     }

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -206,11 +206,11 @@
             text-align: left;
 
             &:first-child {
-                padding-left: $m-padding;
+                padding-left: 0;
             }
 
             &:last-child {
-                padding-right: $m-padding;
+                padding-right: 0;
             }
         }
 

--- a/src/styles/utils/_table.scss
+++ b/src/styles/utils/_table.scss
@@ -2,5 +2,7 @@
 //  table
 // ======================================================================
 .m-u--table {
+    padding: 0 $m-padding $m-padding;
+
     @include m-table();
 }

--- a/src/styles/utils/_table.scss
+++ b/src/styles/utils/_table.scss
@@ -2,7 +2,13 @@
 //  table
 // ======================================================================
 .m-u--table {
-    padding: 0 $m-padding $m-padding;
+    padding: 0 $m-padding--s $m-padding--s;
 
     @include m-table();
+}
+
+@media (min-width: $m-mq--min--s) {
+    .m-u--table {
+        padding: 0 $m-padding $m-padding;
+    }
 }


### PR DESCRIPTION
Le visuel des tableaux à changé. J'ai mis à jour le scss du style générique des tableaux.
Ça nécessite un `<div` class="m-u--table"> autour des tableaux.

- Le changement est fait dans modul-website dans une branche qui pourra être mergé après ce pull-request.
- Le changement est fait dans AEL, dans une branche en attendant ce pull-request
- Il n'y a pas de tableau dans Prisme

Note pour les reviewers. Dans _mixins.scss, les changements sont l'ajout de table { ... } autour du code et le padding sur les &:first-child et &:last-child

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
<!-- Description here... -->
- [x] Include links to issues : MODUL-207
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
Modification au visuel de base des tableaux de données. Ajouter un &lt;div class="m-u--table"&gt; autour de la &lt;table&gt;


<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
