### PR TITLE
Fix incorrect word-break on rich-text in read mode

### DIFF
--- a/src/components/rich-text/rich-text.sandbox.html
+++ b/src/components/rich-text/rich-text.sandbox.html
@@ -5,4 +5,8 @@
     <div>
         <m-rich-text :value="model"></m-rich-text>
     </div>
+    <h5>word-break correctement</h5>
+    <div>
+        <m-rich-text :value="'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'"></m-rich-text>
+    </div>
 </div>

--- a/src/components/rich-text/rich-text.scss
+++ b/src/components/rich-text/rich-text.scss
@@ -2,6 +2,8 @@
 @import '../../styles/abstracts/var-froala';
 
 .m-rich-text {
+    word-break: break-word;
+
     & > :first-child {
         margin-top: 0 !important;
     }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
RTE reader text doesn't wrap
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-504
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
