### PR TITLE
Update input-style and textarea-auto-height

### DIFF
--- a/src/components/input-style/input-style.scss
+++ b/src/components/input-style/input-style.scss
@@ -353,8 +353,6 @@ $m-input-style--padding: 4px !default;
         outline: none;
         text-overflow: ellipsis;
         font-family: $m-font-family;
-        font-size: $m-font-size;
-        font-weight: $m-font-weight--bold;
         text-align: left;
         background: none;
         border: none;
@@ -367,6 +365,8 @@ $m-input-style--padding: 4px !default;
         overflow: hidden;
         width: 100%;
         padding: 0;
+        font-size: $m-font-size;
+        font-weight: $m-font-weight--bold;
         line-height: $m-line-height;
 
         @include m-is-ie() {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

- [x] Provide a small description of the changes introduced by this PR
- J'édite un contenu texte en mode plein écran dans un module. Mon texte est tellement long qu'il dépasse la hauteur de mon écran.

- Résultat attendu :
Être en mesure de poursuivre l'édition de mon texte et le voir

- Résultat obtenu :
L'écran remonte constamment en haut
La régression semble n'être que dans le contenu texte mode plein écran contrairement à la dernière fois où il était dans toutes les boîtes de textarea.

- [x] Include links to issues
- https://jira.dti.ulaval.ca/browse/ENA2-1920
- https://jira.dti.ulaval.ca/browse/MODUL-279
