### PR TITLE
MODUL-514 - Rendre asynchrone les slots du composant m-template

### DIFF
--- a/src/components/template/template.html
+++ b/src/components/template/template.html
@@ -1,31 +1,38 @@
 <section class="m-template"
-         :class="{ 'm--has-column' : hasColumnSlot,
+         :class="{ 'm--has-column' : $slots.column,
                    'm--is-eq-max-s' : isEqMaxS,
                    'm--is-eq-max-m' : isEqMaxM }">
-    <header class="m-template__header-container" v-if="hasHeaderSlot">
+    <header class="m-template__header-container" v-if="$slots.header">
         <div class="m-template__header">
             <slot name="header"></slot>
         </div>
     </header>
-    <div class="m-template__wrap" v-if="hasDefaultSlot || hasColumnSlot || hasFooterSlot ">
-        <div class="m-template__main" v-if="hasDefaultSlot || (hasFooterSlot && !footerFullWidth)">
+    <div class="m-template__wrap"
+         v-if="$slots.default || $slots.subHeader || $slots.column || $slots.footer ">
+        <div class="m-template__main"
+             v-if="$slots.default || $slots.subHeader || ($slots.footer && !footerFullWidth)">
             <div class="m-template__main-content">
-                <div class="m-template__sub-header" v-if="hasSubHeaderSlot">
+                <div class="m-template__sub-header"
+                     v-if="$slots.subHeader">
                     <slot name="subHeader"></slot>
                 </div>
-                <div class="m-template__body" v-if="hasDefaultSlot">
+                <div class="m-template__body"
+                     v-if="$slots.default">
                     <slot></slot>
                 </div>
-                <footer class="m-template__body-footer" v-if="hasFooterSlot && !footerFullWidth">
+                <footer class="m-template__body-footer"
+                        v-if="$slots.footer && !footerFullWidth">
                     <slot name="footer"></slot>
                 </footer>
             </div>
         </div>
-        <aside class="m-template__column" v-if="hasColumnSlot">
+        <aside class="m-template__column"
+               v-if="$slots.column">
             <slot name="column"></slot>
         </aside>
     </div>
-    <footer class="m-template__body__footer" v-if="hasFooterSlot && footerFullWidth">
+    <footer class="m-template__body__footer"
+            v-if="$slots.footer && footerFullWidth">
         <slot name="footer"></slot>
     </footer>
 </section>

--- a/src/components/template/template.html
+++ b/src/components/template/template.html
@@ -17,6 +17,7 @@
                     <slot name="subHeader"></slot>
                 </div>
                 <div class="m-template__body"
+                     :class="{ 'm--no-padding': !paddingBody }"
                      v-if="$slots.default">
                     <slot></slot>
                 </div>

--- a/src/components/template/template.sandbox.html
+++ b/src/components/template/template.sandbox.html
@@ -1,13 +1,11 @@
 <div>
     <!-- Sandbox template -->
-    <h3>Test Title</h3>
-    <p class="m-u--margin-bottom">
-        Test description
-        <!-- if relevant, add link to PR
-        </br>From <a href="https://github.com/ulaval/modul-components/pull/000" target="blank">PR description</a>
-        -->
-    </p>
-    <p>
-        <m-template><!-- Test case --></m-template>
-    </p>
+    <h2>Apparition asynchrone de l'entete</h2>
+    <m-template class="m-u--margin-top">
+        <h2 slot="header" v-if="hasEntete">Entete</h2>
+        <p slot="subHeader">Slot subHeader</p>
+        <p>Corps</p>
+        <div slot="column">Colonne</div>
+        <div slot="footer">Footer</div>
+    </m-template>
 </div>

--- a/src/components/template/template.sandbox.ts
+++ b/src/components/template/template.sandbox.ts
@@ -7,6 +7,13 @@ import WithRender from './template.sandbox.html';
 @WithRender
 @Component
 export class MTemplateSandbox extends Vue {
+    private hasEntete: boolean = false;
+
+    mounted(): void {
+        setTimeout(() => {
+            this.hasEntete = true;
+        }, 2000);
+    }
 }
 
 const TemplateSandboxPlugin: PluginObject<any> = {

--- a/src/components/template/template.scss
+++ b/src/components/template/template.scss
@@ -118,19 +118,7 @@ $m-template--column-color: $m-color--grey-light;
     }
 }
 
-@media (max-width: $m-mq--max--xs) {
-    .m-template {
-        &__header,
-        &__body,
-        &__column {
-            &:not(.m--no-padding) {
-                padding: $m-padding $m-padding--s;
-            }
-        }
-    }
-}
-
-@media (min-width: $m-mq--min--xs) and (max-width: $m-mq--max--s) {
+@media (max-width: $m-mq--max--s) {
     .m-template {
         &__header,
         &__body,
@@ -152,7 +140,9 @@ $m-template--column-color: $m-color--grey-light;
         }
 
         &__header {
-            padding: $m-margin--l $m-padding--l;
+            &:not(.m--no-padding) {
+                padding: $m-margin--l $m-padding--l;
+            }
         }
     }
 }

--- a/src/components/template/template.scss
+++ b/src/components/template/template.scss
@@ -123,7 +123,9 @@ $m-template--column-color: $m-color--grey-light;
         &__header,
         &__body,
         &__column {
-            padding: $m-padding $m-padding--s;
+            &:not(.m--no-padding) {
+                padding: $m-padding $m-padding--s;
+            }
         }
     }
 }
@@ -133,7 +135,9 @@ $m-template--column-color: $m-color--grey-light;
         &__header,
         &__body,
         &__column {
-            padding: $m-padding;
+            &:not(.m--no-padding) {
+                padding: $m-padding;
+            }
         }
     }
 }
@@ -142,7 +146,9 @@ $m-template--column-color: $m-color--grey-light;
     .m-template {
         &__body,
         &__column {
-            padding: $m-padding--l;
+            &:not(.m--no-padding) {
+                padding: $m-padding--l;
+            }
         }
 
         &__header {

--- a/src/components/template/template.scss
+++ b/src/components/template/template.scss
@@ -116,12 +116,6 @@ $m-template--column-color: $m-color--grey-light;
             flex: 0 0 $m-template--column-width;
         }
     }
-
-    &:not(.m--is-eq-max-s) {
-        .m-template__column {
-            max-width: $m-template--column-width;
-        }
-    }
 }
 
 @media (max-width: $m-mq--max--xs) {

--- a/src/components/template/template.ts
+++ b/src/components/template/template.ts
@@ -13,6 +13,8 @@ import WithRender from './template.html?style=./template.scss';
 export class MTemplate extends Vue {
     @Prop()
     public footerFullWidth: boolean;
+    @Prop({ default: true })
+    public paddingBody: boolean;
 }
 
 const TemplatePlugin: PluginObject<any> = {

--- a/src/components/template/template.ts
+++ b/src/components/template/template.ts
@@ -13,26 +13,6 @@ import WithRender from './template.html?style=./template.scss';
 export class MTemplate extends Vue {
     @Prop()
     public footerFullWidth: boolean;
-
-    private get hasHeaderSlot(): boolean {
-        return !!this.$slots.header;
-    }
-
-    private get hasSubHeaderSlot(): boolean {
-        return !!this.$slots.subHeader;
-    }
-
-    private get hasDefaultSlot(): boolean {
-        return !!this.$slots.default;
-    }
-
-    private get hasColumnSlot(): boolean {
-        return !!this.$slots.column;
-    }
-
-    private get hasFooterSlot(): boolean {
-        return !!this.$slots.footer;
-    }
 }
 
 const TemplatePlugin: PluginObject<any> = {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Lorsque le composant m-template est utilisé, il est impossible d'utiliser un v-if sur les slots.
Pour régler le problème, utiliser le $slots directement dans le template.

Ajouter la prop paddingBody: boolean

<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-514
https://jira.dti.ulaval.ca/browse/AEL-294

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
