### PR TITLE
Feature/modul 266 border radius optional on progress bar

### DIFF
--- a/src/components/progress/__snapshots__/progress.spec.ts.snap
+++ b/src/components/progress/__snapshots__/progress.spec.ts.snap
@@ -23,3 +23,9 @@ exports[`MProgress indeterminate mode should render correctly when circle 1`] = 
     <div class="m-progress__slot"></div>
 </div>
 `;
+
+exports[`MProgress indeterminate mode should render correctly when no border radius 1`] = `
+<div name="m--is" appear="" class="m-progress m--is-determinate  m--is-in-progress" style="height:6px;border-radius:initial;">
+    <div class="m-progress__bar" style="width:0%;border-bottom-left-radius:initial;border-top-left-radius:initial;"></div>
+</div>
+`;

--- a/src/components/progress/progress.sandbox.html
+++ b/src/components/progress/progress.sandbox.html
@@ -1,13 +1,63 @@
 <div>
     <!-- Sandbox template -->
-    <h3>Test Title</h3>
-    <p class="m-u--margin-bottom">
-        Test description
-        <!-- if relevant, add link to PR
-        </br>From <a href="https://github.com/ulaval/modul-components/pull/000" target="blank">PR description</a>
-        -->
+    <h3>Progress Bar 50%</h3>
+    <p class="m-u--margin-bottom">Progress bar at 50%, all props default</p>
+    <p>
+        <m-progress value="50"></m-progress>
+    </p>
+    <h3>Progress Bar indeterminate mode</h3>
+    <p class="m-u--margin-bottom">Progress in indeterminate mode</p>
+    <p>
+        <m-progress :indeterminate="true"></m-progress>
+    </p>
+    <h3>Progress Bar 50%, 10px size</h3>
+    <p class="m-u--margin-bottom">Progress bar at 50%, with 10px height</p>
+    <p>
+        <m-progress size="10" value="50"></m-progress>
+    </p>
+    <h3>Progress Bar 50%, no border radius</h3>
+    <p class="m-u--margin-bottom">Progress bar at 50%, no border radius</p>
+    <p>
+        <m-progress value="50" :border-radius="false"></m-progress>
+    </p>
+    <h3>Progress Bar in circle mode</h3>
+    <p class="m-u--margin-bottom">Progress bar in circle mode</p>
+    <p>
+        <m-progress :circle="true" value="50"></m-progress>
+    </p>
+    <h3>Progress Bar in circle mode, indeterminate</h3>
+    <p class="m-u--margin-bottom">Progress bar in circle mode and indeterminate mode </p>
+    <p>
+        <m-progress :circle="true" :indeterminate="true"></m-progress>
+    </p>
+    <h3>Progress Bar in circle mode, stroke 10px</h3>
+    <p class="m-u--margin-bottom">Progress bar in circle mode, stroke of 10px</p>
+    <p>
+        <m-progress :circle="true" value="50" stroke="10"></m-progress>
+    </p>
+    <h3>Progress Bar in circle mode, diameter 100px</h3>
+    <p class="m-u--margin-bottom">Progress bar in circle mode, diameter of 100px</p>
+    <p>
+        <m-progress :circle="true" value="50" diameter="100"></m-progress>
+    </p>
+    <h3>Progress Bar states</h3>
+    <p class="m-u--margin-bottom">Progress bar in normal mode and circle mode, each state</p>
+    <p>
+        <m-progress value="50" state="completed"></m-progress>
     </p>
     <p>
-        <m-progress><!-- Test case --></m-progress>
+        <m-progress value="50" state="in-progress"></m-progress>
+    </p>
+    <p>
+        <m-progress value="50" state="error"></m-progress>
+    </p>
+    <p>
+        <m-progress value="50" state="completed" :circle="true"></m-progress>
+    </p>
+    <p>
+        <m-progress value="50" state="in-progress" :circle="true"></m-progress>
+    </p>
+    <p>
+        <m-progress value="50" state="error" :circle="true"></m-progress>
     </p>
 </div>

--- a/src/components/progress/progress.spec.ts
+++ b/src/components/progress/progress.spec.ts
@@ -44,5 +44,16 @@ describe('MProgress', () => {
 
             return expect(renderComponent(pgr.vm)).resolves.toMatchSnapshot();
         });
+
+        it('should render correctly when no border radius', () => {
+            const pgr: Wrapper<MProgress> = mount(MProgress, {
+                localVue: localVue,
+                propsData: {
+                    borderRadius: false
+                }
+            });
+
+            return expect(renderComponent(pgr.vm)).resolves.toMatchSnapshot();
+        });
     });
 });

--- a/src/components/progress/progress.ts
+++ b/src/components/progress/progress.ts
@@ -36,6 +36,8 @@ export class MProgress extends ModulVue {
             value === MProgressState.Error
     })
     public state: MProgressState;
+    @Prop({ default: true })
+    public borderRadius: boolean;
 
     private mode: string;
     private styleTag: HTMLElement | null;
@@ -80,7 +82,7 @@ export class MProgress extends ModulVue {
     }
 
     private get radiusSize(): string {
-        return this.circle ? 'initial' : this.size / 2 + 'px';
+        return this.circle || !this.borderRadius ? 'initial' : this.size / 2 + 'px';
     }
 
     private get styleObject(): { [name: string ]: string } {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Ajout d'une props pour mettre le border-radius optionnel sur la barre de progression 
- [x] Include links to issues
[MODUL-266](https://jira.dti.ulaval.ca/browse/MODUL-266)
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->
