### PR TITLE
MODUL-348 - ajout d'une largeur maximal pour le titre page d'erreur

### DIFF
--- a/src/components/error-template/error-template.scss
+++ b/src/components/error-template/error-template.scss
@@ -4,7 +4,7 @@
     &__title {
         font-size: $m-font-size--h3;
         text-align: center;
-        max-width: 250px;
+        max-width: 250px; // Magic number
         margin: 0 auto;
 
         .m--is-skin-information & {

--- a/src/components/error-template/error-template.scss
+++ b/src/components/error-template/error-template.scss
@@ -4,6 +4,8 @@
     &__title {
         font-size: $m-font-size--h3;
         text-align: center;
+        max-width: 250px;
+        margin: 0 auto;
 
         .m--is-skin-information & {
             color: $m-color--interactive;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Mettre le titre des pages d'erreurs sur deux lignes ( et plus ..)
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-348
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

