### PR TITLE
ENA2-2237 - arranger bug : lien externe"interne mal géré + ajouter props pour messages desktop vs mobile

### DIFF
--- a/src/components/error-browser-not-supported/__snapshots__/error-browser-not-supported.spec.ts.snap
+++ b/src/components/error-browser-not-supported/__snapshots__/error-browser-not-supported.spec.ts.snap
@@ -2,4 +2,8 @@
 
 exports[`Browser not supported - test Given desktop mode Given custom values Should render with custom values provided 1`] = `<div skin="warning" iconName="m-svg__warning" title="An error title." hints="aHint" links="[object Object]"></div>`;
 
-exports[`Browser not supported - test Given desktop mode Given default values Should render with default values 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-browser-not-supported:title" hints="m-error-browser-not-supported:hint.primary.desktop" links="[object Object]"></div>`;
+exports[`Browser not supported - test Given desktop mode Given default values Should render with default desktop values 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-browser-not-supported:title" hints="m-error-browser-not-supported:hint.primary.desktop" links="[object Object]"></div>`;
+
+exports[`Browser not supported - test Given mobile device size Given custom values Should render with custom mobile values provided 1`] = `<div skin="warning" iconName="m-svg__warning" title="An error title." hints="aHint-Mobile" links="[object Object]"></div>`;
+
+exports[`Browser not supported - test Given mobile device size Given default values Should render with default mobile values provided 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-browser-not-supported:title" hints="m-error-browser-not-supported:hint.primary.mobile" links=""></div>`;

--- a/src/components/error-browser-not-supported/error-browser-not-supported.html
+++ b/src/components/error-browser-not-supported/error-browser-not-supported.html
@@ -1,2 +1,2 @@
-<m-error-template :skin="skin" :iconName="iconName" :title="title" :hints="mqAwareHints" :links="mqAwareLinks">
+<m-error-template :skin="skin" :iconName="iconName" :title="title" :hints="isMqMinS ? hintsDesktop : hintsMobile" :links="isMqMinS ? linksDesktop : linksMobile">
 </m-error-template>

--- a/src/components/error-browser-not-supported/error-browser-not-supported.spec.ts
+++ b/src/components/error-browser-not-supported/error-browser-not-supported.spec.ts
@@ -9,7 +9,9 @@ let wrapper: Wrapper<MErrorBrowserNotSupported>;
 let isMobileDevice: boolean;
 const A_CUSTOM_TITLE: string = 'An error title.';
 const A_HINT: string = 'aHint';
+const A_HINT_MOBILE: string = 'aHint-Mobile';
 const A_LINK: Link = new Link('aLabel', 'anUrl');
+const A_LINK_MOBILE: Link = new Link('aLabel-Mobile', 'anUrl');
 
 const getStubs: any = () => {
     return {
@@ -44,8 +46,10 @@ const initializeWrapperCustomValues: () => void = (): void => {
         mocks: getMocks(),
         propsData: {
             title: A_CUSTOM_TITLE,
-            hints: [A_HINT],
-            links: [A_LINK]
+            hintsDesktop: [A_HINT],
+            hintsMobile: [A_HINT_MOBILE],
+            linksDesktop: [A_LINK],
+            linksMobile: [A_LINK_MOBILE]
         },
         mixins: [{
             data: function(): any {
@@ -66,25 +70,7 @@ describe(`Browser not supported - test`, () => {
             beforeEach(() => {
                 initializeWrapperDefaultValues();
             });
-            describe(`When getting hints`, () => {
-                it(`Should return desktop hints`, () => {
-
-                    let hints: string[] = wrapper.vm.mqAwareHints;
-
-                    expect(hints).toHaveLength(1);
-                    expect(hints[0]).toEqual('m-error-browser-not-supported:hint.primary.desktop');
-                });
-            });
-            describe(`When getting links`, () => {
-                it(`Should return desktop links`, () => {
-                    let links: Link[] = wrapper.vm.mqAwareLinks;
-
-                    expect(links).toHaveLength(1);
-                    expect(links[0].label).toEqual('m-error-browser-not-supported:update-browser.desktop');
-                    expect(links[0].url).toEqual('http://outdatedbrowser.com/fr');
-                });
-            });
-            it(`Should render with default values`, async () => {
+            it(`Should render with default desktop values`, async () => {
                 await expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
             });
         });
@@ -92,22 +78,7 @@ describe(`Browser not supported - test`, () => {
             beforeEach(() => {
                 initializeWrapperCustomValues();
             });
-            describe(`When getting hints`, () => {
-                it(`Should return specified hints`, () => {
-                    let hints: string[] = wrapper.vm.mqAwareHints;
 
-                    expect(hints).toHaveLength(1);
-                    expect(hints[0]).toEqual(A_HINT);
-                });
-            });
-            describe(`When getting links`, () => {
-                it(`Should return specified links`, () => {
-                    let links: Link[] = wrapper.vm.mqAwareLinks;
-
-                    expect(links).toHaveLength(1);
-                    expect(links[0]).toEqual(A_LINK);
-                });
-            });
             it(`Should render with custom values provided`, async () => {
                 await expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
             });
@@ -122,42 +93,16 @@ describe(`Browser not supported - test`, () => {
             beforeEach(() => {
                 initializeWrapperDefaultValues();
             });
-            describe(`When getting hints`, () => {
-                it(`Should return mobile hints`, () => {
-
-                    let hints: string[] = wrapper.vm.mqAwareHints;
-
-                    expect(hints).toHaveLength(1);
-                    expect(hints[0]).toEqual('m-error-browser-not-supported:hint.primary.mobile');
-                });
-            });
-            describe(`When getting links`, () => {
-                it(`Should return no links`, () => {
-                    let links: Link[] = wrapper.vm.mqAwareLinks;
-
-                    expect(links).toHaveLength(0);
-                });
+            it(`Should render with default mobile values provided`, async () => {
+                await expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
             });
         });
         describe(`Given custom values`, () => {
             beforeEach(() => {
                 initializeWrapperCustomValues();
             });
-            describe(`When getting hints`, () => {
-                it(`Should return specified hints`, () => {
-                    let hints: string[] = wrapper.vm.mqAwareHints;
-
-                    expect(hints).toHaveLength(1);
-                    expect(hints[0]).toEqual(A_HINT);
-                });
-            });
-            describe(`When getting links`, () => {
-                it(`Should return specified links`, () => {
-                    let links: Link[] = wrapper.vm.mqAwareLinks;
-
-                    expect(links).toHaveLength(1);
-                    expect(links[0]).toEqual(A_LINK);
-                });
+            it(`Should render with custom mobile values provided`, async () => {
+                await expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
             });
         });
     });

--- a/src/components/error-browser-not-supported/error-browser-not-supported.ts
+++ b/src/components/error-browser-not-supported/error-browser-not-supported.ts
@@ -22,31 +22,27 @@ export class MErrorBrowserNotSupported extends ModulVue {
     })
     public title: string;
 
+    @Prop({
+        default: () => [new Link((Vue.prototype as any).$i18n.translate('m-error-browser-not-supported:update-browser.desktop'), 'http://outdatedbrowser.com/fr', true)]
+    })
+    public linksDesktop: Link[];
+
     @Prop({ default: () => [] })
-    public links: Link[];
+    public linksMobile: Link[];
 
     @Prop({
-        default: () => []
+        default: () => [(Vue.prototype as any).$i18n.translate('m-error-browser-not-supported:hint.primary.desktop')]
     })
-    public hints: string[];
+    public hintsDesktop: string[];
+
+    @Prop({
+        default: () => [(Vue.prototype as any).$i18n.translate('m-error-browser-not-supported:hint.primary.mobile')]
+    })
+    public hintsMobile: string[];
 
     readonly skin: string = MErrorTemplateSkin.Warning;
 
     readonly iconName: string = 'm-svg__warning';
-
-    private get mqAwareLinks(): Link[] {
-        if (this.links.length === 0) {
-            return this.as<MediaQueries>().isMqMinS ? [new Link(this.$i18n.translate('m-error-browser-not-supported:update-browser.desktop'), 'http://outdatedbrowser.com/fr', true)] : [];
-        }
-        return this.links;
-    }
-
-    private get mqAwareHints(): string[] {
-        if (this.hints.length === 0) {
-            return this.as<MediaQueries>().isMqMinS ? [this.$i18n.translate('m-error-browser-not-supported:hint.primary.desktop')] : [this.$i18n.translate('m-error-browser-not-supported:hint.primary.mobile')];
-        }
-        return this.hints;
-    }
 }
 
 const ErrorBrowserNotSupported: PluginObject<any> = {

--- a/src/components/error-page-not-found/error-page-not-found.ts
+++ b/src/components/error-page-not-found/error-page-not-found.ts
@@ -20,7 +20,7 @@ export class MErrorPageNotFound extends ModulVue {
 
     @Prop({
         default: () => [
-            new Link((Vue.prototype as any).$i18n.translate('m-error-page-not-found:home-label'), '\\')]
+            new Link((Vue.prototype as any).$i18n.translate('m-error-page-not-found:home-label'), `\\`)]
     })
     public links: Link[];
 

--- a/src/components/error-template/__snapshots__/error-template.spec.ts.snap
+++ b/src/components/error-template/__snapshots__/error-template.spec.ts.snap
@@ -11,10 +11,10 @@ exports[`Error-template integration tests Given an error with all props and slot
     </div>
     <ul class="m-error-template__links">
         <li>
-            <a icon-name="m-svg__chevron--right" mode="link" url="an Url" target="_blank" class="m-error-template__link">a link</a>
+            <a icon-name="m-svg__chevron--right" mode="link" url="an Url" target="" class="m-error-template__link">a link</a>
         </li>
         <li>
-            <a icon-name="m-svg__chevron--right" mode="link" url="another Url" target="_blank" class="m-error-template__link">another link</a>
+            <a icon-name="m-svg__chevron--right" mode="link" url="another Url" target="" class="m-error-template__link">another link</a>
         </li>
     </ul>
 </article>

--- a/src/components/error-template/error-template.html
+++ b/src/components/error-template/error-template.html
@@ -13,7 +13,7 @@
     </div>
     <ul v-if="hasLinks" class="m-error-template__links">
         <li ref="link" v-for="link in links">
-            <m-link class="m-error-template__link" icon-name="m-svg__chevron--right" mode="link" :url="link.url" target="_blank">{{link.label}}</m-link>
+            <m-link class="m-error-template__link" icon-name="m-svg__chevron--right" mode="link" :url="link.url" :target="isTargetExternal(link.external)">{{link.label}}</m-link>
         </li>
     </ul>
 </article>


### PR DESCRIPTION
permettre de passer des props pour desktop et mobile dans browser non supporté

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Régler deux problèmes dans les pages d'erreur, dans le Template, la gestion de l'ouverture du lien externe dans un nouvel onglet et interne dans le même onglet n'était pas complère (methode non appelée dans le template)
Aussi, permettre de passer des paramètres spécifique aux textes mobile et desktop dans le navigateur non supporté (avant permettait de switcher d'un texte à l'autre selon le mode d'affichage seulement si on prend le message d'erreur par défaut, il utilisait une seule valeur si on en passait un en props)
- [x] Include links to issues
ENA2-2237
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->


<!-- Thanks for contributing! -->
