### PR TITLE
MODUL-356 - modifier la clé du hint m-error-config-not-supported:hint.secondary

### DIFF
--- a/src/components/error-config-not-supported/__snapshots__/error-config-not-supported.spec.ts.snap
+++ b/src/components/error-config-not-supported/__snapshots__/error-config-not-supported.spec.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Configuration not supported- test Given custom values Should render with custom values provided 1`] = `<div skin="warning" iconName="m-svg__warning" title="An error title." hints="aHint" links=""></div>`;
 
-exports[`Configuration not supported- test Given default values Should render with default values 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-config-not-supported:title" hints="m-error-config-not-supported:hint.secondary" links=""></div>`;
+exports[`Configuration not supported- test Given default values Should render with default values 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-config-not-supported:title" hints="m-error-config-not-supported:hint.primary,m-error-config-not-supported:hint.secondary" links=""></div>`;

--- a/src/components/error-config-not-supported/__snapshots__/error-config-not-supported.spec.ts.snap
+++ b/src/components/error-config-not-supported/__snapshots__/error-config-not-supported.spec.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Configuration not supported- test Given custom values Should render with custom values provided 1`] = `<div skin="warning" iconName="m-svg__warning" title="An error title." hints="aHint" links=""></div>`;
 
-exports[`Configuration not supported- test Given default values Should render with default values 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-config-not-supported:title" hints="m-error-config-not-supported:hint.primary" links=""></div>`;
+exports[`Configuration not supported- test Given default values Should render with default values 1`] = `<div skin="warning" iconName="m-svg__warning" title="m-error-config-not-supported:title" hints="m-error-config-not-supported:hint.secondary" links=""></div>`;

--- a/src/components/error-config-not-supported/error-config-not-supported.ts
+++ b/src/components/error-config-not-supported/error-config-not-supported.ts
@@ -23,7 +23,7 @@ export class MErrorConfigNotSupported extends ModulVue {
 
     @Prop({
         default: () => [
-            (Vue.prototype as any).$i18n.translate('m-error-config-not-supported:hint.primary')]
+            (Vue.prototype as any).$i18n.translate('m-error-config-not-supported:hint.secondary')]
     })
     public hints: string[];
 

--- a/src/components/error-config-not-supported/error-config-not-supported.ts
+++ b/src/components/error-config-not-supported/error-config-not-supported.ts
@@ -23,6 +23,7 @@ export class MErrorConfigNotSupported extends ModulVue {
 
     @Prop({
         default: () => [
+            (Vue.prototype as any).$i18n.translate('m-error-config-not-supported:hint.primary'),
             (Vue.prototype as any).$i18n.translate('m-error-config-not-supported:hint.secondary')]
     })
     public hints: string[];


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Modifier la clé du message par défaut du hint de error-config-not-supported 
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-356
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->
