### PR TITLE
Appliquer automatiquement l'état « complété » lorsque l'indicateur de progression atteint 100%

### DIFF
--- a/src/components/progress/__snapshots__/progress.spec.ts.snap
+++ b/src/components/progress/__snapshots__/progress.spec.ts.snap
@@ -29,3 +29,9 @@ exports[`MProgress indeterminate mode should render correctly when no border rad
     <div class="m-progress__bar" style="width:0%;border-bottom-left-radius:initial;border-top-left-radius:initial;"></div>
 </div>
 `;
+
+exports[`MProgress indeterminate mode should render correctly when value is 100% 1`] = `
+<div name="m--is" appear="" class="m-progress m--is-determinate  m--is-completed" style="height:6px;border-radius:initial;">
+    <div class="m-progress__bar" style="width:100%;border-radius:initial;"></div>
+</div>
+`;

--- a/src/components/progress/progress.html
+++ b/src/components/progress/progress.html
@@ -3,9 +3,9 @@
          :class="{'m--is-circle': circle,
          'm--is-indeterminate': indeterminate,
          'm--is-determinate ': !indeterminate,
-         'm--is-completed': state=='completed',
-         'm--is-in-progress': state=='in-progress',
-         'm--is-error': state=='error', }">
+         'm--is-completed': propState=='completed',
+         'm--is-in-progress': propState=='in-progress',
+         'm--is-error': propState=='error', }">
          <div v-if="!circle" class="m-progress__bar" :style="barStyleObject"></div>
          <div v-else class="m-progress__wrap" :style="svgStyles">
             <template>

--- a/src/components/progress/progress.sandbox.html
+++ b/src/components/progress/progress.sandbox.html
@@ -60,4 +60,20 @@
     <p>
         <m-progress value="50" state="error" :circle="true"></m-progress>
     </p>
+    <h3>Progress Bar 100%, no state</h3>
+    <p class="m-u--margin-bottom">Progress bar in normal mode and circle mode, 100%</p>
+    <p>
+        <m-progress value="100"></m-progress>
+    </p>
+    <p>
+        <m-progress value="100" :circle="true"></m-progress>
+    </p>
+    <h3>Progress Bar 99%, no state</h3>
+    <p class="m-u--margin-bottom">Progress bar in normal mode and circle mode, 99%</p>
+    <p>
+        <m-progress value="99"></m-progress>
+    </p>
+    <p>
+        <m-progress value="99" :circle="true"></m-progress>
+    </p>
 </div>

--- a/src/components/progress/progress.sandbox.html
+++ b/src/components/progress/progress.sandbox.html
@@ -60,13 +60,16 @@
     <p>
         <m-progress value="50" state="error" :circle="true"></m-progress>
     </p>
-    <h3>Progress Bar 100%, no state</h3>
+    <h3>Progress Bar no state (value commands state)</h3>
     <p class="m-u--margin-bottom">Progress bar in normal mode and circle mode, 100%</p>
     <p>
-        <m-progress value="100"></m-progress>
+        <m-progress value="0"></m-progress>
     </p>
     <p>
-        <m-progress value="100" :circle="true"></m-progress>
+        <m-progress value="50"></m-progress>
+    </p>
+    <p>
+        <m-progress value="100"></m-progress>
     </p>
     <h3>Progress Bar 99%, no state</h3>
     <p class="m-u--margin-bottom">Progress bar in normal mode and circle mode, 99%</p>

--- a/src/components/progress/progress.sandbox.html
+++ b/src/components/progress/progress.sandbox.html
@@ -61,7 +61,7 @@
         <m-progress value="50" state="error" :circle="true"></m-progress>
     </p>
     <h3>Progress Bar no state (value commands state)</h3>
-    <p class="m-u--margin-bottom">Progress bar in normal mode and circle mode, 100%</p>
+    <p class="m-u--margin-bottom">Progress bar in normal mode, differents value</p>
     <p>
         <m-progress value="0"></m-progress>
     </p>

--- a/src/components/progress/progress.spec.ts
+++ b/src/components/progress/progress.spec.ts
@@ -55,5 +55,17 @@ describe('MProgress', () => {
 
             return expect(renderComponent(pgr.vm)).resolves.toMatchSnapshot();
         });
+
+        it('should render correctly when value is 100%', () => {
+            const pgr: Wrapper<MProgress> = mount(MProgress, {
+                localVue: localVue,
+                propsData: {
+                    borderRadius: false,
+                    value: 100
+                }
+            });
+
+            return expect(renderComponent(pgr.vm)).resolves.toMatchSnapshot();
+        });
     });
 });

--- a/src/components/progress/progress.ts
+++ b/src/components/progress/progress.ts
@@ -29,7 +29,6 @@ export class MProgress extends ModulVue {
     @Prop({ default: 4 })
     public stroke: number;
     @Prop({
-        default: MProgressState.InProgress,
         validator: value =>
             value === MProgressState.Completed ||
             value === MProgressState.InProgress ||
@@ -79,6 +78,10 @@ export class MProgress extends ModulVue {
 
     private get propSize(): string {
         return this.circle ? '100%' : this.size + 'px';
+    }
+
+    private get propState(): MProgressState {
+        return this.state ? this.state : this.value >= 100 ? MProgressState.Completed : MProgressState.InProgress ;
     }
 
     private get radiusSize(): string {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Appliquer automatiquement l'état « complété » lorsque l'indicateur de progression atteint 100%
- [x] Include links to issues
[MODUL-295](https://jira.dti.ulaval.ca/browse/MODUL-295)
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->