### PR TITLE
MODUL-539: Il manque une bordure dans le navbar (skin:tab-light) lorsqu'il y a seulement un item

### DIFF
--- a/src/components/navbar-item/navbar-item.scss
+++ b/src/components/navbar-item/navbar-item.scss
@@ -504,27 +504,19 @@
                 background: $m-color--white;
             }
 
-            &:first-child,
-            &:last-child {
-                &::after {
-                    position: absolute;
-                    top: $m-border-width--l;
-                    bottom: 0;
-                    content: '';
-                    width: $m-border-width--s;
-                    background: $m-color--grey-light;
-                }
-            }
-
             &:first-child {
-                &::after {
-                    left: 0;
+                border-left: 1px solid $m-color--grey-light;
+
+                .m-navbar-item__contents::before {
+                    left: -1px;
                 }
             }
 
             &:last-child {
-                &::after {
-                    right: 0;
+                border-right: 1px solid $m-color--grey-light;
+
+                .m-navbar-item__contents::before {
+                    right: -1px;
                 }
             }
         }

--- a/src/components/navbar/navbar.sandbox.html
+++ b/src/components/navbar/navbar.sandbox.html
@@ -128,10 +128,20 @@
     </m-navbar>
 
     <h3>Skin tab-light</h3>
+    <h4>Skin tab-light : un seul onglet</h4>
+    <br>From <a href="https://github.com/ulaval/modul-components/pull/539" target="blank">PR 539</a>
     <m-navbar skin="tab-light" :selected.sync="selectedItem" :multiline="multiline" title-button-left="Naviguer précédent" title-button-right="Naviguer suivant">
         <m-navbar-item value="item1">
             1 souris verte
         </m-navbar-item>
+    </m-navbar>
+
+    <h4>Skin tab-light : plusieurs onglets</h4>
+    <m-navbar skin="tab-light" :selected.sync="selectedItem" :multiline="multiline" title-button-left="Naviguer précédent" title-button-right="Naviguer suivant">
+        <m-navbar-item value="item1">
+            1 souris verte
+        </m-navbar-item>
+
         <m-navbar-item value="item2">
             2
         </m-navbar-item>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Il manque une bordure dans le navbar (skin:tab-light) lorsqu'il y a seulement un item.
Voir l'image du billet (https://jira.dti.ulaval.ca/browse/MODUL-539)
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-539
https://jira.dti.ulaval.ca/browse/AEL-303
<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
