### PR TITLE
m-touch tap event are emitted twice which cause a bug in the carousel

### DIFF
--- a/src/components/touch/touch.spec.ts
+++ b/src/components/touch/touch.spec.ts
@@ -94,8 +94,9 @@ describe('MTouch', () => {
         });
 
         [MZingGestureDirections.Left, MZingGestureDirections.Right].forEach((direction: MZingGestureDirections) => {
-            it(`should emit swipe${direction} when provided swipe direction is both`, () => {
-                const fakeEventObject: any = { detail: 'someDetail' };
+            it(`should handle swipe${direction} when provided swipe direction is both`, () => {
+                const fakeEventObject: any = { detail: 'someDetail', stopPropagation: jest.fn() };
+                jest.spyOn(fakeEventObject, 'stopPropagation');
                 swipeOptions.direction = MTouchSwipeDirection.both;
                 (ZingTouchUtil.detectDirection as jest.Mock).mockImplementation(() => direction);
 
@@ -103,10 +104,12 @@ describe('MTouch', () => {
                 swipeCallback(fakeEventObject as any);
 
                 expect(wrapper.emitted(`swipe${direction}`.toLowerCase())[0][0]).toBeDefined();
+                expect(fakeEventObject.stopPropagation).toHaveBeenCalled();
             });
 
-            it(`should emit swipe${direction} when provided swipe direction is horizontal`, () => {
-                const fakeEventObject: any = { detail: 'someDetail' };
+            it(`should handle swipe${direction} when provided swipe direction is horizontal`, () => {
+                const fakeEventObject: any = { detail: 'someDetail', stopPropagation: jest.fn() };
+                jest.spyOn(fakeEventObject, 'stopPropagation');
                 swipeOptions.direction = MTouchSwipeDirection.horizontal;
                 (ZingTouchUtil.detectDirection as jest.Mock).mockImplementation(() => direction);
 
@@ -114,10 +117,12 @@ describe('MTouch', () => {
                 swipeCallback(fakeEventObject as any);
 
                 expect(wrapper.emitted(`swipe${direction}`.toLowerCase())[0][0]).toBeDefined();
+                expect(fakeEventObject.stopPropagation).toHaveBeenCalled();
             });
 
-            it(`should not emit swipe${direction} when provided swipe direction is vertical`, () => {
-                const fakeEventObject: any = { detail: 'someDetail' };
+            it(`should handle swipe${direction} when provided swipe direction is vertical`, () => {
+                const fakeEventObject: any = { detail: 'someDetail', stopPropagation: jest.fn() };
+                jest.spyOn(fakeEventObject, 'stopPropagation');
                 swipeOptions.direction = MTouchSwipeDirection.vertical;
                 (ZingTouchUtil.detectDirection as jest.Mock).mockImplementation(() => direction);
 
@@ -125,6 +130,7 @@ describe('MTouch', () => {
                 swipeCallback(fakeEventObject as any);
 
                 expect(wrapper.emitted(`swipe${direction}`.toLowerCase())).toBeUndefined();
+                expect(fakeEventObject.stopPropagation).not.toHaveBeenCalled();
             });
         });
     });
@@ -144,13 +150,15 @@ describe('MTouch', () => {
             });
         });
 
-        it(`should emit tap`, () => {
-            const fakeEventObject: any = { detail: 'someDetail' };
+        it(`should hanndle tap`, () => {
+            const fakeEventObject: any = { detail: 'someDetail', stopPropagation: jest.fn() };
+            jest.spyOn(fakeEventObject, 'stopPropagation');
 
             mountComponent();
             tapcallback(fakeEventObject as any);
 
             expect(wrapper.emitted('tap')[0][0]).toBeDefined();
+            expect(fakeEventObject.stopPropagation).toHaveBeenCalled();
         });
     });
 });

--- a/src/components/touch/touch.ts
+++ b/src/components/touch/touch.ts
@@ -74,16 +74,19 @@ export class MTouch extends Vue {
 
         switch (ZingTouchUtil.detectDirection(event, swipeOptions.angleThreshold)) {
             case MZingGestureDirections.Right:
+                this.handleZingEvent(event);
                 this.$emit('swiperight', event);
                 break;
             case MZingGestureDirections.Left:
+                this.handleZingEvent(event);
                 this.$emit('swipeleft', event);
                 break;
         }
     }
 
     private configureZingTap(): void {
-        this.zingRegion!.bind(this.$el, ZingTouchUtil.GestureFactory.getGesture(MZingTouchGestures.Tap), (event: Event) => {
+        this.zingRegion!.bind(this.$el, ZingTouchUtil.GestureFactory.getGesture(MZingTouchGestures.Tap), (event: CustomEvent) => {
+            this.handleZingEvent(event);
             this.$emit('tap', event);
         });
     }
@@ -91,6 +94,11 @@ export class MTouch extends Vue {
     private destroyZingTouch(): void {
         if (this.zingRegion) { this.zingRegion.unbind(this.$el); }
         this.zingRegion = undefined;
+    }
+
+    private handleZingEvent(event: CustomEvent): void {
+        // Since we reemit the event, we stop event propagation.  Event whould be handled twice from each listener otherwise.
+        event.stopPropagation();
     }
 }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Tap event will not be emitted only once by the m-touch component.  This fix a bug where you could not toggle a property in the tap listener since it would instantly toggle and untoggle
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-455
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
