### PR TITLE
MODUL-538: Dans l'admission, le train disparaît lorsqu'on accède à la section directement par l'URL

### DIFF
--- a/src/components/steppers-item/steppers-item.html
+++ b/src/components/steppers-item/steppers-item.html
@@ -2,19 +2,27 @@
     :class="{ 'm--is-visited' : isVisited,
               'm--is-in-progress' : isInProgress,
               'm--is-disabled' : isDisabled,
-              'm--is-completed': completed }"
-    :tabindex="isTabIndex">
-    <div class="m-steppers-item__icon"
-         @click="onClick">
-        <m-icon :name="iconName"
-                :svg-title="iconTitle"></m-icon>
-        <m-icon class="m-steppers-item__icon-completed"
-                v-if="completed"
-                name="m-svg__completed-filled"></m-icon>
-    </div>
-    <div class="m-steppers-item__title"
-         @click="onClick"
-         ref="title">
-        <slot></slot>
-    </div>
+              'm--is-completed': completed,
+              'm--is-link': isLink }">
+    <component class="m-steppers-item__button"
+               :is="componentToShow"
+               :to="propUrl"
+               :tabindex="isTabIndex"
+               :role="role"
+               :aria-selected="isInProgress"
+               @keyup.enter="onClick"
+               @click="onClick">
+        <div class="m-steppers-item__icon">
+            <m-icon :name="iconName"
+                    :svg-title="iconTitle"></m-icon>
+            <m-icon class="m-steppers-item__icon-completed"
+                    v-if="completed"
+                    name="m-svg__completed-filled"></m-icon>
+        </div>
+        <div class="m-steppers-item__title"
+            @click="onClick"
+            ref="title">
+            <slot></slot>
+        </div>
+    </component>
 </li>

--- a/src/components/steppers-item/steppers-item.scss
+++ b/src/components/steppers-item/steppers-item.scss
@@ -5,35 +5,35 @@ $m-steppers--badge--size: 14px;
 
 .m-steppers-item {
     display: inline-flex;
-    flex-direction: column;
-    align-items: center;
+    list-style: none;
     z-index: 1;
-    outline: none;
 
     &.m--is-visited {
-        cursor: pointer;
-
-        &:focus .m-steppers-item__icon,
-        &:focus .m-steppers-item__title,
-        &:hover .m-steppers-item__icon,
-        &:hover .m-steppers-item__title {
-            color: $m-color--interactive;
-        }
-
         &::before,
-        &::after {
+        &::after,
+        .m-steppers-item__button {
             cursor: pointer;
         }
 
+        .m-steppers-item__button {
+            &:hover,
+            &:focus {
+                .m-steppers-item__icon,
+                .m-steppers-item__title {
+                    color: $m-color--interactive;
+                }
+            }
+        }
+
         .m-steppers-item__icon {
-            border-color: $m-color--ul-blue;
+            border-color: $m-color--interactive;
         }
     }
 
     &.m--is-in-progress {
         .m-steppers-item {
             &__icon {
-                border-color: $m-color--ul-yellow;
+                border-color: $m-color--active;
             }
 
             &__title {
@@ -43,10 +43,9 @@ $m-steppers--badge--size: 14px;
     }
 
     &.m--is-disabled {
-        cursor: not-allowed;
-
         &::before,
-        &::after {
+        &::after,
+        .m-steppers-item__button {
             cursor: not-allowed;
         }
 
@@ -66,6 +65,17 @@ $m-steppers--badge--size: 14px;
         }
     }
 
+    &__button {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        outline: none;
+    }
+
+    a {
+        text-decoration: none;
+    }
+
     &__icon {
         position: relative;
         display: flex;
@@ -78,6 +88,7 @@ $m-steppers--badge--size: 14px;
         background-color: $m-color--white;
         font-size: $m-steppers--icon--size;
         transition: color $m-transition-duration;
+        color: $m-color--text;
     }
 
     &__icon-completed {

--- a/src/components/steppers-item/steppers-item.scss
+++ b/src/components/steppers-item/steppers-item.scss
@@ -9,13 +9,9 @@ $m-steppers--badge--size: 14px;
     z-index: 1;
 
     &.m--is-visited {
-        &::before,
-        &::after,
         .m-steppers-item__button {
             cursor: pointer;
-        }
 
-        .m-steppers-item__button {
             &:hover,
             &:focus {
                 .m-steppers-item__icon,
@@ -43,9 +39,8 @@ $m-steppers--badge--size: 14px;
     }
 
     &.m--is-disabled {
-        &::before,
-        &::after,
         .m-steppers-item__button {
+            user-select: none;
             cursor: not-allowed;
         }
 
@@ -77,6 +72,7 @@ $m-steppers--badge--size: 14px;
     }
 
     &__icon {
+        transition: color $m-transition-duration ease, border-color $m-transition-duration ease;
         position: relative;
         display: flex;
         align-items: center;
@@ -87,11 +83,11 @@ $m-steppers--badge--size: 14px;
         border: 2px solid;
         background-color: $m-color--white;
         font-size: $m-steppers--icon--size;
-        transition: color $m-transition-duration;
         color: $m-color--text;
     }
 
     &__icon-completed {
+        transition: color $m-transition-duration ease;
         position: absolute;
         bottom: -4px; // Magic number
         right: -6px; // Magic number

--- a/src/components/steppers-item/steppers-item.ts
+++ b/src/components/steppers-item/steppers-item.ts
@@ -35,6 +35,8 @@ export class MSteppersItem extends ModulVue {
     public iconTitle: string;
     @Prop({ default: false })
     public completed: boolean;
+    @Prop()
+    url: string;
 
     @Watch('state')
     private stateChanged(value?: string[]): void {
@@ -60,6 +62,22 @@ export class MSteppersItem extends ModulVue {
 
     private get isTabIndex(): 0 | -1 {
         return this.isVisited ? 0 : -1;
+    }
+
+    private get isLink(): boolean {
+        return !!this.url && this.isVisited;
+    }
+
+    private get componentToShow(): string {
+        return this.isLink ? 'router-link' : 'div';
+    }
+
+    private get role(): string | undefined {
+        return this.isLink || this.isDisabled ? undefined : 'button';
+    }
+
+    private get propUrl(): string | undefined {
+        return this.isLink ? this.url : undefined;
     }
 
     private onClick(event: Event): void {

--- a/src/components/steppers/steppers.html
+++ b/src/components/steppers/steppers.html
@@ -1,6 +1,6 @@
 <div class="m-steppers">
     <div class="m-steppers__overflow-wrapper" ref="overflowWrapper">
-        <ul class="m-steppers__wrap" :class="{ 'm--is-last': last }" ref="wrapItem">
+        <ul class="m-steppers__wrap" ref="wrapItem">
             <li aria-hidden="true" class="m-steppers__default-line" ref="defaultLine"></li>
             <li aria-hidden="true" class="m-steppers__selected-line" :class="{ 'm--is-anim-active': isAnimActive }" ref="selectedLine"></li>
             <slot></slot>

--- a/src/components/steppers/steppers.sandbox.html
+++ b/src/components/steppers/steppers.sandbox.html
@@ -4,4 +4,11 @@
         <m-steppers-item icon-name="m-svg__calendar" state="in-progress" :completed="true">Calandrier</m-steppers-item>
         <m-steppers-item icon-name="m-svg__logout" state="disabled" :completed="true">Déconnexion</m-steppers-item>
     </m-steppers>
+
+    <h2>Steppers with prop url</h2>
+    <m-steppers class="m-u--margin-top--l">
+        <m-steppers-item url="/" icon-name="m-svg__profile" state="visited" :completed="true">Profil</m-steppers-item>
+        <m-steppers-item url="/" icon-name="m-svg__calendar">Calandrier</m-steppers-item>
+        <m-steppers-item url="/" icon-name="m-svg__logout" state="in-progress">Déconnexion</m-steppers-item>
+    </m-steppers>
 </div>

--- a/src/components/steppers/steppers.scss
+++ b/src/components/steppers/steppers.scss
@@ -5,7 +5,6 @@ $m-steppers-item--line-width: 2px;
 .m-steppers {
     position: relative;
     overflow: hidden;
-    user-select: none;
 
     &__overflow-wrapper {
         position: relative;

--- a/src/components/steppers/steppers.scss
+++ b/src/components/steppers/steppers.scss
@@ -20,6 +20,7 @@ $m-steppers-item--line-width: 2px;
         display: flex;
         justify-content: space-between;
         margin: 0;
+        padding: 0;
     }
 
     &__selected-line {

--- a/src/components/steppers/steppers.scss
+++ b/src/components/steppers/steppers.scss
@@ -21,6 +21,7 @@ $m-steppers-item--line-width: 2px;
         justify-content: space-between;
         margin: 0;
         padding: 0;
+        list-style: none;
     }
 
     &__selected-line {

--- a/src/components/steppers/steppers.ts
+++ b/src/components/steppers/steppers.ts
@@ -75,7 +75,7 @@ export class MSteppers extends BaseSteppers {
         let initHeight: number = wrapItem.clientHeight;
         let scrollbarSpace: number = 40;
 
-        if (document.readyState === 'complete') {
+        if (document.readyState === 'complete' || initHeight > 0) {
             elStyleHeight = initHeight + 'px';
             overflowWrapperStyleHeight = initHeight + scrollbarSpace + 'px';
             this.setMinWidth();

--- a/src/components/steppers/steppers.ts
+++ b/src/components/steppers/steppers.ts
@@ -63,10 +63,35 @@ export class MSteppers extends BaseSteppers {
     }
 
     protected mounted(): void {
-        this.setMinWidth();
-        this.setHiddenHeight();
+        this.initWidthAndHeightOfSteppers();
+    }
+
+    private initWidthAndHeightOfSteppers(): void {
         this.setLineWidth();
         this.as<ElementQueries>().$on('resizeDone', this.setLineWidth);
+        let overflowWrapperStyleHeight: any = (this.$refs.overflowWrapper as HTMLElement).style.height;
+        let elStyleHeight: any = this.$el.style.height;
+        let wrapItem: HTMLElement = this.$refs.wrapItem as HTMLElement;
+        let initHeight: number = wrapItem.clientHeight;
+        let scrollbarSpace: number = 40;
+
+        if (document.readyState === 'complete') {
+            elStyleHeight = initHeight + 'px';
+            overflowWrapperStyleHeight = initHeight + scrollbarSpace + 'px';
+            this.setMinWidth();
+        } else {
+            let intervalForDomReady: any = setInterval(() => {
+                // The document is ready when the clientHeight is larger than 0
+                if (wrapItem.clientHeight > 0) {
+                    initHeight = wrapItem.clientHeight;
+                    elStyleHeight = initHeight + 'px';
+                    overflowWrapperStyleHeight = initHeight + scrollbarSpace + 'px';
+                    this.setMinWidth();
+                    this.setLineWidth();
+                    window.clearInterval(intervalForDomReady);
+                }
+            }, 100);
+        }
     }
 
     private setMinWidth(): void {
@@ -83,14 +108,6 @@ export class MSteppers extends BaseSteppers {
         wrapItem.style.minWidth = minWidth + 'px';
         wrapItem.style.display = 'flex';
         wrapItem.style.opacity = '1';
-    }
-
-    private setHiddenHeight(): void {
-        let overflowWrapper: HTMLElement = this.$refs.overflowWrapper as HTMLElement;
-        let wrapItem: HTMLElement = this.$refs.wrapItem as HTMLElement;
-        let initHeight: number = wrapItem.clientHeight;
-        this.$el.style.height = initHeight + 'px';
-        overflowWrapper.style.height = initHeight + 40 + 'px';
     }
 
     private centeringElement(element): void {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
1) En mode "shell", dans l'admission, le train disparaît lorsqu'on accède à la section directement par l'URL
Voir les photos du billet (https://jira.dti.ulaval.ca/browse/MODUL-538)
2) Rendre disponible la navigation à l'aide du `<router-link>` dans le `<m-steppers-item>`
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-538


- [X] Include this section in the release notes
Ajout de la nouvelle prop `url` sur le composant `<m-steppers-item>`. Grâce a cette prop, il est maintenant possible de naviguer à l'intérieur d'un `<m-steppers>` à l'aide d'un `<router-link>`.

