### PR TITLE
MODUL-554 - Ajustement du comportement et de l'accessibilité des fenêtres (m-modal, m-dialog, m-popup, m-dropdown, etc.) 

### DIFF
--- a/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
+++ b/src/components/dropdown/__snapshots__/dropdown.spec.ts.snap
@@ -43,7 +43,7 @@ exports[`MDropdown should render correctly when footer slot is set 1`] = `
         <m-accordion-transition transition="true"></m-accordion-transition>
     </div>
     <div class="m-popup">
-        <m-popper-mock placement="bottom-start" focus-management="true" open-trigger="mousedown" enter="function boundFn(a) {
+        <m-popper-mock placement="bottom-start" open-trigger="mousedown" enter="function boundFn(a) {
     var l = arguments.length;
     return l
       ? l &gt; 1

--- a/src/components/dropdown/dropdown.html
+++ b/src/components/dropdown/dropdown.html
@@ -59,7 +59,7 @@
              :enter="transitionEnter"
              :leave="transitionLeave"
              :padding="false"
-             :focus-management="isMqMaxS"
+             :focus-management="false"
              :close-on-backdrop="true"
              :preload="true"
              :open-trigger="'mousedown'"

--- a/src/components/option/__snapshots__/option.spec.ts.snap
+++ b/src/components/option/__snapshots__/option.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MOption Option should render correctly 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -14,7 +14,7 @@ exports[`MOption Option should render correctly 1`] = `
 `;
 
 exports[`MOption Option should render correctly placement left 1`] = `
-<m-popup placement="left" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="left" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -27,7 +27,7 @@ exports[`MOption Option should render correctly placement left 1`] = `
 `;
 
 exports[`MOption Option should render correctly placement right 1`] = `
-<m-popup placement="right" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="right" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -40,7 +40,7 @@ exports[`MOption Option should render correctly placement right 1`] = `
 `;
 
 exports[`MOption Option should render correctly placement top 1`] = `
-<m-popup placement="top" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="top" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -53,7 +53,7 @@ exports[`MOption Option should render correctly placement top 1`] = `
 `;
 
 exports[`MOption should react to open prop changes 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -66,7 +66,7 @@ exports[`MOption should react to open prop changes 1`] = `
 `;
 
 exports[`MOption should react to open prop changes 2`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -79,7 +79,7 @@ exports[`MOption should react to open prop changes 2`] = `
 `;
 
 exports[`MOption should render correctly when close title is set 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -92,7 +92,7 @@ exports[`MOption should render correctly when close title is set 1`] = `
 `;
 
 exports[`MOption should render correctly when open title is set 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Title open" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -105,7 +105,7 @@ exports[`MOption should render correctly when open title is set 1`] = `
 `;
 
 exports[`MOption should render correctly when size is set 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="200px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -118,7 +118,7 @@ exports[`MOption should render correctly when size is set 1`] = `
 `;
 
 exports[`MOption should render correctly when skin is dark 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="dark" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>
@@ -131,7 +131,7 @@ exports[`MOption should render correctly when skin is dark 1`] = `
 `;
 
 exports[`MOption should render correctly when skin is light 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" focus-management="true" class="m-option">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-option">
     <m-icon-button slot="trigger" id="mOption-uuid" aria-haspopup="true" aria-controls="mOption-uuid-controls" skin="light" title="Open menu" icon-name="m-svg__options" button-size="44px" class="m-option__button"></m-icon-button>
     <ul id="mOption-uuid-controls" aria-labelledby="mOption-uuid" class="m-option__list">
         <m-option>

--- a/src/components/option/option.ts
+++ b/src/components/option/option.ts
@@ -61,7 +61,7 @@ export class MOption extends BaseOption implements MOptionInterface {
     public disabled: boolean;
     @Prop({ default: '44px' })
     public size: string;
-    @Prop({ default: true })
+    @Prop({ default: false })
     public focusManagement: boolean;
 
     public hasIcon: boolean = false;

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -56,7 +56,7 @@
                     .m-sidebar__article {
                         transform: translate3d(0, calc(100% + #{ $m-touch-size }), 0);
                         bottom: 0;
-                        max-height: calc(100vh - #{ $m-padding--xl });
+                        max-height: calc(100% - #{ $m-padding--xl });
                     }
                 }
             }

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -7,6 +7,7 @@
          :disabled="disabled"
          :close-on-backdrop="true"
          :class-name="className"
+         :focus-management="isMqMaxS"
          @open="onOpen"
          @close="onClose">
     <m-icon-button :id="id"

--- a/src/utils/modul/modul.ts
+++ b/src/utils/modul/modul.ts
@@ -30,9 +30,9 @@ type StackMap = {
 };
 
 export class Modul {
-    public bodyEl: HTMLElement = document.documentElement || document.body; // The order is important for tooltip positioning in the RTE.
-    public bodyStyle: any = this.bodyEl.style;
     public htmlEl: HTMLElement = document.querySelector('html') as HTMLElement;
+    public bodyEl: HTMLElement = document.querySelector('body') as HTMLElement;
+    public bodyStyle: any = this.bodyEl.style;
     public event = new Vue();
     public scrollPosition: number = 0;
     public stopScrollPosition: number = 0;
@@ -150,8 +150,6 @@ export class Modul {
 
     private ensureBackdrop(viewportIsSmall: boolean): number {
         if (!this.backdropElement) {
-            // this.stopScrollBody(viewportIsSmall);
-
             let element: HTMLElement = document.createElement('div');
             let id: string = BACKDROP_ID + '-' + uuid.generate();
             element.setAttribute('id', id);


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR

1) Lorsqu'on affiche une fenêtre (m-dialog, m-modal, m-sidebar, etc.), on ne devrait par remonter en haut de la page
Pour reproduire le problème, cliquez sur un bouton qui ouvrira n'importe quel type de fenêtre (m-dialog, m-modal, m-sidebar, etc.). Ce bouton devrait être positionné dans le bas d'une page possédant un scroll. Vous constaterez qu'à l'ouverture de la fenêtre, le scroll de la page remonte en haut de la page.
Le comportement souhaité est de conserver la position du scroll actuelle à l'ouverture d'une fenêtre tout en stoppant le scroll.

2) Ajustement de la prop **focus-management** pour composant utilisant `<m-popper>`

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-554
https://jira.dti.ulaval.ca/browse/AEL-345
