### PR TITLE
Encapsulate a sortable so it won't accept items from another sortable

### DIFF
--- a/src/directives/droppable/droppable.spec.ts
+++ b/src/directives/droppable/droppable.spec.ts
@@ -1,10 +1,9 @@
 import { mount, Wrapper } from '@vue/test-utils';
-import Vue, { VueConstructor } from 'vue';
+import Vue from 'vue';
 
 import { resetModulPlugins } from '../../../tests/helpers/component';
 import { isInElement } from '../../utils/mouse/mouse';
 import { polyFillActive } from '../../utils/polyfills';
-import { ModulVue } from '../../utils/vue/vue';
 import { MDOMPlugin } from '../domPlugin';
 import DraggablePlugin, { MDraggable, MDraggableOptions } from '../draggable/draggable';
 import { MRemoveUserSelect } from '../user-select/remove-user-select';
@@ -60,7 +59,6 @@ describe('droppable', () => {
         return { preventDefault: () => {}, stopPropagation: () => {}, dataTransfer: { setData: () => {}, setDragImage: () => {}, getData: () => {} } };
     };
 
-    let localVue: VueConstructor<ModulVue>;
     beforeEach(() => {
         resetModulPlugins();
         Vue.use(DroppablePlugin);

--- a/src/directives/droppable/droppable.spec.ts
+++ b/src/directives/droppable/droppable.spec.ts
@@ -189,7 +189,7 @@ describe('droppable', () => {
         const userDefinedData: any = { someKey: 'someValue' };
         const userDefinedGrouping: string = 'someGrouping';
 
-        const mockCanDrop: (wrapper: Wrapper<Vue>, value: boolean) => void = (wrapper: Wrapper<Vue>, value: boolean) => {
+        const mockCanDrop: (wrapper: Wrapper<Vue>, value: boolean) => void = (_wrapper: Wrapper<Vue>, value: boolean) => {
             const plugin: MDroppable = MDOMPlugin.get(MDroppable, droppable.element);
             plugin.canDrop = jest.fn();
             (plugin.canDrop as jest.Mock).mockImplementation(() => value);

--- a/src/directives/droppable/droppable.ts
+++ b/src/directives/droppable/droppable.ts
@@ -5,7 +5,7 @@ import { dispatchEvent, getVNodeAttributeValue } from '../../utils/vue/directive
 import { DROPPABLE_NAME } from '../directive-names';
 import { MDOMPlugin, MElementDomPlugin, MountFunction, RefreshFunction } from '../domPlugin';
 import { MDraggable } from '../draggable/draggable';
-import { MSortableAction } from '../sortable/sortable';
+import { MSortable, MSortableAction } from '../sortable/sortable';
 import RemoveUserSelectPlugin, { MRemoveUserSelect } from '../user-select/remove-user-select';
 
 export enum MDroppableClassNames {
@@ -108,7 +108,19 @@ export class MDroppable extends MElementDomPlugin<MDroppableOptions> {
         const acceptAny: boolean = this.options.acceptedActions.find(action => action === 'any') !== undefined;
         const draggableAction: string = draggable.options.action;
         const isAllowedAction: boolean = this.options.acceptedActions.find(action => action === draggableAction) !== undefined;
-        return canDrop && !this.isHoveringOverDraggedElementChild() && (acceptAny || isAllowedAction);
+        return canDrop && !this.isHoveringOverDraggedElementChild()
+            && (acceptAny || isAllowedAction)
+            && !this.isDropRestrictedByEncapsuledSortable();
+    }
+
+    private isDropRestrictedByEncapsuledSortable(): boolean {
+        if ((MSortable.activeSortContainer && MSortable.fromSortContainer)
+            && MSortable.activeSortContainer !== MSortable.fromSortContainer
+            && (MSortable.activeSortContainer.options.encapsulate || MSortable.fromSortContainer.options.encapsulate)) {
+            return true;
+        }
+
+        return false;
     }
 
     private setOptions(value: MDroppableOptions): void {
@@ -128,7 +140,6 @@ export class MDroppable extends MElementDomPlugin<MDroppableOptions> {
 
     private isLeavingDroppable(event: DragEvent, droppable?: MDroppable): boolean {
         if (!droppable) { return false; }
-        const threshold: number = 3;
         return !isInElement(event, droppable.element) || MDroppable.previousHoverContainer !== MDroppable.currentHoverDroppable;
     }
 

--- a/src/directives/droppable/droppable.ts
+++ b/src/directives/droppable/droppable.ts
@@ -114,9 +114,11 @@ export class MDroppable extends MElementDomPlugin<MDroppableOptions> {
     }
 
     private isDropRestrictedByEncapsuledSortable(): boolean {
-        if ((MSortable.activeSortContainer && MSortable.fromSortContainer)
+        const activeSortContainer: MSortable | undefined = MSortable.activeSortContainer || MDOMPlugin.getRecursive(MSortable, this.element);
+
+        if ((activeSortContainer && MSortable.fromSortContainer)
             && MSortable.activeSortContainer !== MSortable.fromSortContainer
-            && (MSortable.activeSortContainer.options.encapsulate || MSortable.fromSortContainer.options.encapsulate)) {
+            && (activeSortContainer.options.encapsulate || MSortable.fromSortContainer.options.encapsulate)) {
             return true;
         }
 

--- a/src/directives/droppable/droppable.ts
+++ b/src/directives/droppable/droppable.ts
@@ -115,9 +115,8 @@ export class MDroppable extends MElementDomPlugin<MDroppableOptions> {
 
     private isDropRestrictedByEncapsuledSortable(): boolean {
         const activeSortContainer: MSortable | undefined = MSortable.activeSortContainer || MDOMPlugin.getRecursive(MSortable, this.element);
-
         if ((activeSortContainer && MSortable.fromSortContainer)
-            && MSortable.activeSortContainer !== MSortable.fromSortContainer
+            && activeSortContainer !== MSortable.fromSortContainer
             && (activeSortContainer.options.encapsulate || MSortable.fromSortContainer.options.encapsulate)) {
             return true;
         }

--- a/src/directives/sortable/sortable.spec.ts
+++ b/src/directives/sortable/sortable.spec.ts
@@ -1,14 +1,12 @@
 import { mount, Wrapper, WrapperArray } from '@vue/test-utils';
-import Vue, { VueConstructor } from 'vue';
+import Vue from 'vue';
 
 import { resetModulPlugins } from '../../../tests/helpers/component';
 import { polyFillActive } from '../../utils/polyfills';
-import { ModulVue } from '../../utils/vue/vue';
 import { MDraggable, MDraggableEventNames, MDraggableOptions } from '../draggable/draggable';
-import { MDroppable } from '../droppable/droppable';
+import { MDroppable, MDroppableClassNames } from '../droppable/droppable';
 import DroppableGroupPlugin from '../droppable/droppable-group';
 import { MDOMPlugin } from './../domPlugin';
-import { MDraggableClassNames } from './../draggable/draggable';
 import { MSortableDefaultInsertionMarkerBehavior } from './insertion-behavior';
 import SortablePlugin, { MSortable, MSortableAction, MSortableClassNames, MSortableEventNames, MSortableOptions, MSortInsertPositions } from './sortable';
 
@@ -22,8 +20,8 @@ describe('sortable', () => {
         const innerHTML: string = `${innerHtml || emptyPlaceholderTemplate}`;
         let template: string;
         if (options) {
-            template = bindingValue === undefined ? `<ul v-m-sortable :items="items" :accepted-actions="acceptedActions">${innerHTML}</ul>`
-                    : `<ul v-m-sortable="${bindingValue}" :items="items" :accepted-actions="acceptedActions">${innerHTML}</ul>`;
+            template = bindingValue === undefined ? `<ul v-m-sortable${options.encapsulate ? '.encapsulate' : ''} :items="items" :accepted-actions="acceptedActions">${innerHTML}</ul>`
+                    : `<ul v-m-sortable${options.encapsulate ? '.encapsulate' : ''}="${bindingValue}" :items="items" :accepted-actions="acceptedActions">${innerHTML}</ul>`;
         } else {
             template = bindingValue === undefined ? `<ul v-m-sortable>${innerHTML}</ul>`
                 : `<ul v-m-sortable="${bindingValue}">${innerHTML}</ul>`;
@@ -69,7 +67,6 @@ describe('sortable', () => {
         (droppablePart.canDrop as jest.Mock).mockImplementation(() => true);
     };
 
-    let localVue: VueConstructor<ModulVue>;
     beforeEach(() => {
         resetModulPlugins();
         Vue.use(SortablePlugin);
@@ -80,20 +77,22 @@ describe('sortable', () => {
         it(`it should render correctly when binding ${param} is provided`, () => {
             const userDefinedActions: string[] = ['a', 'b'];
             const userDefinedItems: any[] = [{ id: 0 }];
-            const sortable: Wrapper<Vue> = getSortableDirective(param, { items: userDefinedItems, acceptedActions: userDefinedActions });
+            const userDefinedEncapsulate: boolean = true;
+            const sortable: Wrapper<Vue> = getSortableDirective(param, { items: userDefinedItems, acceptedActions: userDefinedActions, encapsulate: userDefinedEncapsulate });
 
             expect(sortable.element.classList).toContain(MSortableClassNames.Sortable);
             expect(MDOMPlugin.get(MSortable, sortable.element).options.acceptedActions)
                 .toEqual([...userDefinedActions, MSortableAction.Move, MSortableAction.MoveGroup]);
             expect(MDOMPlugin.get(MSortable, sortable.element).options.items).toBe(userDefinedItems);
+            expect(MDOMPlugin.get(MSortable, sortable.element).options.encapsulate).toBe(userDefinedEncapsulate);
             expect(MDOMPlugin.get(MDroppable, sortable.element)).toBeDefined();
         });
 
-        it(`it should default action correctly when binding ${param} is provided and action is not user defined`, () => {
+        it(`it should default options correctly when binding ${param} is provided and action is not user defined`, () => {
             const sortable: Wrapper<Vue> = getSortableDirective(param);
 
-            expect(MDOMPlugin.get(MDroppable, sortable.element).options.acceptedActions)
-                .toEqual([MSortableAction.Default, MSortableAction.Move, MSortableAction.MoveGroup]);
+            expect(MDOMPlugin.get(MDroppable, sortable.element).options.acceptedActions).toEqual([MSortableAction.Default, MSortableAction.Move, MSortableAction.MoveGroup]);
+            expect(MDOMPlugin.get(MSortable, sortable.element).options.encapsulate).toBeFalsy();
         });
 
         it('it should setup empty placeholder correctly', () => {
@@ -211,7 +210,6 @@ describe('sortable', () => {
 
         it('it should clean up childs correctly', () => {
             const sortable: Wrapper<Vue> = getSortableDirective(true, { acceptedActions: ['someAction'], items: [{ id: 0 }] });
-            const plugin: MSortable = MDOMPlugin.get(MSortable, sortable.element);
 
             sortable.destroy();
 
@@ -221,49 +219,53 @@ describe('sortable', () => {
     });
 
     describe('onDragEnter', () => {
-        let sortable: Wrapper<Vue>;
-        let secondSortable: Wrapper<Vue>;
-        let plugin: MSortable;
-        let secondPlugin: MSortable;
-
-        beforeEach(() => {
-            sortable = getSortableDirective(true, { acceptedActions: ['someAction'], items: [{ id: 0 }] });
-            plugin = MDOMPlugin.get(MSortable, sortable.element);
-            makeDroppable(plugin);
-
-            secondSortable = getSortableDirective(true, { acceptedActions: ['someAction'], items: [{ id: 0 }] });
-            secondPlugin = MDOMPlugin.get(MSortable, secondSortable.element);
-            makeDroppable(secondPlugin);
-
-            sortable.find(`.${MDraggableClassNames.Draggable}`).trigger('dragstart', getEventDummy());
-        });
+        const buildSortable: (options: MSortableOptions) => Wrapper<Vue> = (options: MSortableOptions) => {
+            const sortable: Wrapper<Vue> = getSortableDirective(true, options);
+            makeDroppable(MDOMPlugin.get(MSortable, sortable.element));
+            return sortable;
+        };
 
         it('it should handle event correctly', () => {
-            const eventDummy: any = getEventDummy();
-            sortable.find('li').trigger('dragenter', eventDummy);
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
 
-            expect(MSortable.activeSortContainer).toBe(plugin);
+            sortable.find('li').trigger('dragstart', getEventDummy());
+            sortable.find('li').trigger('dragenter', getEventDummy());
+
+            expect(MSortable.activeSortContainer).toBe(MDOMPlugin.get(MSortable, sortable.element));
         });
 
         it('it should handle transition from one active sortable to another', () => {
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+
+            sortable.find('li').trigger('dragstart', getEventDummy());
             sortable.find('li').trigger('dragenter', getEventDummy());
-            jest.spyOn(plugin, 'doCleanUp');
+            jest.spyOn(MDOMPlugin.get(MSortable, sortable.element), 'doCleanUp');
             secondSortable.find('li').trigger('dragenter', getEventDummy());
 
-            expect(plugin.doCleanUp).toHaveBeenCalled();
+            expect(MDOMPlugin.get(MSortable, sortable.element).doCleanUp).toHaveBeenCalled();
             expect(MSortable.activeSortContainer).toBe(MDOMPlugin.get(MSortable, secondSortable.element));
         });
 
         it('it should not call doCleanup more than 1 time on multiple trigger', () => {
-            jest.spyOn(plugin, 'doCleanUp');
-            MSortable.activeSortContainer = plugin;
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+
+            sortable.find('li').trigger('dragstart', getEventDummy());
+            jest.spyOn(MDOMPlugin.get(MSortable, sortable.element), 'doCleanUp');
+            MSortable.activeSortContainer = MDOMPlugin.get(MSortable, sortable.element);
             secondSortable.find('li').trigger('dragenter', getEventDummy());
             secondSortable.find('li').trigger('dragenter', getEventDummy());
 
-            expect(plugin.doCleanUp).toHaveBeenCalledTimes(1);
+            expect(MDOMPlugin.get(MSortable, sortable.element).doCleanUp).toHaveBeenCalledTimes(1);
         });
 
         it('it should transition to sort before class properly', () => {
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+
+            sortable.find('li').trigger('dragStart', getEventDummy());
+
             ((MSortableDefaultInsertionMarkerBehavior as any) as jest.Mock).mockImplementation(() => ({ getInsertPosition: () => MSortInsertPositions.After }));
             secondSortable.find('li').trigger('dragenter', getEventDummy());
 
@@ -275,6 +277,11 @@ describe('sortable', () => {
         });
 
         it('it should transition to sort after class properly', () => {
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+
+            sortable.find('li').trigger('dragstart', getEventDummy());
+
             ((MSortableDefaultInsertionMarkerBehavior as any) as jest.Mock).mockImplementation(() => ({ getInsertPosition: () => MSortInsertPositions.Before }));
             secondSortable.find('li').trigger('dragenter', getEventDummy());
 
@@ -283,6 +290,42 @@ describe('sortable', () => {
 
             expect(secondSortable.find('li').element.classList).toContain(MSortableClassNames.SortAfter);
             expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortBefore);
+        });
+
+        it(`it should not trigger drop events when dragging from a restricted sortable to another`, () => {
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }], encapsulate: true });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+
+            sortable.find('li').trigger('dragstart', getEventDummy());
+            secondSortable.find('li').trigger('dragenter', getEventDummy());
+
+            expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortAfter);
+            expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortBefore);
+            expect(secondSortable.find('li').element.classList).toContain(MDroppableClassNames.CantDrop);
+        });
+
+        it(`it should not trigger drop events when dragging from a non-restricted sortable to a restricted sortable`, () => {
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }], encapsulate: true });
+
+            sortable.find('li').trigger('dragstart', getEventDummy());
+            secondSortable.find('li').trigger('dragenter', getEventDummy());
+
+            expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortAfter);
+            expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortBefore);
+            expect(secondSortable.find('li').element.classList).toContain(MDroppableClassNames.CantDrop);
+        });
+
+        it(`it should trigger drop events normally when moving an item to another index in the same restricted sortable`, () => {
+            const sortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }], encapsulate: true });
+            const secondSortable: Wrapper<Vue> = buildSortable({ acceptedActions: ['someAction'], items: [{ id: 0 }] });
+
+            sortable.find('li').trigger('dragStart', getEventDummy());
+            secondSortable.find('li').trigger('dragenter', getEventDummy());
+
+            expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortAfter);
+            expect(secondSortable.find('li').element.classList).not.toContain(MSortableClassNames.SortBefore);
+            expect(secondSortable.find('li').element.classList).toContain(MDroppableClassNames.CantDrop);
         });
     });
 

--- a/src/directives/sortable/sortable.ts
+++ b/src/directives/sortable/sortable.ts
@@ -13,6 +13,7 @@ export interface MSortableOptions {
     items: any[];
     acceptedActions: string[];
     canSort?: any;
+    encapsulate: boolean;
 }
 
 export enum MSortableEventNames {
@@ -398,7 +399,8 @@ const extractVnodeAttributes: (binding: VNodeDirective, node: VNode) => MSortabl
     return {
         items: getVNodeAttributeValue(node, 'items'),
         acceptedActions: getVNodeAttributeValue(node, 'accepted-actions'),
-        canSort: binding.value
+        canSort: binding.value,
+        encapsulate: binding.modifiers.encapsulate || false
     };
 };
 const Directive: DirectiveOptions = {
@@ -408,13 +410,13 @@ const Directive: DirectiveOptions = {
     update(element: HTMLElement, binding: VNodeDirective, node: VNode): void {
         MDOMPlugin.attach(MSortable, element, extractVnodeAttributes(binding, node));
     },
-    unbind(element: HTMLElement, binding: VNodeDirective): void {
+    unbind(element: HTMLElement): void {
         MDOMPlugin.detach(MSortable, element);
     }
 };
 
 const SortablePlugin: PluginObject<any> = {
-    install(v, options): void {
+    install(v, _options): void {
         v.use(DraggablePlugin);
         v.use(DroppablePlugin);
         v.directive(SORTABLE_NAME, Directive);

--- a/src/directives/sortable/sortable.ts
+++ b/src/directives/sortable/sortable.ts
@@ -13,7 +13,7 @@ export interface MSortableOptions {
     items: any[];
     acceptedActions: string[];
     canSort?: any;
-    encapsulate: boolean;
+    encapsulate?: boolean;
 }
 
 export enum MSortableEventNames {
@@ -300,9 +300,7 @@ export class MSortable extends MElementDomPlugin<MSortableOptions> {
 
         const currentInsertPosition: MSortInsertPositions = this.getCurrentInsertPosition();
         const newInsertPosition: MSortInsertPositions = this.getInsertionMarkerBehavior().getInsertPosition(event);
-        if (MDroppable.currentHoverDroppable === MDroppable.previousHoverContainer && currentInsertPosition === newInsertPosition) {
-            return;
-        }
+        if (MDroppable.currentHoverDroppable === MDroppable.previousHoverContainer && currentInsertPosition === newInsertPosition) { return; }
 
         let element: HTMLElement;
         if (!this.isInsertingOnChild()) {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Encapsulate a sortable so it won't accept items from another sortable
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-386
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes

- Added a new modifier on sortable directive: encapsulate.  When active, it will render drag from another sortable impossible.

- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
