### PR TITLE
fix word-wrap on the rte

### DIFF
--- a/src/components/input-style/input-style.scss
+++ b/src/components/input-style/input-style.scss
@@ -251,6 +251,7 @@ $m-input-style--padding: 4px !default;
             position: relative;
             min-height: 24px;
             flex: 1 1 auto;
+            max-width: 100%;
 
             .m--has-border-top & {
                 .m--is-focus & {

--- a/src/components/rich-text-editor/adapter/vue-froala.scss
+++ b/src/components/rich-text-editor/adapter/vue-froala.scss
@@ -77,6 +77,10 @@
     &--unfocused {
         overflow: hidden;
 
+        /deep/ .fr-box.fr-basic.fr-top .fr-wrapper {
+            background: unset;
+        }
+
         /deep/ .fr-sticky-dummy {
             height: 0 !important; // Fix flicking problem with multiple editors on page.
         }


### PR DESCRIPTION
remove background-color from the editor when it is in read-only mode.

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Fix word wrap and background-color for the rich-text
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-363
https://jira.dti.ulaval.ca/browse/MODUL-364
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
