### PR TITLE
textfield Cannot read property 'setAttribute' of undefined

### DIFF
--- a/src/components/login/__snapshots__/login.spec.ts.snap
+++ b/src/components/login/__snapshots__/login.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`MLogin when login should render correctly 1`] = `
             <label for="mTextfield-uuid" class="m-input-style__label"><span>Username</span></label>
             <div class="m-input-style__body">
                 <div class="m-input-style__body__left">
-                    <input id="mTextfield-uuid" maxlength="Infinity" value="" class="m-textfield__input"> </div>
+                    <input id="mTextfield-uuid" maxlength="Infinity" type="text" value="" class="m-textfield__input"> </div>
                 <div class="m-input-style__body__right"></div>
             </div>
         </div>
@@ -21,7 +21,7 @@ exports[`MLogin when login should render correctly 1`] = `
             <label for="mTextfield-uuid" class="m-input-style__label"><span>Password</span></label>
             <div class="m-input-style__body">
                 <div class="m-input-style__body__left">
-                    <input id="mTextfield-uuid" maxlength="Infinity" value="" class="m-textfield__input"> </div>
+                    <input id="mTextfield-uuid" maxlength="Infinity" type="password" value="" class="m-textfield__input"> </div>
                 <div class="m-input-style__body__right"></div>
             </div>
         </div>

--- a/src/components/textfield/__snapshots__/textfield.spec.ts.snap
+++ b/src/components/textfield/__snapshots__/textfield.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`MTextfield should render correctly 1`] = `
     <div class="m-input-style m--is-tag-default" style="width:undefined;">
         <div class="m-input-style__body">
             <div class="m-input-style__body__left">
-                <input id="mTextfield-uuid" maxlength="Infinity" value="" class="m-textfield__input"> </div>
+                <input id="mTextfield-uuid" maxlength="Infinity" type="text" value="" class="m-textfield__input"> </div>
             <div class="m-input-style__body__right"></div>
         </div>
     </div>

--- a/src/components/textfield/textfield.html
+++ b/src/components/textfield/textfield.html
@@ -36,7 +36,8 @@
                @paste="onPaste"
                :autocomplete="autocomplete"
                v-model="model"
-               v-if="!hasWordWrap">
+               v-if="!hasWordWrap"
+               :type="inputType">
         <template slot="right-content" v-if="!hasWordWrap">
             <transition name="m--is">
                 <m-icon-button class="m-textfield__icon-password"

--- a/src/components/textfield/textfield.spec.ts
+++ b/src/components/textfield/textfield.spec.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 
 import { renderComponent } from '../../../tests/helpers/render';
 import uuid from '../../utils/uuid/uuid';
-import TextfieldPlugin, { MTextfield } from './textfield';
+import TextfieldPlugin, { MTextfield, MTextfieldType } from './textfield';
 
 jest.mock('../../utils/uuid/uuid');
 (uuid.generate as jest.Mock).mockReturnValue('uuid');
@@ -18,5 +18,28 @@ describe('MTextfield', () => {
         });
 
         return expect(renderComponent(component.vm)).resolves.toMatchSnapshot();
+    });
+
+    [MTextfieldType.EMail, MTextfieldType.Password, MTextfieldType.Telephone, MTextfieldType.Text, MTextfieldType.Url]
+        .forEach((type: MTextfieldType) => {
+            it('should return inputType equal to type prop', () => {
+                const component: Wrapper<MTextfield> = mount(MTextfield, {
+                    localVue: Vue,
+                    propsData: { type }
+                });
+
+                expect(component.vm.inputType).toBe(type);
+            });
+        });
+
+    it('should return inputType text for type password if passwordAsText is true', () => {
+        const component: Wrapper<MTextfield> = mount(MTextfield, {
+            localVue: Vue,
+            propsData: { type: MTextfieldType.Password, passwordIcon: true, value: 'someValue' }
+        });
+
+        component.find('.m-textfield__icon-password').trigger('click');
+
+        expect(component.vm.inputType).toBe(MTextfieldType.Text);
     });
 });

--- a/src/components/textfield/textfield.spec.ts
+++ b/src/components/textfield/textfield.spec.ts
@@ -20,7 +20,7 @@ describe('MTextfield', () => {
         return expect(renderComponent(component.vm)).resolves.toMatchSnapshot();
     });
 
-    [MTextfieldType.EMail, MTextfieldType.Password, MTextfieldType.Telephone, MTextfieldType.Text, MTextfieldType.Url]
+    [MTextfieldType.Email, MTextfieldType.Password, MTextfieldType.Telephone, MTextfieldType.Text, MTextfieldType.Url]
         .forEach((type: MTextfieldType) => {
             it('should return inputType equal to type prop', () => {
                 const component: Wrapper<MTextfield> = mount(MTextfield, {

--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -75,14 +75,12 @@ export class MTextfield extends ModulVue implements InputManagementData {
     }
 
     protected mounted(): void {
-        (this.$refs.input as HTMLElement).setAttribute('type', this.inputType);
         this.as<InputManagement>().trimWordWrap = this.hasWordWrap;
     }
 
     @Watch('type')
     private typeChanged(type: MTextfieldType): void {
         this.$log.warn(TEXTFIELD_NAME + ': Change of property "type" is not supported');
-        (this.$refs.input as HTMLElement).setAttribute('type', this.inputType);
     }
 
     @Watch('inputType')
@@ -107,12 +105,6 @@ export class MTextfield extends ModulVue implements InputManagementData {
             this.type === MTextfieldType.Telephone) {
             type = this.type;
         }
-        this.$nextTick(() => {
-            let inputEl: HTMLElement = this.$refs.input as HTMLElement;
-            if (inputEl) {
-                inputEl.setAttribute('type', type);
-            }
-        });
         return type;
     }
 

--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -19,7 +19,7 @@ import WithRender from './textfield.html?style=./textfield.scss';
 export enum MTextfieldType {
     Text = 'text',
     Password = 'password',
-    EMail = 'email',
+    Email = 'email',
     Url = 'url',
     Telephone = 'tel'
 }
@@ -41,7 +41,7 @@ export class MTextfield extends ModulVue implements InputManagementData {
     @Prop({
         default: MTextfieldType.Text,
         validator: value =>
-            value === MTextfieldType.EMail ||
+            value === MTextfieldType.Email ||
             value === MTextfieldType.Password ||
             value === MTextfieldType.Telephone ||
             value === MTextfieldType.Text ||
@@ -101,7 +101,7 @@ export class MTextfield extends ModulVue implements InputManagementData {
         let type: MTextfieldType = MTextfieldType.Text;
         if (this.type === MTextfieldType.Password && this.passwordAsText) {
             type = MTextfieldType.Text;
-        } else if (this.type === MTextfieldType.Password || this.type === MTextfieldType.EMail || this.type === MTextfieldType.Url ||
+        } else if (this.type === MTextfieldType.Password || this.type === MTextfieldType.Email || this.type === MTextfieldType.Url ||
             this.type === MTextfieldType.Telephone) {
             type = this.type;
         }

--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -97,7 +97,7 @@ export class MTextfield extends ModulVue implements InputManagementData {
         this.passwordAsText = !this.passwordAsText;
     }
 
-    private get inputType(): MTextfieldType {
+    public get inputType(): MTextfieldType {
         let type: MTextfieldType = MTextfieldType.Text;
         if (this.type === MTextfieldType.Password && this.passwordAsText) {
             type = MTextfieldType.Text;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Fixed a weird case where we tried to set input style while the ref was not defined.  Moreover, reactivity should always be used instead of refs when possible.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-492
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
### Breaking changes
- Possible breaking change dans les tests qui n'utilisent pas le shallowMount => Avant l'attribut "type" n'était pas render dans le dom.  Maintenant il l'est.
- MTextfieldType.EMail a été renommé en MTextfieldType.Email

- [ ] Other info

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
