### PR TITLE
Added a check for RTE containing only HTML

### DIFF
--- a/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
+++ b/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`MRichTextEditor should render correctly 1`] = `
 <div class="m-rich-text" style="width:100%;max-width:288px;">
-    <m-input-style label-for="mrich-text-uuid" empty="true" border-top="true" tag-style="default"></m-input-style>
+    <m-input-style label-for="mrich-text-uuid" empty="true" border-top="true" tag-style="default">
+        <froala config="[object Object]" value=""></froala>
+    </m-input-style>
     <div class="m-textfield__validation">
         <m-validation-message class="m-textfield__validation__message"></m-validation-message>
     </div>

--- a/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
+++ b/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`MRichTextEditor should render correctly 1`] = `
 <div class="m-rich-text" style="width:100%;max-width:288px;">
     <m-input-style label-for="mrich-text-uuid" empty="true" border-top="true" tag-style="default">
-        <froala config="[object Object]" value=""></froala>
+        <froala config="[object Object]" value="" custom-translations="[object Object]"></froala>
     </m-input-style>
     <div class="m-textfield__validation">
         <m-validation-message class="m-textfield__validation__message"></m-validation-message>

--- a/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
+++ b/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`MRichTextEditor should render correctly 1`] = `
 <div class="m-rich-text" style="width:100%;max-width:288px;">
     <m-input-style label-for="mrich-text-uuid" empty="true" border-top="true" tag-style="default">
-        <froala config="[object Object]" value="" custom-translations="[object Object]"></froala>
+        <froala config="[object Object]" value=""></froala>
     </m-input-style>
     <div class="m-textfield__validation">
         <m-validation-message class="m-textfield__validation__message"></m-validation-message>

--- a/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -83,6 +83,7 @@ export enum FroalaStatus {
     };
     protected model: string | undefined = undefined;
     protected oldModel: string | undefined = undefined;
+    protected rawHtmlInput: string | undefined = undefined;
 
     protected isFocused: boolean = false;
     protected isInitialized: boolean = false;
@@ -452,12 +453,21 @@ export enum FroalaStatus {
         let modelContent: string = '';
 
         const returnedHtml: any = this._$element.froalaEditor('html.get');
-        if (typeof returnedHtml === 'string') {
-            modelContent = returnedHtml;
+        if (typeof returnedHtml === 'string' && returnedHtml !== this.rawHtmlInput) {
+            this.rawHtmlInput = returnedHtml;
+            modelContent = this.removeEmptyHTML(returnedHtml);
+        } else {
+            modelContent = (this.oldModel) ? this.oldModel : '';
         }
 
         this.oldModel = modelContent;
         this.$emit('input', modelContent);
+    }
+
+    private removeEmptyHTML(value: string): string {
+        const div: HTMLElement = document.createElement('div');
+        div.innerHTML = value;
+        return ((div.textContent || div.innerText || '').trim().length > 0) ? value : '';
     }
 
     private registerEvent(element: any, eventName: any, callback: any): void {

--- a/src/components/rich-text-editor/rich-text-editor.sandbox.html
+++ b/src/components/rich-text-editor/rich-text-editor.sandbox.html
@@ -17,9 +17,18 @@
         <div><button @click="disabled = !disabled">Disabled (now: {{ disabled }})</button></div>
     </div>
     <div class="m-u--margin-bottom">
-        <m-rich-text-editor v-model="model" toolbar-sticky-offset=".mtest-header" :label="'texte riche'" :max-width="'large'"
-            :placeholder="'some placeholder'" :focus="focus" :error="error" :error-message="errorMessage"
-            :valid-message="validMessage" :helper-message="helperMessage" :waiting="waiting" :disabled="disabled"></m-rich-text-editor>
+        <m-rich-text-editor v-model="model"
+            toolbar-sticky-offset=".mtest-header"
+            :label="'texte riche'"
+            :max-width="'large'"
+            :placeholder="'some placeholder'"
+            :focus="focus"
+            :error="error"
+            :error-message="errorMessage"
+            :valid-message="validMessage"
+            :helper-message="helperMessage"
+            :waiting="waiting"
+            :disabled="disabled"></m-rich-text-editor>
     </div>
     <div class="m-u--margin-bottom">
         <h5>Résultat dans le lecteur</h5>
@@ -31,7 +40,7 @@
         <h5>Contenu du v-model</h5>
         <div>
             <pre>
-                {{ model }}
+{{ model }}
             </pre>
         </div>
     </div>
@@ -72,9 +81,17 @@
     </div>
     <h5 class="m-u--margin-bottom">placeholder vide n'affiche rien</h5>
     <div class="m-u--margin-bottom">
-        <m-rich-text-editor v-model="model" :toolbar-sticky-offset="58" :label="'texte riche'" :max-width="'large'"
-            :focus="focus" :error="error" :error-message="errorMessage" :valid-message="validMessage" :helper-message="helperMessage"
-            :waiting="waiting" :disabled="disabled"></m-rich-text-editor>
+        <m-rich-text-editor v-model="model"
+            :toolbar-sticky-offset="58"
+            :label="'texte riche'"
+            :max-width="'large'"
+            :focus="focus"
+            :error="error"
+            :error-message="errorMessage"
+            :valid-message="validMessage"
+            :helper-message="helperMessage"
+            :waiting="waiting"
+            :disabled="disabled"></m-rich-text-editor>
     </div>
     <h5 class="m-u--margin-bottom">Tests de la case à cocher « Ouvrir dans un nouvel onglet » d'un lien externe</h5>
     <div class="m-u--margin-bottom">

--- a/src/components/rich-text-editor/rich-text-editor.sandbox.html
+++ b/src/components/rich-text-editor/rich-text-editor.sandbox.html
@@ -17,22 +17,23 @@
         <div><button @click="disabled = !disabled">Disabled (now: {{ disabled }})</button></div>
     </div>
     <div class="m-u--margin-bottom">
-        <m-rich-text-editor v-model="model"
-        toolbar-sticky-offset=".mtest-header"
-        :label="'texte riche'"
-        :max-width="'large'"
-        :placeholder="'some placeholder'"
-        :focus="focus"
-        :error="error"
-        :error-message="errorMessage"
-        :valid-message="validMessage"
-        :helper-message="helperMessage"
-        :waiting="waiting"
-        :disabled="disabled"></m-rich-text-editor>
+        <m-rich-text-editor v-model="model" toolbar-sticky-offset=".mtest-header" :label="'texte riche'" :max-width="'large'"
+            :placeholder="'some placeholder'" :focus="focus" :error="error" :error-message="errorMessage"
+            :valid-message="validMessage" :helper-message="helperMessage" :waiting="waiting" :disabled="disabled"></m-rich-text-editor>
     </div>
     <div class="m-u--margin-bottom">
         <h5>Résultat dans le lecteur</h5>
-        <div><m-rich-text :value="model"></m-rich-text></div>
+        <div>
+            <m-rich-text :value="model"></m-rich-text>
+        </div>
+    </div>
+    <div>
+        <h5>Contenu du v-model</h5>
+        <div>
+            <pre>
+                {{ model }}
+            </pre>
+        </div>
     </div>
     <h5 class="m-u--margin-bottom">fonctionne quand le modèle est déjà initialisé</h5>
     <div class="m-u--margin-bottom">
@@ -55,7 +56,8 @@
     </div>
     <div>
         <h5 class="m-u--margin-bottom">fonctionne dans un formulaire pleine page</h5>
-        <button @click="afficherFormulairePleinePage = !afficherFormulairePleinePage">Afficher formulaire pleine page</button>
+        <button @click="afficherFormulairePleinePage = !afficherFormulairePleinePage">Afficher formulaire pleine
+            page</button>
         <m-edit-window :open.sync="afficherFormulairePleinePage">
             <template slot="header">
                 <span class="m-u--h2 m-u--font-weight--bold">
@@ -63,24 +65,16 @@
                 </span>
             </template>
             <div>
-                <m-rich-text-editor scrollable-container=".m-edit-window__body" class="p-formulaire-texte__textearea" :label="'texte riche'"
-                    tag-style="p" max-width="720px" v-model="fullScreenFormModel"></m-rich-text-editor>
+                <m-rich-text-editor scrollable-container=".m-edit-window__body" class="p-formulaire-texte__textearea"
+                    :label="'texte riche'" tag-style="p" max-width="720px" v-model="fullScreenFormModel"></m-rich-text-editor>
             </div>
         </m-edit-window>
     </div>
     <h5 class="m-u--margin-bottom">placeholder vide n'affiche rien</h5>
     <div class="m-u--margin-bottom">
-        <m-rich-text-editor v-model="model"
-        :toolbar-sticky-offset="58"
-        :label="'texte riche'"
-        :max-width="'large'"
-        :focus="focus"
-        :error="error"
-        :error-message="errorMessage"
-        :valid-message="validMessage"
-        :helper-message="helperMessage"
-        :waiting="waiting"
-        :disabled="disabled"></m-rich-text-editor>
+        <m-rich-text-editor v-model="model" :toolbar-sticky-offset="58" :label="'texte riche'" :max-width="'large'"
+            :focus="focus" :error="error" :error-message="errorMessage" :valid-message="validMessage" :helper-message="helperMessage"
+            :waiting="waiting" :disabled="disabled"></m-rich-text-editor>
     </div>
     <h5 class="m-u--margin-bottom">Tests de la case à cocher « Ouvrir dans un nouvel onglet » d'un lien externe</h5>
     <div class="m-u--margin-bottom">

--- a/src/components/rich-text-editor/rich-text-editor.spec.ts
+++ b/src/components/rich-text-editor/rich-text-editor.spec.ts
@@ -17,7 +17,12 @@ let defaultOptions: MRichTextEditorStandardOptions;
 describe('MRichTextEditor', () => {
     beforeEach(() => {
         Vue.use(RichTextLicensePlugin, { key: froalaLicenseKey });
-        wrapper = shallow(MRichTextEditor);
+        wrapper = shallow(MRichTextEditor,
+            {
+                stubs: {
+                    froala : '<froala></froala>'
+                }
+            });
         richTextEditor = wrapper.vm;
         defaultOptions = new MRichTextEditorStandardOptions(froalaLicenseKey, richTextEditor.$i18n.currentLang());
     });
@@ -53,17 +58,18 @@ describe('MRichTextEditor', () => {
     });
 
     describe('when refreshing model', () => {
-        it('should refresh with real value if has value', () => {
+        it('should refresh with real value if it has value', () => {
             const content: string = '<p>abc123</p>';
 
-            richTextEditor.$emit('input', content);
+            const obj: Vue = (richTextEditor.$refs.input as Vue).$emit('input', content);
 
             expect(wrapper.emitted().input[0]).toEqual([content]);
         });
+
         it(`should refresh with an empty string if it doesn't have value`, () => {
             const content: string = '<p><strong> &nbsp; </strong></p>';
 
-            richTextEditor.$emit('input', content);
+            const obj: Vue = (richTextEditor.$refs.input as Vue).$emit('input', content);
 
             expect(wrapper.emitted().input[0]).toEqual(['']);
         });

--- a/src/components/rich-text-editor/rich-text-editor.spec.ts
+++ b/src/components/rich-text-editor/rich-text-editor.spec.ts
@@ -41,40 +41,6 @@ describe('MRichTextEditor', () => {
         expect(richTextEditor.froalaLicenseKey).toEqual(froalaLicenseKey);
     });
 
-    describe('custom validation for HTML content', () => {
-        ['', '<p></p>', '<p>&nbsp;</p>', ' &nbsp; ', '<p><strong></strong></p>']
-        .forEach((value: string) => {
-            it(`A RTE with '${value}' is considered to be empty`, () => {
-                expect(richTextEditor.customHasValue(value)).toBeFalsy();
-            });
-        });
-
-        ['a', '<p>abc</p>', '<p>a&nbsp;</p>', ' &nbsp; abc', '<p><strong>abc</strong></p>']
-        .forEach((value: string) => {
-            it(`A RTE with '${value}' is considered NOT to be empty`, () => {
-                expect(richTextEditor.customHasValue(value)).toBeTruthy();
-            });
-        });
-    });
-
-    describe('when refreshing model', () => {
-        it('should refresh with real value if it has value', () => {
-            const content: string = '<p>abc123</p>';
-
-            const obj: Vue = (richTextEditor.$refs.input as Vue).$emit('input', content);
-
-            expect(wrapper.emitted().input[0]).toEqual([content]);
-        });
-
-        it(`should refresh with an empty string if it doesn't have value`, () => {
-            const content: string = '<p><strong> &nbsp; </strong></p>';
-
-            const obj: Vue = (richTextEditor.$refs.input as Vue).$emit('input', content);
-
-            expect(wrapper.emitted().input[0]).toEqual(['']);
-        });
-    });
-
     describe('In standard Mode', () => {
         beforeEach(() => {
             wrapper.setProps({

--- a/src/components/rich-text-editor/rich-text-editor.spec.ts
+++ b/src/components/rich-text-editor/rich-text-editor.spec.ts
@@ -36,6 +36,39 @@ describe('MRichTextEditor', () => {
         expect(richTextEditor.froalaLicenseKey).toEqual(froalaLicenseKey);
     });
 
+    describe('custom validation for HTML content', () => {
+        ['', '<p></p>', '<p>&nbsp;</p>', ' &nbsp; ', '<p><strong></strong></p>']
+        .forEach((value: string) => {
+            it(`A RTE with '${value}' is considered to be empty`, () => {
+                expect(richTextEditor.customHasValue(value)).toBeFalsy();
+            });
+        });
+
+        ['a', '<p>abc</p>', '<p>a&nbsp;</p>', ' &nbsp; abc', '<p><strong>abc</strong></p>']
+        .forEach((value: string) => {
+            it(`A RTE with '${value}' is considered NOT to be empty`, () => {
+                expect(richTextEditor.customHasValue(value)).toBeTruthy();
+            });
+        });
+    });
+
+    describe('when refreshing model', () => {
+        it('should refresh with real value if has value', () => {
+            const content: string = '<p>abc123</p>';
+
+            richTextEditor.$emit('input', content);
+
+            expect(wrapper.emitted().input[0]).toEqual([content]);
+        });
+        it(`should refresh with an empty string if it doesn't have value`, () => {
+            const content: string = '<p><strong> &nbsp; </strong></p>';
+
+            richTextEditor.$emit('input', content);
+
+            expect(wrapper.emitted().input[0]).toEqual(['']);
+        });
+    });
+
     describe('In standard Mode', () => {
         beforeEach(() => {
             wrapper.setProps({

--- a/src/components/rich-text-editor/rich-text-editor.ts
+++ b/src/components/rich-text-editor/rich-text-editor.ts
@@ -3,7 +3,7 @@ import { Prop } from 'vue-property-decorator';
 
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { InputLabel } from '../../mixins/input-label/input-label';
-import { InputManagement, InputManagementData } from '../../mixins/input-management/input-management';
+import { InputManagement, InputManagementData, InputManagementFunction } from '../../mixins/input-management/input-management';
 import { InputState, InputStateInputSelector } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
 import uuid from '../../utils/uuid/uuid';
@@ -30,7 +30,8 @@ export enum MRichTextEditorMode {
         ElementQueries
     ]
 })
-export class MRichTextEditor extends ModulVue implements InputManagementData, InputStateInputSelector {
+export class MRichTextEditor extends ModulVue implements InputManagementData, InputStateInputSelector, InputManagementFunction {
+
     selector: string = '.fr-element.fr-view';
     internalValue: string;
 
@@ -86,8 +87,20 @@ export class MRichTextEditor extends ModulVue implements InputManagementData, In
         return `${RICH_TEXT_EDITOR_NAME}: No element has been found with the selector given in the ${prop} prop.`;
     }
 
+    customHasValue(newValue: string): boolean {
+        const div: HTMLElement = document.createElement('div');
+        div.innerHTML = newValue;
+        return (div.textContent || div.innerText || '')
+            .trim()
+            .length > 0;
+    }
+
     protected refreshModel(newValue: string): void {
-        this.$emit('input', newValue);
+        if (this.customHasValue(newValue)) {
+            this.$emit('input', newValue);
+        } else {
+            this.$emit('input', '');
+        }
     }
 
     protected calculateToolbarStickyOffset(): number | undefined {

--- a/src/components/rich-text-editor/rich-text-editor.ts
+++ b/src/components/rich-text-editor/rich-text-editor.ts
@@ -3,7 +3,7 @@ import { Prop } from 'vue-property-decorator';
 
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { InputLabel } from '../../mixins/input-label/input-label';
-import { InputManagement, InputManagementData, InputManagementFunction } from '../../mixins/input-management/input-management';
+import { InputManagement, InputManagementData } from '../../mixins/input-management/input-management';
 import { InputState, InputStateInputSelector } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
 import uuid from '../../utils/uuid/uuid';
@@ -30,7 +30,7 @@ export enum MRichTextEditorMode {
         ElementQueries
     ]
 })
-export class MRichTextEditor extends ModulVue implements InputManagementData, InputStateInputSelector, InputManagementFunction {
+export class MRichTextEditor extends ModulVue implements InputManagementData, InputStateInputSelector {
 
     selector: string = '.fr-element.fr-view';
     internalValue: string;
@@ -87,20 +87,8 @@ export class MRichTextEditor extends ModulVue implements InputManagementData, In
         return `${RICH_TEXT_EDITOR_NAME}: No element has been found with the selector given in the ${prop} prop.`;
     }
 
-    customHasValue(newValue: string): boolean {
-        const div: HTMLElement = document.createElement('div');
-        div.innerHTML = newValue;
-        return (div.textContent || div.innerText || '')
-            .trim()
-            .length > 0;
-    }
-
     protected refreshModel(newValue: string): void {
-        if (this.customHasValue(newValue)) {
-            this.$emit('input', newValue);
-        } else {
-            this.$emit('input', '');
-        }
+        this.$emit('input', newValue);
     }
 
     protected calculateToolbarStickyOffset(): number | undefined {

--- a/src/mixins/input-management/input-management.ts
+++ b/src/mixins/input-management/input-management.ts
@@ -15,6 +15,10 @@ export interface InputManagementData {
     internalValue: string;
 }
 
+export interface InputManagementFunction {
+    customHasValue(value: string): boolean;
+}
+
 export enum InputManagementAutocomplete {
     Off = 'off',
     On = 'on'
@@ -32,9 +36,9 @@ export class InputManagement extends ModulVue
     @Prop({
         default: undefined,
         validator: value =>
-        value === InputManagementAutocomplete.Off ||
-        value === InputManagementAutocomplete.On ||
-        value === undefined
+            value === InputManagementAutocomplete.Off ||
+            value === InputManagementAutocomplete.On ||
+            value === undefined
     })
     public autocomplete: string;
     @Prop()
@@ -129,7 +133,8 @@ export class InputManagement extends ModulVue
     }
 
     private get hasValue(): boolean {
-        return this.model !== '';
+        const customHasValue: (value: string) => boolean = this.as<InputManagementFunction>().customHasValue;
+        return customHasValue ? customHasValue(this.model) : this.model !== '';
     }
 
     private get isEmpty(): boolean {

--- a/src/mixins/input-management/input-management.ts
+++ b/src/mixins/input-management/input-management.ts
@@ -15,10 +15,6 @@ export interface InputManagementData {
     internalValue: string;
 }
 
-export interface InputManagementFunction {
-    customHasValue(value: string): boolean;
-}
-
 export enum InputManagementAutocomplete {
     Off = 'off',
     On = 'on'
@@ -133,8 +129,7 @@ export class InputManagement extends ModulVue
     }
 
     private get hasValue(): boolean {
-        const customHasValue: (value: string) => boolean = this.as<InputManagementFunction>().customHasValue;
-        return customHasValue ? customHasValue(this.model) : this.model !== '';
+        return this.model !== '';
     }
 
     private get isEmpty(): boolean {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist



<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Added a method in input-management to allow a component to override the behavior of the method `hasValue`. This change was needed to allow the RTE to be considered empty in those cases:
  - RTE contains only empty HTML tags (`<div><p><p></div>`)
  - RTE contains only HTML tags and spaces (`<div>&nbsp; &nbsp;</div>`)
  - RTE contains only HTML tags, spaces and returns (`<div>&nbsp; \n \n</div>`)

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-482
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->