### PR TITLE
It's impossible to select a dropdown option when it is a numeric value

### DIFF
--- a/src/components/dropdown/dropdown.sandbox.html
+++ b/src/components/dropdown/dropdown.sandbox.html
@@ -304,6 +304,19 @@
         </m-dropdown>
     </p>
 
+    <p>
+        <h3>Dropdown-item avec une value numerique</h3>
+        <p class="m-u--margin-bottom">
+            From <a href="https://github.com/ulaval/modul-components/pull/458" target="blank" label="When internalValue is not a string, trim() can't be apply">Pull request</a>
+
+            <!-- if relevant, add link to PR
+            </br>From <a href="https://github.com/ulaval/modul-components/pull/458" target="blank" label="PR description</a> -->
+        </p>
+
+        <m-dropdown :filterable="false" label="Item à valeur numérique" v-model="numValue">
+                <m-dropdown-item v-for="item of numItems" :value="item" :label="item"></m-dropdown-item>
+        </m-dropdown>
+    </p>
 
     <!-- Sandbox template
     <br><br><br><br><br>

--- a/src/components/dropdown/dropdown.sandbox.html
+++ b/src/components/dropdown/dropdown.sandbox.html
@@ -307,7 +307,7 @@
     <p>
         <h3>Dropdown-item avec une value numerique</h3>
         <p class="m-u--margin-bottom">
-            From <a href="https://github.com/ulaval/modul-components/pull/458" target="blank" label="When internalValue is not a string, trim() can't be apply">Pull request</a>
+            From <a href="https://github.com/ulaval/modul-components/pull/458" target="blank">PR #458</a> : It's impossible to select a dropdown option when it is a numeric value
 
             <!-- if relevant, add link to PR
             </br>From <a href="https://github.com/ulaval/modul-components/pull/458" target="blank" label="PR description</a> -->

--- a/src/components/dropdown/dropdown.sandbox.ts
+++ b/src/components/dropdown/dropdown.sandbox.ts
@@ -16,6 +16,8 @@ export class MDropdownSandbox extends Vue {
     public undefinedValue1: undefined = undefined;
     public undefinedValue2: undefined = undefined;
     public undefinedValue3: undefined = undefined;
+
+    public numItems: number[] = [2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007];
 }
 
 const DropdownSandboxPlugin: PluginObject<any> = {

--- a/src/mixins/input-popup/input-popup.ts
+++ b/src/mixins/input-popup/input-popup.ts
@@ -55,7 +55,7 @@ export class InputPopup extends ModulVue {
 
     public hasValue(): boolean {
         // undefined, null and empty string return false
-        return !!(this.internalValue || '').trim();
+        return !!(this.internalValue || '').toString().trim();
     }
 
     public hasPlaceholder(): boolean {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
When internalValue is not a string, trim() can't be apply
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-440
https://jira.dti.ulaval.ca/browse/AEL-278
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
