### PR TITLE
MODUL-509 - Rafraichissement du RTE après le changement de la valeur du model

### DIFF
--- a/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -423,10 +423,6 @@ export enum FroalaStatus {
     }
 
     private setContent(firstTime: boolean = false): void {
-        if (!firstTime) {
-            return;
-        }
-
         if (this.model || this.model === '') {
             this.oldModel = this.model;
 

--- a/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -354,7 +354,7 @@ export enum FroalaStatus {
 
         this._$element = $(this.$refs.editor);
 
-        this.setContent(true);
+        this.setContent();
 
         this.registerEvents();
         if (this._$element.froalaEditor) {
@@ -422,7 +422,7 @@ export enum FroalaStatus {
         this.setContent();
     }
 
-    private setContent(firstTime: boolean = false): void {
+    private setContent(): void {
         if (this.model || this.model === '') {
             this.oldModel = this.model;
 

--- a/src/components/rich-text-editor/rich-text-editor.sandbox.html
+++ b/src/components/rich-text-editor/rich-text-editor.sandbox.html
@@ -142,4 +142,44 @@
             In orci lorem, consectetur sed hendrerit ac, sodales non leo. Fusce dolor sapien, faucibus vitae sapien vel, porta elementum nunc. Phasellus non nisi ac ligula pretium placerat nec a turpis. Mauris at orci magna. Praesent dictum purus quis metus vehicula placerat. Praesent eu pellentesque lorem. Integer et euismod nulla. Integer ex erat, tincidunt a sem a, blandit blandit leo. Curabitur nisi libero, molestie dapibus enim eget, imperdiet egestas ex.
         </p>
     </div>
+
+    <div>
+        <h5 class="m-u--margin-bottom">Réutilisation d'un RTE</h5>
+        <p>Si on change la valeur du model dans le JS, le changement est rapporté dans le RTE<p>
+        <div>
+            <h6>Current todo</h6>
+            <dl>
+                <dt>TODO :</dt>
+                <dd>
+                    <code>{{ currentTodo.todo }}</code>
+                </dd>
+                <dt>DONE : </dt>
+                <dd>
+                    <code>{{ currentTodo.done }}</code>
+                </dd>
+            </dl>
+        </div>
+
+        <ul v-if="todos.length > 0">
+            <li v-for="todo in todos">
+                {{ todo.todo }} is {{ (todo.done) ? "done" : "in progress" }}
+            </li>
+        </ul>
+
+        <div>
+                <m-rich-text-editor v-model="currentTodo.todo"
+                :toolbar-sticky-offset="58"
+                :label="'Todo'"
+                :max-width="'large'"
+                :focus="focus"
+                :error="error"
+                :error-message="errorMessage"
+                :valid-message="validMessage"
+                :helper-message="helperMessage"
+                :waiting="waiting"
+                :disabled="disabled"></m-rich-text-editor>
+                <br>
+                <button @click="addTodo">Add todo</button><input type="text" placeholder="Valeur à affecter au RTE lors de la réinitialisation" v-model="resetValue">
+        </div>
+    </div>
 </div>

--- a/src/components/rich-text-editor/rich-text-editor.sandbox.ts
+++ b/src/components/rich-text-editor/rich-text-editor.sandbox.ts
@@ -25,8 +25,17 @@ export class MRichTextEditorSandBox extends Vue {
     public linksOpenInNewWindowModel = '<p>Tests de la La case à cocher « Ouvrir dans un nouvel onglet ».</p><ol><li>Elle est <strong>sélectionnée par défaut&nbsp;</strong>à la création d&#39;un <strong>nouveau&nbsp;</strong>lien externe.</li><li>Elle est <strong>sélectionnée&nbsp;</strong>lors de la modification d&#39;un lien existant, si l&#39;utilisateur l&#39;a laissé sélectionnée à la création du <a href="http://google.ca" rel="noopener noreferrer" target="_blank">lien</a>.</li><li>Par contre, elle <strong>n&#39;est pas&nbsp;</strong><strong>sélectionnée&nbsp;</strong>lors de la modification d&#39;un lien existant, si l&#39;utilisateur l&#39;avait désélectionnée à la création du <a href="http://google.ca">lien</a>.</li></ol></div>';
     public inputFocusTestInputType = '';
 
+    public todos: {todo: string, done: boolean}[] = [];
+    public currentTodo: {todo: string, done: boolean} = { todo: '', done: false };
+    public resetValue: string = '';
+
     public alertTestSuccess(message: string): void {
         alert(message);
+    }
+
+    public addTodo(): void {
+        this.todos.push({ todo: this.currentTodo.todo, done: this.currentTodo.done });
+        this.currentTodo = { todo: this.resetValue, done: false };
     }
 }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Lors de la réutilisation d'un RTE pour la création de contenu, il est impossible de réinitialiser la valeur. Lorsque le champ récupère le focus, l'ancienne valeur du RTE est toujours présente.

Ce qui a été fait
* Possibilité de réinitialiser le contenu du RTE
* Ajout d'une démonstration dans le sandbox pour reproduire le bug / valider qu'il a été réglé

<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-509
<!-- Links here... -->
- [ ] Openshift deployment requested

