### PR TITLE
Separate click and tap interaction when tapping on zingTouch

### DIFF
--- a/src/components/carousel/carousel.html
+++ b/src/components/carousel/carousel.html
@@ -1,3 +1,3 @@
-<m-touch class="m-carousel" @tap="onTap" @swipeleft="showNextItem" @swiperight="showPrevItem" :swipe-options="{direction: 'horizontal'}" tag="ul">
+<m-touch class="m-carousel" @tap="onTap" @click="onClick" @swipeleft="showNextItem" @swiperight="showPrevItem" :swipe-options="{direction: 'horizontal'}" tag="ul">
     <slot></slot>
 </m-touch>

--- a/src/components/carousel/carousel.sandbox.html
+++ b/src/components/carousel/carousel.sandbox.html
@@ -130,4 +130,23 @@
             </m-carousel-item>
         </m-carousel>
     </p>
+    <h3>Carousel - Event detection</h3>
+    <p class="m-u--margin-bottom">From <a href="https://github.com/ulaval/modul-components/pull/479" target="blank" title="PR #479 : Bugfix zingtouch detect click and tap #479">PR #479</a> : m-carousel tap should not be emitted twice (desktop or mobile).</p>
+    <p>
+        Number of tap: {{ tapCounter }}
+    </p>
+    <p>
+        <m-carousel mousedown.native.capture="clearEventDetectionTest()" @tap="testTap" style="height: 400px;" margin="0">
+            <m-carousel-item>
+                <video controls="true" style="display: block; max-height: 300px; max-width: 300px;">
+                    <source id="mp4" src="http://grochtdreis.de/fuer-jsfiddle/video/sintel_trailer-480.mp4" type="video/mp4">
+                </video>
+            </m-carousel-item>
+            <m-carousel-item>
+                <video controls="true" style="display: block; max-height: 300px; max-width: 300px;" playsinline="true">
+                    <source id="mp4" src="http://grochtdreis.de/fuer-jsfiddle/video/sintel_trailer-480.mp4" type="video/mp4">
+                </video>
+            </m-carousel-item>
+        </m-carousel>
+    </p>
 </div>

--- a/src/components/carousel/carousel.sandbox.ts
+++ b/src/components/carousel/carousel.sandbox.ts
@@ -7,7 +7,16 @@ import WithRender from './carousel.sandbox.html';
 @WithRender
 @Component
 export class MCarouselSandbox extends Vue {
+    protected tapCounter: number = 0;
     private test: number = 0;
+
+    protected clearEventDetectionTest(): void {
+        this.tapCounter = 0;
+    }
+
+    protected testTap(): void {
+        this.tapCounter++;
+    }
 
     private onClick(): void {
         if (this.test === 0) {

--- a/src/components/carousel/carousel.ts
+++ b/src/components/carousel/carousel.ts
@@ -30,6 +30,10 @@ export class MCarousel extends Vue {
         this.$emit('tap', event);
     }
 
+    public onClick(event: Event): void {
+        this.$emit('click', event);
+    }
+
     protected mounted(): void {
         this.toggleKeyboardNavigation(this.keyboardNavigable);
         if (this.interval) {

--- a/src/components/touch/enums.ts
+++ b/src/components/touch/enums.ts
@@ -8,3 +8,8 @@ export enum MZingGestureDirections {
     Right = 'right',
     None = 'none'
 }
+
+export enum MZingTapInteractions {
+    Click = 'click',
+    Tap = 'tap'
+}

--- a/src/components/touch/touch.spec.ts
+++ b/src/components/touch/touch.spec.ts
@@ -1,7 +1,7 @@
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vue, { VueConstructor } from 'vue';
 
-import { MZingGestureDirections, MZingTouchGestures } from './enums';
+import { MZingGestureDirections, MZingTapInteractions, MZingTouchGestures } from './enums';
 import { MTouch, MTouchSwipeDirection, MTouchSwipeOptions } from './touch';
 import ZingTouchUtil, { MZingGesture, MZingGestureCallback, MZingRegion } from './zingtouch';
 
@@ -11,7 +11,8 @@ jest.mock('./zingtouch', () => ({
     GestureFactory: {
         getGesture: jest.fn()
     },
-    detectDirection: jest.fn()
+    detectDirection: jest.fn(),
+    detectTap: jest.fn()
 }));
 
 describe('MTouch', () => {
@@ -150,14 +151,27 @@ describe('MTouch', () => {
             });
         });
 
-        it(`should hanndle tap`, () => {
+        it(`should handle tap when detected tap is a tap`, () => {
             const fakeEventObject: any = { detail: 'someDetail', stopPropagation: jest.fn() };
             jest.spyOn(fakeEventObject, 'stopPropagation');
+            (ZingTouchUtil.detectTap as jest.Mock).mockImplementation(() => MZingTapInteractions.Tap);
 
             mountComponent();
             tapcallback(fakeEventObject as any);
 
-            expect(wrapper.emitted('tap')[0][0]).toBeDefined();
+            expect(wrapper.emitted('tap')).toBeDefined();
+            expect(fakeEventObject.stopPropagation).toHaveBeenCalled();
+        });
+
+        it(`should handle tap when detected tap is a click`, () => {
+            const fakeEventObject: any = { detail: 'someDetail', stopPropagation: jest.fn() };
+            jest.spyOn(fakeEventObject, 'stopPropagation');
+            (ZingTouchUtil.detectTap as jest.Mock).mockImplementation(() => MZingTapInteractions.Click);
+
+            mountComponent();
+            tapcallback(fakeEventObject as any);
+
+            expect(wrapper.emitted('click')).toBeDefined();
             expect(fakeEventObject.stopPropagation).toHaveBeenCalled();
         });
     });

--- a/src/components/touch/touch.ts
+++ b/src/components/touch/touch.ts
@@ -3,7 +3,7 @@ import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 
 import { TOUCH_NAME } from '../component-names';
-import { MZingGestureDirections, MZingTouchGestures } from './enums';
+import { MZingGestureDirections, MZingTapInteractions, MZingTouchGestures } from './enums';
 import WithRender from './touch.html';
 import ZingTouchUtil, { MZingRegion } from './zingtouch';
 
@@ -86,8 +86,16 @@ export class MTouch extends Vue {
 
     private configureZingTap(): void {
         this.zingRegion!.bind(this.$el, ZingTouchUtil.GestureFactory.getGesture(MZingTouchGestures.Tap), (event: CustomEvent) => {
-            this.handleZingEvent(event);
-            this.$emit('tap', event);
+            switch (ZingTouchUtil.detectTap(event)) {
+                case MZingTapInteractions.Tap:
+                    this.handleZingEvent(event);
+                    this.$emit('tap', event);
+                    break;
+                case MZingTapInteractions.Click:
+                    this.handleZingEvent(event);
+                    this.$emit('click', event);
+                    break;
+            }
         });
     }
 

--- a/src/components/touch/zingtouch.spec.ts
+++ b/src/components/touch/zingtouch.spec.ts
@@ -1,6 +1,6 @@
 import ZingTouch from 'zingtouch';
 
-import { MZingGestureDirections, MZingTouchGestures } from './enums';
+import { MZingGestureDirections, MZingTapInteractions, MZingTouchGestures } from './enums';
 import { MZingGesture, MZingTouchGestureFactory, MZingTouchUtil } from './zingtouch';
 
 describe('MZingTouchGestureFactory', () => {
@@ -66,5 +66,18 @@ describe('MZingTouchUtil', () => {
         });
     });
 
-    // The rest of the code is untestable
+    [
+        { interval: 0, result: MZingTapInteractions.Click },
+        { interval: 4, result: MZingTapInteractions.Click },
+        { interval: 5, result: MZingTapInteractions.Click },
+        { interval: 6, result: MZingTapInteractions.Tap },
+        { interval: 7, result: MZingTapInteractions.Tap },
+        { interval: 10, result: MZingTapInteractions.Tap }
+    ].forEach(keyValue => {
+        it(`it should detect ${keyValue.result} when interval is ${keyValue.interval}`, () => {
+            const interaction: MZingTapInteractions = util.detectTap({ detail: { interval: keyValue.interval } } as CustomEvent);
+
+            expect(interaction).toBe(keyValue.result);
+        });
+    });
 });

--- a/src/components/touch/zingtouch.ts
+++ b/src/components/touch/zingtouch.ts
@@ -1,6 +1,6 @@
 import ZingTouch from 'zingtouch';
 
-import { MZingGestureDirections, MZingTouchGestures } from './enums';
+import { MZingGestureDirections, MZingTapInteractions, MZingTouchGestures } from './enums';
 
 export type MZingGestureCallback = (event: CustomEvent) => void;
 export interface MZingGesture {}
@@ -41,6 +41,15 @@ export class MZingTouchUtil {
         }
 
         return MZingGestureDirections.None;
+    }
+
+    detectTap(event: CustomEvent): MZingTapInteractions {
+        const interval: number = event.detail.interval;
+        if (interval <= 5) {
+            return MZingTapInteractions.Click;
+        } else {
+            return MZingTapInteractions.Tap;
+        }
     }
 }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Tap event was emitted twice on mobile devices and in device simulation on chrome.  Now it won't, but it could emited a tap and a click event at the same time (ghost click on mobile devices)
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-455
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
