### PR TITLE
Autoselect router-active tab when it exists on mounted

### DIFF
--- a/src/components/navbar-item/navbar-item-helper.ts
+++ b/src/components/navbar-item/navbar-item-helper.ts
@@ -1,0 +1,8 @@
+import { MNavbarItem } from './navbar-item';
+export class NavbarItemHelper {
+    isRouterLinkActive(navbarItem: MNavbarItem): boolean {
+        return !!navbarItem.$el.querySelector('.router-link-active');
+    }
+}
+
+export default new NavbarItemHelper();

--- a/src/components/navbar-item/navbar-item.html
+++ b/src/components/navbar-item/navbar-item.html
@@ -5,7 +5,7 @@
     <router-link class="m-navbar-item__contents"
                  ref="item"
                  :to="url" v-if="url && !disabled"
-                 @click="onClick"
+                 @click.native="onClick"
                  @keyup.enter="onClick"
                  @mouseover="onMouseover"
                  @mouseleave="onMouseleave"

--- a/src/components/navbar-item/navbar-item.spec.ts
+++ b/src/components/navbar-item/navbar-item.spec.ts
@@ -1,18 +1,43 @@
-import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import { createLocalVue, mount, Wrapper, shallow } from '@vue/test-utils';
 import Vue, { VueConstructor } from 'vue';
 
 import { renderComponent } from '../../../tests/helpers/render';
 import ModulPlugin from '../../utils/modul/modul';
 import NavbarItemPlugin, { MNavbarItem } from './navbar-item';
+import { MNavbar } from '../navbar/navbar';
+import NavbarItemHelper from './navbar-item-helper';
+let mockIsRouterLinkActive: boolean = false;
+
+jest.mock('./navbar-item-helper', () => ({
+    isRouterLinkActive: jest.fn(() => mockIsRouterLinkActive)
+}));
 
 describe('MNavbarItem', () => {
+    let wrapper: Wrapper<MNavbarItem>;
+    let parentNavbar: Wrapper<MNavbar>;
     let localVue: VueConstructor<Vue>;
-
     beforeEach(() => {
+        mockIsRouterLinkActive = false;
         Vue.use(ModulPlugin);
         localVue = createLocalVue();
         localVue.use(NavbarItemPlugin);
+        parentNavbar = shallow(MNavbar);
     });
+
+    const initializeWrapper: (initialPropValues: any)
+    => Wrapper<MNavbarItem> = (initialPropValues: any = {}) => {
+        document.querySelector = () => true;
+        wrapper = shallow(MNavbarItem, {
+            methods: {
+                getParent(): MNavbar {
+                    return parentNavbar.vm;
+                }
+            },
+            propsData: initialPropValues
+        });
+
+        return wrapper;
+    };
 
     const defaultSlot: any = {
         default: `navbar item content`
@@ -37,5 +62,64 @@ describe('MNavbarItem', () => {
         });
         expect(wrapper.classes()).toContain('m--is-disabled');
         expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
+    });
+
+    describe('given parent Navbar has autoselect set to true', () => {
+        beforeEach(() => {
+            parentNavbar = shallow(MNavbar);
+            parentNavbar.setProps({ autoSelect: true });
+            parentNavbar.vm.updateValue = jest.fn();
+        });
+
+        it('should set parentNavbar value if current item is router-link-active', () => {
+            mockIsRouterLinkActive = true;
+            jest.spyOn(parentNavbar.vm, 'updateValue');
+            jest.spyOn(NavbarItemHelper, 'isRouterLinkActive');
+
+            initializeWrapper({ value: 'someValue' });
+
+            expect(NavbarItemHelper.isRouterLinkActive).toHaveBeenCalledWith(wrapper.vm);
+            expect(parentNavbar.vm.updateValue).toHaveBeenCalledWith('someValue');
+        });
+
+        it('should not set parentNavbar value if current item is not router-link-active', () => {
+            mockIsRouterLinkActive = false;
+            jest.spyOn(parentNavbar.vm, 'updateValue');
+            jest.spyOn(NavbarItemHelper, 'isRouterLinkActive');
+
+            initializeWrapper({ value: 'someValue' });
+
+            expect(NavbarItemHelper.isRouterLinkActive).toHaveBeenCalledWith(wrapper.vm);
+            expect(parentNavbar.vm.updateValue).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('given parent Navbar has autoselect set to false', () => {
+        beforeEach(() => {
+            parentNavbar = shallow(MNavbar);
+            parentNavbar.setProps({ autoSelect: false });
+        });
+
+        it('should not set parentNavbar value if current item is router-link-active', () => {
+            mockIsRouterLinkActive = true;
+            jest.spyOn(parentNavbar.vm, 'updateValue');
+            jest.spyOn(NavbarItemHelper, 'isRouterLinkActive');
+
+            initializeWrapper({ value: 'someValue' });
+
+            expect(NavbarItemHelper.isRouterLinkActive).not.toHaveBeenCalledWith(wrapper.vm);
+            expect(parentNavbar.vm.updateValue).not.toHaveBeenCalled();
+        });
+
+        it('should not set parentNavbar value if current item is not router-link-active', () => {
+            mockIsRouterLinkActive = false;
+            jest.spyOn(parentNavbar.vm, 'updateValue');
+            jest.spyOn(NavbarItemHelper, 'isRouterLinkActive');
+
+            initializeWrapper({ value: 'someValue' });
+
+            expect(NavbarItemHelper.isRouterLinkActive).not.toHaveBeenCalledWith(wrapper.vm);
+            expect(parentNavbar.vm.updateValue).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/components/navbar-item/navbar-item.ts
+++ b/src/components/navbar-item/navbar-item.ts
@@ -6,6 +6,7 @@ import { ModulVue } from '../../utils/vue/vue';
 import { NAVBAR_ITEM_NAME } from '../component-names';
 import { BaseNavbar, Navbar } from '../navbar/navbar';
 import WithRender from './navbar-item.html?style=./navbar-item.scss';
+import NavbarItemHelper from './navbar-item-helper';
 
 // must be sync with selected css class
 const FAKE_SELECTED_CLASS: string = 'm--is-fake-selected';
@@ -42,7 +43,7 @@ export class MNavbarItem extends ModulVue {
             this.parentNavbar = (parentNavbar as any) as Navbar;
             this.setDimension();
 
-            if (this.parentNavbar.autoSelect && this.$el.querySelector('.router-link-active')) {
+            if (this.parentNavbar.autoSelect && NavbarItemHelper.isRouterLinkActive(this)) {
                 this.parentNavbar.updateValue(this.value);
             }
         } else {

--- a/src/components/navbar-item/navbar-item.ts
+++ b/src/components/navbar-item/navbar-item.ts
@@ -42,6 +42,9 @@ export class MNavbarItem extends ModulVue {
             this.parentNavbar = (parentNavbar as any) as Navbar;
             this.setDimension();
 
+            if (this.parentNavbar.autoSelect && this.$el.querySelector('.router-link-active')) {
+                this.parentNavbar.updateValue(this.value);
+            }
         } else {
             console.error('m-navbar-item need to be inside m-navbar');
         }

--- a/src/components/navbar/navbar.ts
+++ b/src/components/navbar/navbar.ts
@@ -147,6 +147,9 @@ export class MNavbar extends BaseNavbar implements Navbar {
     @Watch('multiline')
     private multilineChanged(): void {
         // Wait for navbar-item height calculation -> setimension()
+        setTimeout(() => {
+            this.setupScrolllH();
+        });
     }
 
     private setDisplayButtonArrrow(): void {

--- a/src/components/navbar/navbar.ts
+++ b/src/components/navbar/navbar.ts
@@ -218,7 +218,7 @@ export class MNavbar extends BaseNavbar implements Navbar {
             // Allow time to make sure an item is selected
             setTimeout(() => {
                 let wrapEl: HTMLElement = this.$refs.wrap;
-                if (element && element.$props.value === this.selected && wrapEl) {
+                if (element && element.$props.value === this.model && wrapEl) {
                     let buttonLeftWidth: number = this.$refs.buttonLeft && this.hasArrowLeft ? this.$refs.buttonLeft.clientWidth : 0;
                     let buttonRightWidth: number = this.$refs.buttonRight && this.hasArrowRight ? this.$refs.buttonRight.clientWidth : 0;
                     let scrollPositionAlignLeft: number = element.$el.offsetLeft - buttonLeftWidth;

--- a/src/components/navbar/navbar.ts
+++ b/src/components/navbar/navbar.ts
@@ -15,6 +15,7 @@ export abstract class BaseNavbar extends ModulVue { }
 export interface Navbar {
     model: string;
     multiline: boolean;
+    autoSelect: boolean;
     updateValue(value: string): void;
     onMouseover(event: Event, value: string): void;
     onMouseleave(event: Event, value: string): void;
@@ -81,6 +82,8 @@ export class MNavbar extends BaseNavbar implements Navbar {
     public titleButtonLeft: string;
     @Prop()
     public titleButtonRight: string;
+    @Prop({ default: false })
+    public autoSelect: boolean;
 
     public $refs: {
         buttonRight: HTMLElement,
@@ -144,9 +147,6 @@ export class MNavbar extends BaseNavbar implements Navbar {
     @Watch('multiline')
     private multilineChanged(): void {
         // Wait for navbar-item height calculation -> setimension()
-        setTimeout(() => {
-            this.setupScrolllH();
-        });
     }
 
     private setDisplayButtonArrrow(): void {

--- a/src/components/navbar/navbar.ts
+++ b/src/components/navbar/navbar.ts
@@ -217,10 +217,10 @@ export class MNavbar extends BaseNavbar implements Navbar {
         this.navbarItems().elements.forEach(element => {
             // Allow time to make sure an item is selected
             setTimeout(() => {
-                if (element && element.$props.value === this.selected) {
+                let wrapEl: HTMLElement = this.$refs.wrap;
+                if (element && element.$props.value === this.selected && wrapEl) {
                     let buttonLeftWidth: number = this.$refs.buttonLeft && this.hasArrowLeft ? this.$refs.buttonLeft.clientWidth : 0;
                     let buttonRightWidth: number = this.$refs.buttonRight && this.hasArrowRight ? this.$refs.buttonRight.clientWidth : 0;
-                    let wrapEl: HTMLElement = this.$refs.wrap;
                     let scrollPositionAlignLeft: number = element.$el.offsetLeft - buttonLeftWidth;
 
                     // Check if selected element is visible in navbar


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
1- Je sais pas pourquoi on y a été avec une propriété "selected" dans le navbar au lieu d'utiliser le truc built-in de vue-router 
https://router.vuejs.org/api/#linkactiveclass

2- Considérant qu'on a pas utilisé le comportement de built-in de vue, c'est vraiment chiant d'avoir à gérer le tab actif quand on travail avec le router.  Sans vouloir tout remanier, je propose la modif suivante qui, sur le mounted, va aller chercher si le linkactiveclass est contenue dans un navbar-item.. si c'est le cas j'initialise le selected avec cette valeur.

3- J'avais peur de créer des régressions, j'ai donc mis un guard sous la forme d'une prop que j'ai appellé autoselect.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-546
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
