### PR TITLE
Feature/modul 416 tree add prop open

### DIFF
--- a/src/components/tree-node/tree-node.html
+++ b/src/components/tree-node/tree-node.html
@@ -1,18 +1,18 @@
 <li class="m-tree-node" :class="{ 'm--is-selected': isSelected, 'm--is-disabled' : isDisabled }">
     <div class="m-tree-node__item" role="button" :tabindex="isDisabled ? '-1' : 1" @click="onClick" ref="item">
-        <m-tree-icon class="m-tree-icon" v-if="icons" :filename="node.id" :folder-open="open" :folder="isFolder"></m-tree-icon>
+        <m-tree-icon class="m-tree-icon" v-if="icons" :filename="node.id" :folder-open="internalOpen" :folder="isFolder"></m-tree-icon>
         <span class="m-tree-node__item__label">{{label}}</span>
     </div>
     <template v-if="isFolder">
         <m-accordion-transition v-if="hasChildren">
-            <ul v-show="open" class="m-tree-node__children" :class="{'m-tree-node__line-extension' : hasSibling}" ref="children">
+            <ul v-show="internalOpen" class="m-tree-node__children" :class="{'m-tree-node__line-extension' : hasSibling}" ref="children">
                 <m-tree-node v-for="(childNode, index) in node.children" :key="childNode.id" class="m-tree-node__child" :path="currentPath"
-                    :icons="icons" :selectable="selectable" :node="childNode" :selected-nodes="selectedNodes" :has-sibling="childHasSibling(index)"
+                    :icons="icons" :selectable="selectable" :node-open.sync="childNode.open" :node="childNode" :selected-nodes="selectedNodes" :has-sibling="childHasSibling(index)"
                     @click="onChildClick"></m-tree-node>
             </ul>
         </m-accordion-transition>
         <m-accordion-transition v-else>
-            <ul v-show="open" class="m-tree-node__children" :class="{'m-tree-node__line-extension' : hasSibling}">
+            <ul v-show="internalOpen" class="m-tree-node__children" :class="{'m-tree-node__line-extension' : hasSibling}">
                 <li class="m-tree-node__child-empty">
                     {{emptyContentMessage}}
                 </li>

--- a/src/components/tree-node/tree-node.spec.ts
+++ b/src/components/tree-node/tree-node.spec.ts
@@ -152,6 +152,42 @@ describe('MTreeNode', () => {
                     expect(wrapper.vm.hasChildren).toBeTruthy();
                 });
 
+                describe(`and we open the node`, () => {
+
+                    beforeEach(() => {
+                        wrapper.vm.internalOpen = false;
+                        wrapper.vm.onClick();
+                    });
+
+                    it(`Then should be open`, () => {
+                        expect(wrapper.vm.internalOpen).toBeTruthy();
+                    });
+
+                    it(`Then the event update:open is emitted with the value true`, () => {
+                        expect(wrapper.emitted('update:open')).toBeTruthy();
+                        expect(wrapper.emitted('update:open')[0]).toEqual([true]);
+                    });
+
+                });
+
+                describe(`and we close the node`, () => {
+
+                    beforeEach(() => {
+                        wrapper.vm.internalOpen = true;
+                        wrapper.vm.onClick();
+                    });
+
+                    it(`Then should be closed`, () => {
+                        expect(wrapper.vm.internalOpen).toBeFalsy();
+                    });
+
+                    it(`Then the event update:open is emitted with the value false`, () => {
+                        expect(wrapper.emitted('update:open')).toBeTruthy();
+                        expect(wrapper.emitted('update:open')[0]).toEqual([false]);
+                    });
+
+                });
+
             });
 
             describe(`When the node is a parent of the selected node`, () => {

--- a/src/components/tree-node/tree-node.ts
+++ b/src/components/tree-node/tree-node.ts
@@ -37,7 +37,7 @@ export class MTreeNode extends ModulVue {
     @Prop()
     public hasSibling: boolean;
 
-    private internalOpen: boolean = false;
+    public internalOpen: boolean = false;
 
     public onClick(): void {
         if (this.isFolder) {

--- a/src/components/tree-node/tree-node.ts
+++ b/src/components/tree-node/tree-node.ts
@@ -16,6 +16,9 @@ export class MTreeNode extends ModulVue {
     @Prop()
     public node: TreeNode;
 
+    @Prop({ default: false })
+    public open: boolean;
+
     @Prop({ default: [] })
     public selectedNodes: string[];
 
@@ -34,11 +37,12 @@ export class MTreeNode extends ModulVue {
     @Prop()
     public hasSibling: boolean;
 
-    private open: boolean = false;
+    private internalOpen: boolean = false;
 
     public onClick(): void {
         if (this.isFolder) {
-            this.open = !this.open;
+            this.internalOpen = !this.internalOpen;
+            this.$emit('update:open', this.internalOpen);
         } else if (this.selectable) {
             this.$emit('click', this.currentPath);
         }
@@ -56,7 +60,7 @@ export class MTreeNode extends ModulVue {
     }
 
     protected mounted(): void {
-        this.open = this.isParentOfSelectedFile;
+        this.internalOpen = this.open ? this.open : this.isParentOfSelectedFile;
     }
 
     public get currentPath(): string {

--- a/src/components/tree/tree.html
+++ b/src/components/tree/tree.html
@@ -6,7 +6,7 @@
         {{'m-tree:empty' | f-m-i18n}}
     </p>
     <ul v-else class="m-tree__content">
-        <m-tree-node ref="tree-node" v-for="node in tree" :key="node.id" :selectable="selectable" :node="node" :selected-nodes="propSelectedNodes"
+        <m-tree-node ref="tree-node" v-for="node in tree" :key="node.id" :selectable="selectable" :open.sync="node.open" :node="node" :selected-nodes="propSelectedNodes"
             :icons="icons" @click="onClick"></m-tree-node>
     </ul>
 </div>

--- a/src/components/tree/tree.sandbox.html
+++ b/src/components/tree/tree.sandbox.html
@@ -3,14 +3,14 @@
     <div style="width: 50%; float:left;">
         <h2>No selection</h2>
         <p>
-            <m-tree :tree="tree" selectionMode="0" ></m-tree>
+            <m-tree :tree="tree" selection-mode="0" ></m-tree>
         </p>
     </div>
 
     <div style="width: 50%; float:left;">
         <h2>Single node selection</h2>
         <p>
-            <m-tree :tree="tree" :selectedNodes="currentFile2" @select="onSelect"></m-tree>
+            <m-tree :tree="tree" :selected-nodes="currentFile2" @select="onSelect"></m-tree>
         </p>
     </div>
 
@@ -20,14 +20,14 @@
     <div style="width: 50%; float:left;">
         <h3>No file selection</h3>
         <p>
-            <m-tree :tree="fileTree" selectionMode="0" :icons="true"></m-tree>
+            <m-tree :tree="fileTree" selection-mode="0" :icons="true"></m-tree>
         </p>
     </div>
 
     <div style="width: 50%; float:left;">
         <h3>Single file selection</h3>
         <p>
-            <m-tree :tree="fileTree" selectionMode="1" :selectedNodes="currentFile" :icons="true" @select="onSelect"></m-tree>
+            <m-tree :tree="fileTree" selection-mode="1" :selected-nodes="currentFile" :icons="true" @select="onSelect"></m-tree>
         </p>
     </div>
 
@@ -55,7 +55,7 @@
         <h3>Selected node not found</h3>
         <span>Console error</span>
         <p>
-            <m-tree :tree="tree" :selectedNodes="wrongCurrentFile" @select="onSelect"></m-tree>
+            <m-tree :tree="tree" :selected-nodes="wrongCurrentFile" @select="onSelect"></m-tree>
         </p>
     </div>
 

--- a/src/components/tree/tree.sandbox.ts
+++ b/src/components/tree/tree.sandbox.ts
@@ -71,6 +71,7 @@ export class MRootTreeSandbox extends Vue {
         {
             id: '7',
             label: 'Title 3',
+            open: true,
             children: [
                 {
                     id: '1',

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -11,6 +11,7 @@ import WithRender from './tree.html?style=./tree.scss';
 export interface TreeNode {
     id: string;
     label?: string;
+    open?: boolean;
     children?: TreeNode[];
     hasChildren?: boolean;
     data?: any;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Ajout de la propriété open au m-tree. Cette propriété permet à l'utilisateur externe de pouvoir jouer de son coté avec l'ouverture/fermeture de l'arbre. Dans notre cas, on voulait ouvrir le premier répertoire si celui-ci est le seul nœud présent à la racine.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-416
- [ ] Openshift deployment requested

<!-- Thanks for contributing! -->
