### PR TITLE
rte it is impossible to have an empty placeholder.  A default valut i…

### DIFF
--- a/src/components/rich-text-editor/adapter/vue-froala.spec.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.spec.ts
@@ -12,8 +12,7 @@ $.FroalaEditor = {
     DefineIconTemplate: jest.fn(),
     POPUP_TEMPLATES: {},
     PLUGINS: {},
-    RegisterCommand: jest.fn(),
-    DefineIconTemplate: jest.fn()
+    RegisterCommand: jest.fn()
 };
 
 describe('VueFroala', () => {

--- a/src/components/rich-text-editor/rich-text-editor.sandbox.html
+++ b/src/components/rich-text-editor/rich-text-editor.sandbox.html
@@ -49,5 +49,18 @@
             </div>
         </m-edit-window>
     </div>
-
+    <h5 class="m-u--margin-bottom">placeholder vide n'affiche rien</h5>
+    <div class="m-u--margin-bottom">
+        <m-rich-text-editor v-model="model"
+        :toolbar-sticky-offset="58"
+        :label="'texte riche'"
+        :max-width="'large'"
+        :focus="focus"
+        :error="error"
+        :error-message="errorMessage"
+        :valid-message="validMessage"
+        :helper-message="helperMessage"
+        :waiting="waiting"
+        :disabled="disabled"></m-rich-text-editor>
+    </div>
 </div>

--- a/src/components/rich-text-editor/rich-text-editor.spec.ts
+++ b/src/components/rich-text-editor/rich-text-editor.spec.ts
@@ -44,7 +44,7 @@ describe('MRichTextEditor', () => {
 
     describe('without props set', () => {
         it('internal options are defaultOptions', () => {
-            const customOptions: any = { placeholderText: undefined, scrollableContainer: undefined };
+            const customOptions: any = { placeholderText: ' ', scrollableContainer: undefined };
             expect(richTextEditor.internalOptions).toEqual({ ...defaultOptions, ...customOptions });
         });
     });
@@ -67,9 +67,9 @@ describe('MRichTextEditor', () => {
         });
 
         it('internal options are customed defaultOptions', () => {
-            const customOptions: any = { toolbarStickyOffset: 1 };
+            const customOptions: any = { toolbarStickyOffset: 1, placeholderText: 'placeholder', scrollableContainer: 'container' };
 
-            wrapper.setProps({ toolbarStickyOffset: 1 });
+            wrapper.setProps({ toolbarStickyOffset: 1, placeholder: 'placeholder', scrollableContainer: 'container' });
             expect(richTextEditor.internalOptions).toEqual({ ...defaultOptions, ...customOptions });
         });
     });

--- a/src/components/rich-text-editor/rich-text-editor.spec.ts
+++ b/src/components/rich-text-editor/rich-text-editor.spec.ts
@@ -67,9 +67,9 @@ describe('MRichTextEditor', () => {
         });
 
         it('internal options are customed defaultOptions', () => {
-            const customOptions: any = { toolbarStickyOffset: 1, placeholderText: 'placeholder', scrollableContainer: 'container' };
+            const customOptions: any = { toolbarStickyOffset: 1, placeholderText: 'placeholder' };
 
-            wrapper.setProps({ toolbarStickyOffset: 1, placeholder: 'placeholder', scrollableContainer: 'container' });
+            wrapper.setProps({ toolbarStickyOffset: 1, placeholder: 'placeholder' });
             expect(richTextEditor.internalOptions).toEqual({ ...defaultOptions, ...customOptions });
         });
     });

--- a/src/components/rich-text-editor/rich-text-editor.ts
+++ b/src/components/rich-text-editor/rich-text-editor.ts
@@ -57,6 +57,7 @@ export class MRichTextEditor extends ModulVue implements InputManagementData, In
 
     public get internalOptions(): any {
         const propOptions: any = {
+            // Hack to "hide" the default froala placeholder text
             placeholderText: this.as<InputManagement>()!.placeholder || ' ',
             toolbarStickyOffset: this.calculateToolbarStickyOffset(),
             scrollableContainer: this.getScrollableContainer()

--- a/src/components/rich-text-editor/rich-text-editor.ts
+++ b/src/components/rich-text-editor/rich-text-editor.ts
@@ -57,7 +57,7 @@ export class MRichTextEditor extends ModulVue implements InputManagementData, In
 
     public get internalOptions(): any {
         const propOptions: any = {
-            placeholderText: this.as<InputManagement>()!.placeholder,
+            placeholderText: this.as<InputManagement>()!.placeholder || ' ',
             toolbarStickyOffset: this.calculateToolbarStickyOffset(),
             scrollableContainer: this.getScrollableContainer()
         };


### PR DESCRIPTION
…s always provided by froala

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
It is not possible to have an empty placeholder for the rich text.  A default value is always provided by froala
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-396
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
