### PR TITLE
RTE + mobile safari: focusing the rich-text after exiting full screen…

### DIFF
--- a/src/components/rich-text-editor/adapter/vue-froala.scss
+++ b/src/components/rich-text-editor/adapter/vue-froala.scss
@@ -83,6 +83,10 @@
                 }
             }
         }
+
+        .fr-sticky-dummy + .fr-sticky-dummy {
+            height: 0 !important; // Fix flicking problem with multiple editors on page and https://github.com/froala/wysiwyg-editor/issues/2818
+        }
     }
 
     /deep/ {


### PR DESCRIPTION
… showed an extra space

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
RTE + mobile safari: focusing the rich-text after exiting full screen showed an extra space
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-426
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
