### PR TITLE
fix enum case sensitivity

### DIFF
--- a/src/directives/draggable/draggable-allow-scroll.ts
+++ b/src/directives/draggable/draggable-allow-scroll.ts
@@ -8,8 +8,8 @@ import { ScrollTo } from '../scroll-to/scroll-to-lib';
 import { CancelableScrollTo, ScrollToDuration } from './../scroll-to/scroll-to-lib';
 
 export enum MDraggableAllowScrollDirection {
-    Top,
-    Bottom
+    Top = 'top',
+    Bottom = 'bottom'
 }
 
 export interface MDraggableAllowScrollOptions {
@@ -115,7 +115,7 @@ export class MDraggableAllowScroll extends MElementDomPlugin<MDraggableAllowScro
 const extractOptions: (binding: VNodeDirective) => MDraggableAllowScrollOptions = (binding: VNodeDirective) => {
     return {
         allowScroll: binding.value as boolean,
-        scrollDirection: MDraggableAllowScrollDirection[binding.arg.toUpperCase() as keyof typeof MDraggableAllowScrollDirection]
+        scrollDirection: binding.arg as MDraggableAllowScrollDirection
     };
 };
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Fix regression for enum modification

@Mboulianne, j'ai fait les tests suivants, et ça fonctionne bien, ça devrait donc être correct si l'utilisateur de la directive utilise 'top' et 'bottom' en minuscules. Ça va suivre comme avec tous les enums des composantes qui fonctionnent également de cette façon.

Test que j'ai fait
```
enum Test {
    Alpha = 'alpha',
    Bravo = 'bravo'
}
...
protected mounted(): void {
    let s: string = 'bravo';
    this.testme(s as Test);
}

private testme(t: Test): void {
    switch (t) {
        case Test.Alpha:
            console.log('switch alpha');
            break;
        case Test.Bravo:
            console.log('switch bravo');
            break;
        default: console.log('??');
    }
}

// output 'switch bravo'
```
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-241
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

