### PR TITLE
MODUL-545: Ajouter l'icône not-allowed au textfield et l'icône chevron--right au datepicker	

### DIFF
--- a/src/assets/icons/sprites-default.svg
+++ b/src/assets/icons/sprites-default.svg
@@ -681,6 +681,10 @@
             c-0.2,0.2-0.5,0.2-0.7,0L19,11.3V17v0.1v0.1c0,1.2-1.2,2.2-2.7,2.2s-2.7-1-2.7-2.2s1.2-2.2,2.7-2.2c0.7,0,1.3,0.2,1.7,0.5V10
             c0-0.2,0.1-0.4,0.3-0.5c0.2-0.1,0.4,0,0.5,0.1l2.5,2.5C21.5,12.3,21.5,12.7,21.3,12.9z"/>
     </symbol>
+    <symbol id="m-svg__not-allowed" viewBox="-1 -1 26 26">
+        <circle fill="none" stroke="currentColor" stroke-miterlimit="10" cx="12" cy="12" r="11.5"/>
+        <line fill="none" stroke="currentColor" stroke-miterlimit="10" x1="3.9" y1="3.9" x2="20.1" y2="20.1"/>
+    </symbol>
     <symbol id="m-svg__notification" viewBox="-1 -1 26 26">
         <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M21.1,18.7v1.7H2.9
             v-1.7l2-1.8V9.7c0-3.2,2.2-6,5.2-6.8c0-0.2-0.1-0.4-0.1-0.5c0-1.1,0.9-1.9,1.9-1.9c1.1,0,1.9,0.9,1.9,1.9c0,0.2,0,0.4-0.1,0.5

--- a/src/components/datepicker/datepicker.html
+++ b/src/components/datepicker/datepicker.html
@@ -57,12 +57,12 @@
             <nav class="m-datepicker__header__nav">
                 <m-icon-button icon-name="m-svg__chevron--left" @click="selectYear(selectedYear - 1)" :disabled="isMinYear">previous year</m-icon-button>
                 <button type="button" class="m-datepicker__years" @click="showYears" aria-live="polite">{{selectedYear}}</button>
-                <m-icon-button icon-name="m-svg__chevron" @click="selectYear(selectedYear + 1)" :disabled="isMaxYear">next year</m-icon-button>
+                <m-icon-button icon-name="m-svg__chevron--right" @click="selectYear(selectedYear + 1)" :disabled="isMaxYear">next year</m-icon-button>
             </nav>
             <nav class="m-datepicker__header__nav">
                 <m-icon-button icon-name="m-svg__chevron--left" @click="selectMonth(selectedMonth - 1)" :disabled="isMinMonth">previous month</m-icon-button>
                 <button type="button" class="m-datepicker__months" @click="view = 'month'" aria-live="polite">{{ selectedMonthName }}</button>
-                <m-icon-button icon-name="m-svg__chevron" @click="selectMonth(selectedMonth + 1)" :disabled="isMaxMonth">next month</m-icon-button>
+                <m-icon-button icon-name="m-svg__chevron--right" @click="selectMonth(selectedMonth + 1)" :disabled="isMaxMonth">next month</m-icon-button>
             </nav>
         </div>
         <div :id="ariaControls2" class="m-datepicker__body" ref="body" :aria-labelledby="id" aria-live="polite">

--- a/src/components/input-style/input-style.html
+++ b/src/components/input-style/input-style.html
@@ -26,6 +26,6 @@
             <slot name="right-content"></slot>
         </div>
         <m-spinner size="small" class="m-input-style__spinner" v-if="isWaiting"></m-spinner>
-        <m-icon class="m-input-style__disabled-icon" name="m-svg__close-clear" v-if="isDisabled"></m-icon>
+        <m-icon class="m-input-style__disabled-icon" name="m-svg__not-allowed" v-if="isDisabled"></m-icon>
     </div>
 </div>

--- a/tests/app/app-frame/app-frame.html
+++ b/tests/app/app-frame/app-frame.html
@@ -1,13 +1,12 @@
-<div>
-    <header class="m-test__header m-u--box-shadow--s">
-        <h1 class="m-u--h4 m-u--no-margin-top">
-            <span>MOD<span class="m-test__title">UL</span> - Components</span>
-            <span class="m-u--font-size--s m-u--no-margin-top">
-                <m-link mode="link" target="_blank" url="https://ulaval.github.io/modul/">Documentation</m-link>
-            </span>
+<m-flex-template>
+    <div class="m-app-frame__header m-u--box-shadow--s" slot="header">
+        <h1 class="m-app-frame__titre">
+            <span class="m-app-frame__logo">Mod<b class="m-app-frame__logo-gras">ul</b></span>
+            <span class="m-app-frame__sous-titre">Components</span>
         </h1>
-    </header>
-    <main class="m-test__content">
+        <m-link class="m-u--font-size--s m-u--margin-left" mode="link" target="_blank" url="https://ulaval.github.io/modul/">Documentation</m-link>
+    </div>
+    <main class="m-app-frame__content">
         <router-view></router-view>
     </main>
-</div>
+</m-flex-template>

--- a/tests/app/app-frame/app-frame.scss
+++ b/tests/app/app-frame/app-frame.scss
@@ -1,32 +1,48 @@
 @import '../../../src/styles/abstracts/variables';
 
-.m-test {
+.m-app-frame {
     &__header {
-        position: fixed;
-        top: 0;
-        right: 0;
-        left: 0;
-        z-index: 2;
-        padding: 16px 32px;
-        background: #fff;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: $m-color--white;
+        padding: $m-spacing;
+        min-width: $m-min-width;
 
-        @media (max-width: $m-mq--max--s) {
-            padding: 16px;
+        @media (min-width: $m-mq--min--s) {
+            padding: $m-spacing $m-spacing--l;
         }
+    }
 
-        h1 {
-            display: flex;
-            justify-content: space-between;
+    &__titre {
+        display: flex;
+        flex-direction: column;
+        font-size: $m-font-size--h4;
+
+        @media (min-width: $m-mq--min--s) {
+            flex-direction: row;
             align-items: center;
         }
     }
 
-    &__title {
-        font-weight: 800;
+    &__logo {
+        text-transform: uppercase;
     }
 
-    &__content {
-        margin-top: 46px;
+    &__logo-gras {
+        font-weight: $m-font-weight--black;
+    }
+
+    &__sous-titre {
+        font-size: $m-font-size--s;
+
+        @media (min-width: $m-mq--min--s) {
+            margin-left: $m-spacing--s;
+
+            &::before {
+                content: '-';
+                margin-right: $m-spacing--s;
+            }
+        }
     }
 }
-

--- a/tests/app/attributes/attributes.html
+++ b/tests/app/attributes/attributes.html
@@ -1,36 +1,34 @@
-<m-flex-template padding-top="52px">
-    <m-template>
-        <div slot="header">
-            <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Menu</m-link>
-            <h1>Attributes list</h1>
-        </div>
-        <h2>Attributes by component</h2>
-        <ul class="m-u--margin-top m-u--bullet-list">
-            <li v-for="meta in allMeta">
-                {{meta.tag}}
-                <ul>
-                    <li v-for="attribute in getAttributes(meta)">
-                        <span>
-                    {{attribute}}: <span style="color: blue">{{meta.attributes[attribute].type}}</span>
-                        </span>
-                        <span v-for="(value, index) in meta.attributes[attribute].values" style="margin-left: 8px">
-                        <i v-if="meta.attributes[attribute].default === index" style="font-weight:400">{{value}}</i>
-                        <span v-else>{{value}}</span>
-                        </span>
-                    </li>
-                </ul>
-            </li>
-        </ul>
-        <h2>Components by attribute</h2>
-        <ul class="m-u--margin-top m-u--bullet-list">
-            <li v-for="attribute in getAllAttributes()">
-                {{attribute}}
-                <ul>
-                    <li v-for="tag in attributeMap[attribute]">
-                        {{tag}}
-                    </li>
-                </ul>
-            </li>
-        </ul>
-    </m-template>
-</m-flex-template>
+<m-template>
+    <div slot="header">
+        <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Menu</m-link>
+        <h1>Attributes list</h1>
+    </div>
+    <h2>Attributes by component</h2>
+    <ul class="m-u--margin-top m-u--bullet-list">
+        <li v-for="meta in allMeta">
+            {{meta.tag}}
+            <ul>
+                <li v-for="attribute in getAttributes(meta)">
+                    <span>
+                {{attribute}}: <span style="color: blue">{{meta.attributes[attribute].type}}</span>
+                    </span>
+                    <span v-for="(value, index) in meta.attributes[attribute].values" style="margin-left: 8px">
+                    <i v-if="meta.attributes[attribute].default === index" style="font-weight:400">{{value}}</i>
+                    <span v-else>{{value}}</span>
+                    </span>
+                </li>
+            </ul>
+        </li>
+    </ul>
+    <h2>Components by attribute</h2>
+    <ul class="m-u--margin-top m-u--bullet-list">
+        <li v-for="attribute in getAllAttributes()">
+            {{attribute}}
+            <ul>
+                <li v-for="tag in attributeMap[attribute]">
+                    {{tag}}
+                </li>
+            </ul>
+        </li>
+    </ul>
+</m-template>

--- a/tests/app/index.html
+++ b/tests/app/index.html
@@ -7,9 +7,7 @@
 </head>
 
 <body class="m-u--app-body">
-    <div class="mtest-content">
-        <div id="vue">Waiting...</div>
-    </div>
+    <div id="vue">Waiting...</div>
 </body>
 
 </html>

--- a/tests/app/media-queries/media-queries.html
+++ b/tests/app/media-queries/media-queries.html
@@ -1,29 +1,27 @@
 
-<m-flex-template padding-top="52px">
-    <m-template>
-        <div slot="header">
-            <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Menu</m-link>
-            <h1>Media Queries</h1>
-        </div>
-        <div>
-            <h2 v-if="isMqMinXS || isMqMinS || isMqMinM || isMqMinL || isMqMinXL" >min-width</h2>
-            <p id="min480" v-if="isMqMinXS">480px >= ... <strong>isMqMinXS</strong></p>
-            <p id="min768" v-if="isMqMinS">768px >= ... <strong>isMqMinS</strong></p>
-            <p id="min1024" v-if="isMqMinM">1024px >= ... <strong>isMqMinM</strong></p>
-            <p id="min1200" v-if="isMqMinL"> 1200px >= ... <strong>isMqMinL</strong></p>
-            <p id="min1600" v-if="isMqMinXL">1600px >= ... <strong>isMqXL</strong></p>
+<m-template>
+    <div slot="header">
+        <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Menu</m-link>
+        <h1>Media Queries</h1>
+    </div>
+    <div>
+        <h2 v-if="isMqMinXS || isMqMinS || isMqMinM || isMqMinL || isMqMinXL" >min-width</h2>
+        <p id="min480" v-if="isMqMinXS">480px >= ... <strong>isMqMinXS</strong></p>
+        <p id="min768" v-if="isMqMinS">768px >= ... <strong>isMqMinS</strong></p>
+        <p id="min1024" v-if="isMqMinM">1024px >= ... <strong>isMqMinM</strong></p>
+        <p id="min1200" v-if="isMqMinL"> 1200px >= ... <strong>isMqMinL</strong></p>
+        <p id="min1600" v-if="isMqMinXL">1600px >= ... <strong>isMqXL</strong></p>
 
-            <h2 v-if="isMqMaxXS || isMqMaxS || isMqMaxM || isMqMaxL || isMqMaxXL">max-width</h2>
-            <p id="max480" v-if="isMqMaxXS"><strong>isMqXS</strong> ... < 480px</p>
-            <p id="max768" v-if="isMqMaxS"><strong>isMqMaxS</strong> ... < 768px</p>
-            <p id="max1024" v-if="isMqMaxM"><strong>isMqMaxM</strong> ... < 1024px</p>
-            <p id="max1200" v-if="isMqMaxL"><strong>isMqMaxL</strong> ... < 1200px</p>
-            <p id="max1600" v-if="isMqMaxXL"><strong>isMqMaxXL</strong> ... < 1600px</p>
+        <h2 v-if="isMqMaxXS || isMqMaxS || isMqMaxM || isMqMaxL || isMqMaxXL">max-width</h2>
+        <p id="max480" v-if="isMqMaxXS"><strong>isMqXS</strong> ... < 480px</p>
+        <p id="max768" v-if="isMqMaxS"><strong>isMqMaxS</strong> ... < 768px</p>
+        <p id="max1024" v-if="isMqMaxM"><strong>isMqMaxM</strong> ... < 1024px</p>
+        <p id="max1200" v-if="isMqMaxL"><strong>isMqMaxL</strong> ... < 1200px</p>
+        <p id="max1600" v-if="isMqMaxXL"><strong>isMqMaxXL</strong> ... < 1600px</p>
 
-            <h2 v-if="isMqS || isMqM || isMqL" >min-width and max-width</h2>
-            <p id="in480-768" v-if="isMqS">480px =­> ... <strong>isMqS</strong> ... < 768px</p>
-            <p id="in768-1024" v-if="isMqM">768px => ... <strong>isMqM</strong>... < 1024px</p>
-            <p id="in1024-1600" v-if="isMqL">1024px => ... <strong>isMqL</strong> ... < 1600px</p>
-        </div>
-    </m-template>
-</m-flex-template>
+        <h2 v-if="isMqS || isMqM || isMqL" >min-width and max-width</h2>
+        <p id="in480-768" v-if="isMqS">480px =­> ... <strong>isMqS</strong> ... < 768px</p>
+        <p id="in768-1024" v-if="isMqM">768px => ... <strong>isMqM</strong>... < 1024px</p>
+        <p id="in1024-1600" v-if="isMqL">1024px => ... <strong>isMqL</strong> ... < 1600px</p>
+    </div>
+</m-template>

--- a/tests/app/navigation/navigation.html
+++ b/tests/app/navigation/navigation.html
@@ -1,69 +1,67 @@
-<m-flex-template padding-top="52px">
-    <m-template>
-        <div slot="header">
-            <h1>Sandboxes</h1>
-            <nav class="m-u--margin-top">
-                <ul class="m-navigation__submenu">
-                    <li>
-                        <m-link mode="link" href="#component">Components</m-link>
-                    </li>
-                    <li>
-                        <m-link mode="link" href="#directives">Directives</m-link>
-                    </li>
-                    <li>
-                        <m-link mode="link" href="#filters">Filters</m-link>
-                    </li>
-                    <li>
-                        <m-link mode="link" href="#mixins">Mixins</m-link>
-                    </li>
-                </ul>
-            </nav>
-        </div>
-
-        <a class="anchor" id="component"></a>
-        <h2>Components <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
-        </h2>
+<m-template>
+    <div slot="header">
+        <h1 class="m-u--no-margin">Sandboxes</h1>
         <nav class="m-u--margin-top">
-            <ul class="m-u--bullet-list">
-                <li v-for="route in componentsTag">
-                    <m-link :url="'components/' + route">{{route}}</m-link>
-                </li>
-            </ul>
-        </nav>
-        <a class="anchor" id="directives"></a>
-        <h2>Directives <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px" ></m-icon></m-link>
-        </h2>
-        <nav class="m-u--margin-top">
-            <ul class="m-u--bullet-list">
-                <li v-for="route in directivesName">
-                    <m-link :url="'directives/' + route">{{route}}</m-link>
-                </li>
-            </ul>
-        </nav>
-        <a class="anchor" id="filters"></a>
-        <h2>Filters  <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
-        </h2>
-        <nav class="m-u--margin-top">
-            <ul class="m-u--bullet-list">
-                <li v-for="route in filtersName">
-                    <m-link :url="'filters/' + route">{{route}}</m-link>
-                </li>
-            </ul>
-        </nav>
-        <a class="anchor" id="mixins"></a>
-        <h2>Mixins <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
-        </h2>
-        <nav class="m-u--margin-top">
-            <ul class="m-u--bullet-list">
+            <ul class="m-navigation__submenu">
                 <li>
-                    <m-link url="media-queries">Media Queries</m-link>
+                    <m-link mode="link" href="#component">Components</m-link>
                 </li>
                 <li>
-                    <m-link url="attributes">Attributes list</m-link>
+                    <m-link mode="link" href="#directives">Directives</m-link>
+                </li>
+                <li>
+                    <m-link mode="link" href="#filters">Filters</m-link>
+                </li>
+                <li>
+                    <m-link mode="link" href="#mixins">Mixins</m-link>
                 </li>
             </ul>
-
         </nav>
+    </div>
 
-    </m-template>
-</m-flex-template>
+    <a class="anchor" id="component"></a>
+    <h2 class="m-u--no-margin">Components <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    </h2>
+    <nav class="m-u--margin-top">
+        <ul class="m-u--bullet-list">
+            <li v-for="route in componentsTag">
+                <m-link :url="'components/' + route">{{route}}</m-link>
+            </li>
+        </ul>
+    </nav>
+    <a class="anchor" id="directives"></a>
+    <h2>Directives <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px" ></m-icon></m-link>
+    </h2>
+    <nav class="m-u--margin-top">
+        <ul class="m-u--bullet-list">
+            <li v-for="route in directivesName">
+                <m-link :url="'directives/' + route">{{route}}</m-link>
+            </li>
+        </ul>
+    </nav>
+    <a class="anchor" id="filters"></a>
+    <h2>Filters  <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    </h2>
+    <nav class="m-u--margin-top">
+        <ul class="m-u--bullet-list">
+            <li v-for="route in filtersName">
+                <m-link :url="'filters/' + route">{{route}}</m-link>
+            </li>
+        </ul>
+    </nav>
+    <a class="anchor" id="mixins"></a>
+    <h2>Mixins <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    </h2>
+    <nav class="m-u--margin-top">
+        <ul class="m-u--bullet-list">
+            <li>
+                <m-link url="media-queries">Media Queries</m-link>
+            </li>
+            <li>
+                <m-link url="attributes">Attributes list</m-link>
+            </li>
+        </ul>
+
+    </nav>
+
+</m-template>

--- a/tests/app/viewer/viewer.html
+++ b/tests/app/viewer/viewer.html
@@ -1,9 +1,7 @@
-<m-flex-template :menuOpen="menuOpen">
-    <m-template>
-        <div slot="header">
-            <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Retour</m-link>
-            <h1>{{$route.meta}}</h1>
-        </div>
-        <m-dynamic-template :template="tag"></m-dynamic-template>
-    </m-template>
-</m-flex-template>
+<m-template>
+    <div slot="header">
+        <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Retour</m-link>
+        <h1>{{$route.meta}}</h1>
+    </div>
+    <m-dynamic-template :template="tag"></m-dynamic-template>
+</m-template>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [X] Provide a small description of the changes introduced by this PR
Ajouter l'icône not-allowed au textfield et l'icône chevron--right au datepicker (voir les photos dans le billet MODUL-545)

J'ai **mis à jour** le visuel des template de la section sandbox.
- Suppression des m-flex-template qui servait à rien
- Nouveau style et balisage pour le composant m-app-frame


- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-545


<!-- END_REQUIRED -->