### PR TITLE
MODUL-490 - Transparent tap on modal

### DIFF
--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -42,6 +42,7 @@ $m-modal--max-width--s: 420px !default;
 
         &.m--is-close-on-backdrop {
             cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
         }
 
         &.m--is-enter-active,


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Transparent tap on modal instead of a blue tap.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-490
- [ ] Openshift deployment requested

- [x] Other info
This modification had already been merged in https://github.com/ulaval/modul-components/pull/498
but it seems it had been partially removed during the renaming of dialog and modal.


