### PR TITLE
Added global parameters to i18n Message class

### DIFF
--- a/src/utils/i18n/i18n.spec.lang.fr.json
+++ b/src/utils/i18n/i18n.spec.lang.fr.json
@@ -18,7 +18,5 @@
     "exemples_avec_parametres_globaux": {
         "decompte_medailles_olympiques_canada": "Les athlètes canadiens ont gagnés %(nbMedailles)s%(espace_insecable__global)smedaille.",
         "decompte_medailles_olympiques_canada_default_formatting": "Les athlètes canadiens ont gagnés {0} medaille.",
-
-        "decompte_medailles_olympiques_canada.p": "Les athlètes canadiens ont gagnés %(nbMedailles)%(espace_insecable.global)medailles."
     }
 }

--- a/src/utils/i18n/i18n.spec.lang.fr.json
+++ b/src/utils/i18n/i18n.spec.lang.fr.json
@@ -14,5 +14,11 @@
         "decompte_athletes_olympiques_canada.p": "Il y a %(nbAthletes)s athlètes olympiques canadiens.",
         "decompte_athletes_olympiques_pays": "Il y a %(nbAthletes)s athlètes olympiques et %(nbPays)s pays participants.",
         "decompte_athletes_olympiques_pays_default_formatting": "Il y a {0} athlètes olympiques et {1} pays participants."
+    },
+    "exemples_avec_parametres_globaux": {
+        "decompte_medailles_olympiques_canada": "Les athlètes canadiens ont gagnés %(nbMedailles)s%(espace_insecable__global)smedaille.",
+        "decompte_medailles_olympiques_canada_default_formatting": "Les athlètes canadiens ont gagnés {0} medaille.",
+
+        "decompte_medailles_olympiques_canada.p": "Les athlètes canadiens ont gagnés %(nbMedailles)%(espace_insecable.global)medailles."
     }
 }

--- a/src/utils/i18n/i18n.spec.lang.fr.json
+++ b/src/utils/i18n/i18n.spec.lang.fr.json
@@ -17,6 +17,6 @@
     },
     "exemples_avec_parametres_globaux": {
         "decompte_medailles_olympiques_canada": "Les athlètes canadiens ont gagnés %(nbMedailles)s%(espace_insecable__global)smedaille.",
-        "decompte_medailles_olympiques_canada_default_formatting": "Les athlètes canadiens ont gagnés {0} medaille.",
+        "decompte_medailles_olympiques_canada_default_formatting": "Les athlètes canadiens ont gagnés {0} medaille."
     }
 }

--- a/src/utils/i18n/i18n.spec.ts
+++ b/src/utils/i18n/i18n.spec.ts
@@ -1,7 +1,8 @@
 import Vue from 'vue';
-import I18nPlugin, { Messages, ENGLISH, I18nPluginOptions, FormatMode } from './i18n';
+
 import { resetModulPlugins } from '../../../tests/helpers/component';
 import { addMessages } from '../../../tests/helpers/lang';
+import I18nPlugin, { ENGLISH, FormatMode, I18nPluginOptions, Messages } from './i18n';
 
 describe('i18n plugin', () => {
     describe('when not installed', () => {
@@ -89,6 +90,59 @@ describe('i18n plugin', () => {
         });
         it(`calling translate with params modifier should return the string with the params applied`, () => {
             expect(Vue.prototype.$i18n.translate('exemples_avec_parametres:decompte_athletes_olympiques_pays', { nbAthletes: 2925, nbPays: 93 })).toEqual('Il y a 2925 athlètes olympiques et 93 pays participants.');
+        });
+    });
+
+    describe('with global variables en mode Vsprintf', () => {
+        beforeEach(() => {
+            let options: I18nPluginOptions = {
+                formatMode: FormatMode.Vsprintf,
+                globalParams: { espace_insecable : '__ESPACE_INSECABLE__' } // use in place of "\xa0" to be able to validate the result
+            };
+
+            resetModulPlugins();
+            Vue.use(I18nPlugin, options);
+            addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
+        });
+        it(`will replace global variables`, () => {
+            expect(Vue.prototype.$i18n.translate('exemples_avec_parametres_globaux:decompte_medailles_olympiques_canada', { nbMedailles: 1 })).toEqual('Les athlètes canadiens ont gagnés 1__ESPACE_INSECABLE__medaille.');
+        });
+        it(`will allow messages without global variables`, () => {
+            expect(Vue.prototype.$i18n.translate('exemples_avec_parametres:decompte_athletes_olympiques_pays', { nbAthletes: 2925, nbPays: 93 })).toEqual('Il y a 2925 athlètes olympiques et 93 pays participants.');
+        });
+    });
+
+    describe('with global variables en mode sprintf', () => {
+        beforeEach(() => {
+            let options: I18nPluginOptions = {
+                formatMode: FormatMode.Sprintf,
+                globalParams: { espace_insecable : '__ESPACE_INSECABLE__' } // use in place of "\xa0" to be able to validate the result
+            };
+
+            resetModulPlugins();
+            Vue.use(I18nPlugin, options);
+            addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
+        });
+        it(`will replace global variables`, () => {
+            expect(Vue.prototype.$i18n.translate('exemples_avec_parametres_globaux:decompte_medailles_olympiques_canada', { nbMedailles: 1 })).toEqual('Les athlètes canadiens ont gagnés 1__ESPACE_INSECABLE__medaille.');
+        });
+        it(`will allow messages without global variables`, () => {
+            expect(Vue.prototype.$i18n.translate('exemples_avec_parametres:decompte_athletes_olympiques_pays', { nbAthletes: 2925, nbPays: 93 })).toEqual('Il y a 2925 athlètes olympiques et 93 pays participants.');
+        });
+    });
+
+    describe('with global variables en mode sprintf', () => {
+        beforeEach(() => {
+            let options: I18nPluginOptions = {
+                globalParams: { espace_insecable : '__ESPACE_INSECABLE__' } // use in place of "\xa0" to be able to validate the result
+            };
+
+            resetModulPlugins();
+            Vue.use(I18nPlugin, options);
+            addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
+        });
+        it(`will not use global variables`, () => {
+            expect(Vue.prototype.$i18n.translate('exemples_avec_parametres_globaux:decompte_medailles_olympiques_canada_default_formatting', [1])).toEqual('Les athlètes canadiens ont gagnés 1 medaille.');
         });
     });
 

--- a/src/utils/i18n/i18n.spec.ts
+++ b/src/utils/i18n/i18n.spec.ts
@@ -93,7 +93,7 @@ describe('i18n plugin', () => {
         });
     });
 
-    describe('with global variables en mode Vsprintf', () => {
+    describe('with global variables in mode Vsprintf', () => {
         beforeEach(() => {
             let options: I18nPluginOptions = {
                 formatMode: FormatMode.Vsprintf,
@@ -112,7 +112,7 @@ describe('i18n plugin', () => {
         });
     });
 
-    describe('with global variables en mode sprintf', () => {
+    describe('with global variables in mode sprintf', () => {
         beforeEach(() => {
             let options: I18nPluginOptions = {
                 formatMode: FormatMode.Sprintf,
@@ -131,7 +131,7 @@ describe('i18n plugin', () => {
         });
     });
 
-    describe('with global variables en mode sprintf', () => {
+    describe('with global variables in default mode', () => {
         beforeEach(() => {
             let options: I18nPluginOptions = {
                 globalParams: { espace_insecable : '__ESPACE_INSECABLE__' } // use in place of "\xa0" to be able to validate the result

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -29,7 +29,7 @@ const GLOBAL_SEPARATOR: string = '__';
 /**
  * Default suffixe used for global parameters
  */
-const GLOBAL_SUFFIXE_DEFAULT = 'global';
+const GLOBAL_SUFFIXE_DEFAULT: string = 'global';
 
 export type MessageMap = {
     [key: string]: string;

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -143,9 +143,7 @@ export class Messages {
 
         let val: string = this.resolveKey(this.curLang, key, nb, modifier);
 
-        if (this.globalParams
-            && (this.formatMode === FormatMode.Sprintf || this.formatMode === FormatMode.Vsprintf)
-        ) {
+        if (this.globalParams && (this.formatMode === (FormatMode.Sprintf || FormatMode.Vsprintf))) {
             params = Object.assign(this.globalParams, params);
         }
 

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -143,7 +143,8 @@ export class Messages {
 
         let val: string = this.resolveKey(this.curLang, key, nb, modifier);
 
-        if (this.globalParams && (this.formatMode === (FormatMode.Sprintf || FormatMode.Vsprintf))) {
+        if (this.globalParams && (this.formatMode === FormatMode.Sprintf || this.formatMode === FormatMode.Vsprintf)
+        ) {
             params = Object.assign(this.globalParams, params);
         }
 

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -155,7 +155,7 @@ export class Messages {
             }
         }
 
-        val = this.format(val, params, this.formatMode);
+        val = this.format(val, params);
 
         return val;
     }
@@ -165,8 +165,8 @@ export class Messages {
      * @param {string} val the string to format
      * @param {any[]} params the values to insert in string
      */
-    private format(val: string, params: any, formatMode: FormatMode = FormatMode.Default): string {
-        switch (formatMode) {
+    private format(val: string, params: any): string {
+        switch (this.formatMode) {
             case FormatMode.Vsprintf:
                 return vsprintf(val, params);
             case FormatMode.Sprintf:


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Permettre la configuration de chaines de traductions globale pour la classe de Message d'i18n.

Cas d'utilisation ayant mené à cette amélioration:
Possibilité de formatter une chaine de caractère avec des espaces insécable et rendre ce formattage plus explicite dans les fichiers de traduction.

Actuellement dans les fichiers de traduction, un espace insécable est représenté comme:
    `%(date)s à %(time)s`

La proposition de changement:
    `%(date)s à%(espace_insecable__global)s%(time)s`

Le parametre `espace_insecable__global` est configuré à l'initialisation de l'objet

Deux nouveau paramètres ont été ajoutés pour permettre cette configuration:
* globalParams -> Map `{[key: string] : string}`
* globalParamsSuffixe -> :string

Cet ajout fonctionne pour les modes de formattage `sprintf` et `vsprintf`. Les paramètres globaux sont ignorés pour le mode par défaut. 

<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-523
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->