### PR TITLE
MODUL-464 : Fix for dropdown undefined property HasFooterSlot

### DIFF
--- a/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
+++ b/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
@@ -26,6 +26,32 @@ exports[`MDropdown should render correctly 1`] = `
 </div>
 `;
 
+exports[`MDropdown should render correctly when footer slot is set 1`] = `
+<div class="m-dropdown" style="width:100%;max-width:288px;">
+    <div class="m-input-style m--is-tag-default" style="width:100%;">
+        <div class="m-input-style__body">
+            <div class="m-input-style__body__left">
+                <input type="text" id="mDropdown-uuid" aria-haspopup="true" aria-controls="mDropdown-uuid-controls" readonly="readonly" value="" class="m-dropdown__input"> </div>
+            <div class="m-input-style__body__right">
+                <div class="m-dropdown__arrow">
+                    <svg aria-hidden="true" width="1em" height="1em" button-size="18px" icon-size="16px" class="m-icon m-dropdown__arrow__icon">
+                        <use aria-hidden="true"></use>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="m-validation-message">
+        <m-accordion-transition transition="true"></m-accordion-transition>
+    </div>
+    <div class="m-popup">
+        <div class="m-popper">
+            <DIV class="v-portal" style="display:none;"></DIV>
+        </div>
+    </div>
+</div>
+`;
+
 exports[`MDropdown should render correctly when placeholder is set 1`] = `
 <div class="m-dropdown" style="width:100%;max-width:288px;">
     <div class="m-input-style m--is-tag-default" style="width:100%;">

--- a/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
+++ b/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
@@ -45,9 +45,23 @@ exports[`MDropdown should render correctly when footer slot is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <div class="m-popper">
-            <DIV class="v-portal" style="display:none;"></DIV>
-        </div>
+        <m-popper-mock placement="bottom-start" focus-management="true" open-trigger="mousedown" enter="function boundFn(a) {
+    var l = arguments.length;
+    return l
+      ? l &gt; 1
+        ? fn.apply(ctx, arguments)
+        : fn.call(ctx, a)
+      : fn.call(ctx)
+  }" leave="function boundFn(a) {
+    var l = arguments.length;
+    return l
+      ? l &gt; 1
+        ? fn.apply(ctx, arguments)
+        : fn.call(ctx, a)
+      : fn.call(ctx)
+  }" padding-header="true" padding-body="true" padding-footer="true" preload="true" width="100%" background="true">
+            <div>footer-content</div>
+        </m-popper-mock>
     </div>
 </div>
 `;

--- a/src/components/dropdown/dropdown.lang.fr.json
+++ b/src/components/dropdown/dropdown.lang.fr.json
@@ -1,10 +1,10 @@
 {
     "m-dropdown": {
-        "no-data": "Aucune données",
-        "no-result": "Aucun résultats",
+        "no-data": "Aucune donnée",
+        "no-result": "Aucun résultat",
         "none": "(Aucun)",
-        "research" : "Recherche",
-        "search" : "Rechercher",
+        "research": "Recherche",
+        "search": "Rechercher",
         "open": "Ouvrir la liste déroulante",
         "close": "Fermer la liste déroulante"
     }

--- a/src/components/dropdown/dropdown.spec.ts
+++ b/src/components/dropdown/dropdown.spec.ts
@@ -8,15 +8,6 @@ import { renderComponent } from '../../../tests/helpers/render';
 import uuid from '../../utils/uuid/uuid';
 import DropdownPlugin, { MDropdown } from './dropdown';
 
-
-
-
-
-
-
-
-
-
 jest.mock('../../utils/uuid/uuid');
 (uuid.generate as jest.Mock).mockReturnValue('uuid');
 

--- a/src/components/dropdown/dropdown.spec.ts
+++ b/src/components/dropdown/dropdown.spec.ts
@@ -1,4 +1,4 @@
-import { mount, Slots, Wrapper } from '@vue/test-utils';
+import { createLocalVue, mount, Slots, Wrapper } from '@vue/test-utils';
 import Vue, { VueConstructor } from 'vue';
 
 import { resetModulPlugins } from '../../../tests/helpers/component';
@@ -13,11 +13,16 @@ jest.mock('../../utils/uuid/uuid');
 
 describe('MDropdown', () => {
     let localVue: VueConstructor<Vue>;
+    let mockPopper: VueConstructor<Vue>;
 
     beforeEach(() => {
         resetModulPlugins();
-        Vue.use(DropdownPlugin);
-        addMessages(Vue, [
+        localVue = createLocalVue();
+        localVue.use(DropdownPlugin);
+        mockPopper = localVue.component('m-popper', {
+            template: '<m-popper-mock><slot name="footer"></slot></m-popper-mock>'
+        });
+        addMessages(localVue, [
             'components/dropdown/dropdown.lang.en.json'
         ]);
     });
@@ -25,7 +30,7 @@ describe('MDropdown', () => {
     it('should render correctly', () => {
         const dropdown: Wrapper<MDropdown> = mount(MDropdown, {
             mocks: getDefaultMock(),
-            localVue: Vue
+            localVue: localVue
         });
 
         return expect(renderComponent(dropdown.vm)).resolves.toMatchSnapshot();
@@ -34,7 +39,7 @@ describe('MDropdown', () => {
     it('should render correctly when placeholder is set', () => {
         const dropdown: Wrapper<MDropdown> = mount(MDropdown, {
             mocks: getDefaultMock(),
-            localVue: Vue,
+            localVue: localVue,
             propsData: {
                 placeholder: 'placeholder test'
             }
@@ -44,11 +49,12 @@ describe('MDropdown', () => {
     });
 
     it('should render correctly when footer slot is set', () => {
+        Vue.component('m-popper', mockPopper);
         const dropdown: Wrapper<MDropdown> = mount(MDropdown, {
             mocks: getDefaultMock(),
-            localVue: Vue,
+            localVue: localVue,
             slots: {
-                footer: '<div></div>'
+                footer: '<div>footer-content</div>'
             }
         });
         return expect(renderComponent(dropdown.vm)).resolves.toMatchSnapshot();

--- a/src/components/dropdown/dropdown.spec.ts
+++ b/src/components/dropdown/dropdown.spec.ts
@@ -8,6 +8,15 @@ import { renderComponent } from '../../../tests/helpers/render';
 import uuid from '../../utils/uuid/uuid';
 import DropdownPlugin, { MDropdown } from './dropdown';
 
+
+
+
+
+
+
+
+
+
 jest.mock('../../utils/uuid/uuid');
 (uuid.generate as jest.Mock).mockReturnValue('uuid');
 
@@ -40,6 +49,17 @@ describe('MDropdown', () => {
             }
         });
 
+        return expect(renderComponent(dropdown.vm)).resolves.toMatchSnapshot();
+    });
+
+    it('should render correctly when footer slot is set', () => {
+        const dropdown: Wrapper<MDropdown> = mount(MDropdown, {
+            mocks: getDefaultMock(),
+            localVue: Vue,
+            slots: {
+                footer: '<div></div>'
+            }
+        });
         return expect(renderComponent(dropdown.vm)).resolves.toMatchSnapshot();
     });
 

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -269,6 +269,10 @@ export class MDropdown extends BaseDropdown implements MDropdownInterface {
         return this.as<InputState>().isDisabled || this.as<InputState>().isWaiting;
     }
 
+    private get hasFooterSlot(): boolean {
+        return !!this.$slots.footer;
+    }
+
     private onKeydownUp($event: KeyboardEvent): void {
         if (!this.open) {
             this.open = true;


### PR DESCRIPTION
- [x] Provide a small description of the changes introduced by this PR
Re-added the "hasFooterSlot" computed property in dropdown.ts since it was removed while still being referenced in the component html. 

It seems to have been removed last October with the following merge commit:
https://github.com/ulaval/modul-components/commit/260a3cabc332cf8c4fa428cb528622c7254938a7#diff-32d19fa68636b089eb226685394c1f32

This caused a few errors to be displayed in the console each time a dropdown was rendered. I'm unsure if this is the best way to fix the problem or if its removal was preferred.

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-464
- [ ] Openshift deployment requested


