### PR TITLE
RTE in read mode => Remove the top margin of the first paragraph

### DIFF
--- a/src/components/rich-text/rich-text.scss
+++ b/src/components/rich-text/rich-text.scss
@@ -2,6 +2,10 @@
 @import '../../styles/abstracts/var-froala';
 
 .m-rich-text {
+    & > :first-child {
+        margin-top: 0 !important;
+    }
+
     /deep/ {
         @include commonsFroalaStyles();
     }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
First paragraph had a top margin in RTE reader.  It is not good since it can create some visual inconsistency.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-409
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
