### PR TITLE
MODUL-398 - Corriger la méthode onClose du composant m-tooltip

### DIFF
--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -1,13 +1,14 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
+
 import { MediaQueries, MediaQueriesMixin } from '../../mixins/media-queries/media-queries';
 import MediaQueriesPlugin from '../../utils/media-queries/media-queries';
+import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
 import ButtonPlugin from '../button/button';
 import { TOOLTIP_NAME } from '../component-names';
 import I18nPlugin from '../i18n/i18n';
-import uuid from '../../utils/uuid/uuid';
 import LinkPlugin from '../link/link';
 import { MPopperPlacement } from '../popper/popper';
 import WithRender from './tooltip.html?style=./tooltip.scss';
@@ -89,7 +90,7 @@ export class MTooltip extends ModulVue {
         this.$emit('open');
     }
 
-    private onClose(): void {
+    private onClose(event: Event): void {
         this.$emit('close', event);
     }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Permet de corriger le problème suivant: https://jira.dti.ulaval.ca/browse/ENA2-2402
Dans firefox, lorsqu'on ferme un tooltip, un message d'erreur apparaît.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-398
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
