### PR TITLE
MODUL-490 - Changer le tap pour etre transparent

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -42,6 +42,7 @@ $m-dialog--max-width--s: 420px !default;
 
         &.m--is-close-on-backdrop {
             cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
         }
 
         &.m--is-enter-active,

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -23,6 +23,7 @@
 
         &.m--is-close-on-backdrop {
             cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
         }
 
         &.m--is-origin {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
En passant à un tap-highlight transparent, on évite que le dialog ou la sidebar devienne bleu en tappant dessus sur mobile.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-490
https://jira.dti.ulaval.ca/browse/ENA2-62
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
<!-- Release notes here... -->
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
