### PR TITLE
Lazy load portal

### DIFF
--- a/src/components/datepicker/__snapshots__/datepicker.spec.ts.snap
+++ b/src/components/datepicker/__snapshots__/datepicker.spec.ts.snap
@@ -15,9 +15,7 @@ exports[`MDatepicker should render correctly 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -37,9 +35,7 @@ exports[`MDatepicker should render correctly min/max time 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -62,9 +58,7 @@ exports[`MDatepicker should render correctly when disabled is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -92,9 +86,7 @@ exports[`MDatepicker should render correctly when error is set 1`] = `
         </m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -122,9 +114,7 @@ exports[`MDatepicker should render correctly when valid is set 1`] = `
         </m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -147,9 +137,7 @@ exports[`MDatepicker should render correctly when waiting is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;

--- a/src/components/dialog/dialog.html
+++ b/src/components/dialog/dialog.html
@@ -1,8 +1,8 @@
 <div class="m-dialog" ref="baseWindow">
     <slot name="trigger"></slot>
-    <portal :target-el="'#' + propId">
+    <portal :target-el="portalTargetSelector" v-if="portalCreated">
         <transition name="m--is">
-            <div v-show="propOpen" v-if="propOpen || preload || loaded"
+            <div v-show="propOpen" v-if="portalMounted"
                  class="m-dialog__wrap m--is-dialog"
                  :class="[{ 'm--is-small': sizeSmall,
                             'm--is-large': sizeLarge,

--- a/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
+++ b/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
@@ -19,9 +19,7 @@ exports[`MDropdown should render correctly 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -45,9 +43,7 @@ exports[`MDropdown should render correctly when placeholder is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;

--- a/src/components/edit-window/edit-window.html
+++ b/src/components/edit-window/edit-window.html
@@ -1,12 +1,12 @@
 <div class="m-edit-window" ref="baseWindow">
     <slot name="trigger"></slot>
-    <portal :target-el="'#' + propId">
+    <portal :target-el="portalTargetSelector" v-if="portalCreated">
         <transition name="m--is" :duration="{ enter: 800, leave: 600 }">
             <div class="m-edit-window__wrap"
                  :class="[{ 'm--is-disabled':disabled },
                             className ]"
                  ref="dialogWrap"
-                 v-show="propOpen" v-if="propOpen || preload || loaded">
+                 v-show="propOpen" v-if="portalMounted">
                 <section class="m-edit-window__article" ref="article">
                     <header class="m-edit-window__header"
                             :class="{'m--no-padding': !padding || !paddingHeader}">

--- a/src/components/edit-window/edit-window.ts
+++ b/src/components/edit-window/edit-window.ts
@@ -1,11 +1,11 @@
 import { PluginObject } from 'vue';
-import { ModulVue } from '../../utils/vue/vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
+
+import { BackdropMode, Portal, PortalMixin, PortalTransitionDuration } from '../../mixins/portal/portal';
+import { ModulVue } from '../../utils/vue/vue';
 import { EDIT_WINDOW_NAME } from '../component-names';
-import { Portal, PortalMixin, PortalMixinImpl, BackdropMode, PortalTransitionDuration } from '../../mixins/portal/portal';
 import WithRender from './edit-window.html?style=./edit-window.scss';
-import { log } from 'util';
 
 @WithRender
 @Component({

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -1,28 +1,28 @@
 <div class="m-modal" ref="baseWindow">
     <slot name="trigger"></slot>
-    <portal :target-el="'#' + propId">
+    <portal :target-el="portalTargetSelector" v-if="portalCreated">
         <transition name="m--is">
             <div class="m-modal__wrap"
-                 :class="[{ 'm--is-disabled': disabled }, className ]"
-                 v-show="propOpen"
-                 v-if="propOpen || preload || loaded"
-                 ref="dialogWrap">
+                    :class="[{ 'm--is-disabled': disabled }, className ]"
+                    v-show="propOpen"
+                    v-if="portalMounted"
+                    ref="dialogWrap">
                 <article class="m-modal__article"
-                         :class="{ 'm--has-width-large': hasWidthLarge }"
-                         ref="article">
+                            :class="{ 'm--has-width-large': hasWidthLarge }"
+                            ref="article">
                     <header class="m-modal__header"
                             v-if="hasTitle">
                         <h2>{{ title }}</h2>
                     </header>
                     <div class="m-modal__body"
-                         v-if="hasDefaultSlot || hasMessage">
+                            v-if="hasDefaultSlot || hasMessage">
                         <p v-if="hasMessage" v-html="message"></p>
                         <slot></slot>
                     </div>
                     <footer class="m-modal__footer">
                         <slot name="footer"></slot>
                         <nav class="m-modal__footer__nav"
-                             v-if="!hasFooterSlot">
+                                v-if="!hasFooterSlot">
                             <m-button @click="onOk()">
                                 <template v-if="hasOkLabel">{{ okLabel }}</template>
                                 <m-i18n v-else k="m-modal:ok"></m-i18n>

--- a/src/components/popper/popper.html
+++ b/src/components/popper/popper.html
@@ -1,6 +1,6 @@
 <div class="m-popper" :class="{ 'm--is-open': propOpen }">
     <slot name="trigger"></slot>
-    <portal :target-el="'#' + propId" v-if="hasDefaultSlot">
+    <portal :target-el="portalTargetSelector" v-if="hasDefaultSlot && portalCreated">
         <transition
             name="m--is"
             @before-enter="onBeforeEnter"
@@ -21,7 +21,7 @@
                                 className ]"
                      :aria-hidden="!propOpen"
                      :style="{ width: width }"
-                     v-show="propOpen" v-if="preload || loaded">
+                     v-show="propOpen" v-if="portalMounted">
                 <header class="m-popper__header" :class="{ 'm--no-padding': !padding || !paddingHeader }"  v-if="hasHeaderSlot">
                     <slot name="header"></slot>
                 </header>

--- a/src/components/popper/popper.ts
+++ b/src/components/popper/popper.ts
@@ -160,7 +160,8 @@ export class MPopper extends ModulVue implements PortalMixinImpl {
     private onDocumentClick(event: MouseEvent): void {
         if (this.as<PortalMixin>().propOpen) {
             let trigger: HTMLElement | undefined = this.as<PortalMixin>().getTrigger();
-            if (!(this.as<PortalMixin>().getPortalElement().contains(event.target as Node) || this.$el.contains(event.target as HTMLElement) ||
+            const element: HTMLElement = this.as<PortalMixin>().getPortalElement();
+            if (!(element && element.contains(event.target as Node) || this.$el.contains(event.target as HTMLElement) ||
                 (trigger && trigger.contains(event.target as HTMLElement)))) {
                 this.as<PortalMixin>().propOpen = false;
             }

--- a/src/components/sidebar/sidebar.html
+++ b/src/components/sidebar/sidebar.html
@@ -1,8 +1,8 @@
 <div class="m-sidebar" ref="baseWindow">
     <slot name="trigger"></slot>
-    <portal :target-el="'#' + propId">
+    <portal :target-el="portalTargetSelector" v-if="portalCreated">
         <transition name="m--is">
-            <div v-show="propOpen" v-if="propOpen || preload || loaded"
+            <div v-show="propOpen" v-if="portalMounted"
                 class="m-sidebar__wrap m--is-sidebar"
                 :class="[{ 'm--is-close-on-backdrop': closeOnBackdrop,
                            'm--is-disabled':disabled },

--- a/src/components/sidebar/sidebar.sandbox.html
+++ b/src/components/sidebar/sidebar.sandbox.html
@@ -8,6 +8,9 @@
         -->
     </p>
     <p>
-        <m-sidebar><!-- Test case --></m-sidebar>
+        <m-sidebar>
+            <m-button slot="trigger">Ouvrir la fenêtre</m-button>
+            Lorem ipsum dolor, sit amet consectetur adipisicing elit. Facere, velit? Temporibus et ipsa, voluptatibus cum, ducimus rerum ex officia minima culpa maiores architecto tempore aut, consequuntur consectetur possimus tempora recusandae!
+        </m-sidebar>
     </p>
 </div>

--- a/src/components/timepicker/__snapshots__/timepicker.spec.ts.snap
+++ b/src/components/timepicker/__snapshots__/timepicker.spec.ts.snap
@@ -15,9 +15,7 @@ exports[`MTimepicker should render correctly 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -37,9 +35,7 @@ exports[`MTimepicker should render correctly min/max time 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -62,9 +58,7 @@ exports[`MTimepicker should render correctly when disabled is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -92,9 +86,7 @@ exports[`MTimepicker should render correctly when error is set 1`] = `
         </m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -122,9 +114,7 @@ exports[`MTimepicker should render correctly when valid is set 1`] = `
         </m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;
@@ -147,9 +137,7 @@ exports[`MTimepicker should render correctly when waiting is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <div class="m-popper"> </div>
     </div>
 </div>
 `;

--- a/src/mixins/portal/portal.ts
+++ b/src/mixins/portal/portal.ts
@@ -280,12 +280,9 @@ export class Portal extends ModulVue implements PortalMixin {
 
             // We wait for the portal creation / mounting.
             this.$nextTick(() => {
-                const portalElement: HTMLElement = this.$el.querySelector('.v-portal') as HTMLElement;
-                if (portalElement) {
-                    this.portalTargetIsReady = true;
-                    this.portalTargetEl = document.querySelector(this.portalTargetSelector) as HTMLElement;
-                    onPortalReady();
-                }
+                this.portalTargetIsReady = true;
+                this.portalTargetEl = document.querySelector(this.portalTargetSelector) as HTMLElement;
+                onPortalReady();
             });
         } else {
             onPortalReady();

--- a/src/mixins/portal/portal.ts
+++ b/src/mixins/portal/portal.ts
@@ -80,8 +80,8 @@ export class Portal extends ModulVue implements PortalMixin {
     private stackId: string;
     private internalTransitionDuration: number = PortalTransitionDuration.Regular;
     private opening: boolean = false;
-    private portalTargetElExists: boolean = false;
-    private portalTargetIsReady: boolean = false;
+    private portalTargetCreated: boolean = false;
+    private portalTargetMounted: boolean = false;
 
     public setFocusToPortal(): void {
         if (this.as<PortalMixinImpl>().handlesFocus()) {
@@ -145,8 +145,8 @@ export class Portal extends ModulVue implements PortalMixin {
 
         if (this.portalTargetEl && this.portalTargetEl.parentNode) {
             this.portalTargetEl.parentNode.removeChild(this.portalTargetEl);
-            this.portalTargetElExists = false;
-            this.portalTargetIsReady = false;
+            this.portalTargetCreated = false;
+            this.portalTargetMounted = false;
         }
     }
 
@@ -215,11 +215,11 @@ export class Portal extends ModulVue implements PortalMixin {
     }
 
     public get portalCreated(): boolean {
-        return this.portalTargetElExists;
+        return this.portalTargetCreated;
     }
 
     public get portalMounted(): boolean {
-        return (this.propOpen || this.preload || this.loaded) && this.portalTargetIsReady;
+        return (this.propOpen || this.preload || this.loaded) && this.portalTargetMounted;
     }
 
     @Watch('trigger')
@@ -274,13 +274,13 @@ export class Portal extends ModulVue implements PortalMixin {
         if (!this.portalTargetEl) {
             this.propId = this.id === undefined ? 'mPortal-' + uuid.generate() : this.id;
             this.portalTargetEl = document.createElement('div');
-            this.portalTargetElExists = true;
             this.portalTargetEl.setAttribute('id', this.propId);
             document.body.appendChild(this.portalTargetEl);
+            this.portalTargetCreated = true;
 
             // We wait for the portal creation / mounting.
             this.$nextTick(() => {
-                this.portalTargetIsReady = true;
+                this.portalTargetMounted = true;
                 this.portalTargetEl = document.querySelector(this.portalTargetSelector) as HTMLElement;
                 onPortalReady();
             });

--- a/src/mixins/portal/portal.ts
+++ b/src/mixins/portal/portal.ts
@@ -80,6 +80,8 @@ export class Portal extends ModulVue implements PortalMixin {
     private stackId: string;
     private internalTransitionDuration: number = PortalTransitionDuration.Regular;
     private opening: boolean = false;
+    private portalTargetElExists: boolean = false;
+    private portalTargetIsReady: boolean = false;
 
     public setFocusToPortal(): void {
         if (this.as<PortalMixinImpl>().handlesFocus()) {
@@ -129,13 +131,6 @@ export class Portal extends ModulVue implements PortalMixin {
         }
     }
 
-    protected beforeMount(): void {
-        this.propId = this.id === undefined ? 'mPortal-' + uuid.generate() : this.id;
-        let element: HTMLElement = document.createElement('div');
-        element.setAttribute('id', this.propId);
-        document.body.appendChild(element);
-    }
-
     protected mounted(): void {
         this.portalTargetEl = document.getElementById(this.propId) as HTMLElement;
         this.handleTrigger();
@@ -148,8 +143,10 @@ export class Portal extends ModulVue implements PortalMixin {
             this.internalTrigger.removeEventListener('mouseenter', this.handleMouseEnter);
         }
 
-        if (this.portalTargetEl.parentNode) {
+        if (this.portalTargetEl && this.portalTargetEl.parentNode) {
             this.portalTargetEl.parentNode.removeChild(this.portalTargetEl);
+            this.portalTargetElExists = false;
+            this.portalTargetIsReady = false;
         }
     }
 
@@ -164,20 +161,23 @@ export class Portal extends ModulVue implements PortalMixin {
     public set propOpen(value: boolean) {
         if (value !== this.internalOpen) {
             if (value) {
-                if (this.portalTargetEl) {
-                    this.stackId = this.$modul.pushElement(this.portalTargetEl, this.as<PortalMixinImpl>().getBackdropMode(), this.as<MediaQueriesMixin>().isMqMaxS);
-                    if (!this.as<PortalMixinImpl>().doCustomPropOpen(value, this.portalTargetEl)) {
-                        this.portalTargetEl.style.position = 'absolute';
+                this.ensurePortalTargetEl(() => {
+                    if (this.portalTargetEl) {
+                        this.stackId = this.$modul.pushElement(this.portalTargetEl, this.as<PortalMixinImpl>().getBackdropMode(), this.as<MediaQueriesMixin>().isMqMaxS);
 
-                        // this.opening is important since it's fix a race condition where the portal
-                        // could appear behind the content of the page if it was toggled too quickly.
-                        this.opening = true;
-                        setTimeout(() => {
-                            this.setFocusToPortal();
-                            this.opening = false;
-                        }, this.transitionDuration);
+                        if (!this.as<PortalMixinImpl>().doCustomPropOpen(value, this.portalTargetEl)) {
+                            this.portalTargetEl.style.position = 'absolute';
+
+                            // this.opening is important since it's fix a race condition where the portal
+                            // could appear behind the content of the page if it was toggled too quickly.
+                            this.opening = true;
+                            setTimeout(() => {
+                                this.setFocusToPortal();
+                                this.opening = false;
+                            }, this.transitionDuration);
+                        }
                     }
-                }
+                });
             } else {
                 if (this.portalTargetEl) {
                     this.$modul.popElement(this.stackId);
@@ -208,6 +208,18 @@ export class Portal extends ModulVue implements PortalMixin {
 
     public set transitionDuration(speed: number) {
         this.internalTransitionDuration = speed;
+    }
+
+    public get portalTargetSelector(): string {
+        return this.propId ? `#${this.propId}` : '';
+    }
+
+    public get portalCreated(): boolean {
+        return this.portalTargetElExists;
+    }
+
+    public get portalMounted(): boolean {
+        return (this.propOpen || this.preload || this.loaded) && this.portalTargetIsReady;
     }
 
     @Watch('trigger')
@@ -256,6 +268,28 @@ export class Portal extends ModulVue implements PortalMixin {
 
     private handleMouseEnter(): void {
         this.propOpen = true;
+    }
+
+    private ensurePortalTargetEl(onPortalReady: () => void = () => {}): void {
+        if (!this.portalTargetEl) {
+            this.propId = this.id === undefined ? 'mPortal-' + uuid.generate() : this.id;
+            this.portalTargetEl = document.createElement('div');
+            this.portalTargetElExists = true;
+            this.portalTargetEl.setAttribute('id', this.propId);
+            document.body.appendChild(this.portalTargetEl);
+
+            // We wait for the portal creation / mounting.
+            this.$nextTick(() => {
+                const portalElement: HTMLElement = this.$el.querySelector('.v-portal') as HTMLElement;
+                if (portalElement) {
+                    this.portalTargetIsReady = true;
+                    this.portalTargetEl = document.querySelector(this.portalTargetSelector) as HTMLElement;
+                    onPortalReady();
+                }
+            });
+        } else {
+            onPortalReady();
+        }
     }
 
     @Watch('open')


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Si on utilisait souvent la Mixin portal, ça créait pas mal d'éléments superflus dans le DOM.  Maintenant, les éléments nécéssaires au bon fonctionnement d'un Portal seront mis en place au premier init de la mixin (première fois que propOpen = true).

Faire attention.  Il y a quelques breaking changes dans brio : 
-Un composant qui utilise la mixin Portal ne peut avoir un <portal> comme root element.
-Pour renseigner le target-el, il est maintenant conseillé d'utiliser la propriété portalTargetSelector dans la mixin.  L'id n'est plus disponible dès le départ, et un target-el qui contient '#' + propId (undefined) n'est pas valide aux yeux de vue-portal.  
-Si on utilise un portal contenant une transition, il est important d'attendre que l'élément portal soit bien monté dans le DOM afin que tout s'anime correctement.  Pour se faire, la propriété "portalMounted" est maintenant disponible dans la mixin.

`
<portal :target-el="portalTargetSelector" v-if="portalCreated">
        <transition name="p--is">
            <section class="p-contenu"
                     v-show="propOpen"
                     v-if="portalMounted">
`
Notez aussi l'usage de portalCreated sur le portal.  Cette étape n'est pas nécéssaire.  Ceci dit, ça évite d'avoir du DOM inutile dans notre solution.  La propriété portalCrated est aussi disponible dans la mixin.

Ne pas merger en attendant que je donne une PR de gestion des breaking change dans brio.

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-475
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
