### PR TITLE
MODUL-561 Lien mode RouterLink et disabled ne doit plus naviguer lorsque cliquer

### DIFF
--- a/src/components/link/link.html
+++ b/src/components/link/link.html
@@ -11,12 +11,19 @@
                  :target="target"
                  v-if="isRouterLink"
                  :tabindex="disabled ? '-1' : tabindex"
-                 ref="router">
-        <m-icon :name="propIconName" :size="iconSize" class="m-link__icon" v-if="hasIcon" aria-hidden="true"></m-icon>
+                 ref="router"
+                 :event="routerEvent">
+        <m-icon :name="propIconName"
+                :size="iconSize"
+                class="m-link__icon"
+                v-if="hasIcon"
+                aria-hidden="true"></m-icon>
         <span class="m-link__text">
             <slot></slot>
         </span>
-        <m-i18n class="m-link__hidden" v-if="isTargetBlank" k="m-link:open-new-tab"></m-i18n>
+        <m-i18n class="m-link__hidden"
+                v-if="isTargetBlank"
+                k="m-link:open-new-tab"></m-i18n>
     </router-link>
     <a class="m-link"
        :class="{ 'm--is-unvisited': isUnvisited,
@@ -34,10 +41,16 @@
        @keyup="onKeyup"
        :tabindex="disabled ? '-1' : tabindex"
        ref="link">
-        <m-icon class="m-link__icon" :name="propIconName" :size="iconSize" v-if="hasIcon" aria-hidden="true"></m-icon>
+        <m-icon class="m-link__icon"
+                :name="propIconName"
+                :size="iconSize"
+                v-if="hasIcon"
+                aria-hidden="true"></m-icon>
         <span class="m-link__text">
             <slot></slot>
         </span>
-        <m-i18n class="m-link__hidden" v-if="isTargetBlank" k="m-link:open-new-tab"></m-i18n>
+        <m-i18n class="m-link__hidden"
+                v-if="isTargetBlank"
+                k="m-link:open-new-tab"></m-i18n>
     </a>
 </transition>

--- a/src/components/link/link.sandbox.html
+++ b/src/components/link/link.sandbox.html
@@ -31,4 +31,12 @@
             <m-icon class="m-u--link-icon-right" name="m-svg__clock"></m-icon>
         </a>
     </p>
+    <h2>Lien de type RouterLink n'est pas fonctionnel en mode disabled (MODUL-561)</h2>
+    <p>
+        <m-link icon-name="m-svg__clock"
+                :disabled="routerLinkDisabled">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eius reiciendis tempore modi rerum beatae. Placeat nam iure cupiditate ipsum non ipsa! Sequi enim ab, est tenetur a aliquam officiis cupiditate!</m-link>
+    </p>
+    <p>
+        <m-button @click="routerLinkDisabled = !routerLinkDisabled">Désactiver/Activer le lien</m-button>
+    </p>
 </div>

--- a/src/components/link/link.sandbox.ts
+++ b/src/components/link/link.sandbox.ts
@@ -1,12 +1,12 @@
 import Vue, { PluginObject } from 'vue';
 import { Component } from 'vue-property-decorator';
-
 import { LINK_NAME } from '../component-names';
 import WithRender from './link.sandbox.html';
 
 @WithRender
 @Component
 export class MLinkSandbox extends Vue {
+    public routerLinkDisabled: boolean = false;
 }
 
 const LinkSandboxPlugin: PluginObject<any> = {

--- a/src/components/link/link.spec.ts
+++ b/src/components/link/link.spec.ts
@@ -1,7 +1,6 @@
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vue, { VueConstructor } from 'vue';
 import VueRouter from 'vue-router';
-
 import { addMessages } from '../../../tests/helpers/lang';
 import { renderComponent } from '../../../tests/helpers/render';
 import LinkPlugin, { MLink, MLinkIconPosition, MLinkMode } from './link';
@@ -129,6 +128,38 @@ describe('MLink', () => {
             });
 
             await renderAllIconStyle(link);
+        });
+
+        it(`should assign router-link event correctly when disabled`, () => {
+            const link: Wrapper<MLink> = mount(MLink, {
+                router: router,
+                localVue: localVue,
+                propsData: {
+                    mode: MLinkMode.RouterLink,
+                    disabled: true
+                }
+            });
+
+            const refRouter: Wrapper<Vue> = link.find({ ref: 'router' });
+
+            expect(refRouter.exists()).toBe(true);
+            expect(refRouter.props().event).toBe('');
+        });
+
+        it(`should assign router-link event correctly when enabled`, () => {
+            const link: Wrapper<MLink> = mount(MLink, {
+                router: router,
+                localVue: localVue,
+                propsData: {
+                    mode: MLinkMode.RouterLink,
+                    disabled: false
+                }
+            });
+
+            const refRouter: Wrapper<Vue> = link.find({ ref: 'router' });
+
+            expect(refRouter.exists()).toBe(true);
+            expect(refRouter.props().event).toBe('click');
         });
     });
 

--- a/src/components/link/link.ts
+++ b/src/components/link/link.ts
@@ -1,7 +1,6 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-
 import { KeyCode } from '../../utils/keycode/keycode';
 import { ModulVue } from '../../utils/vue/vue';
 import { LINK_NAME } from '../component-names';
@@ -171,6 +170,10 @@ export class MLink extends ModulVue {
 
     private get routerLinkUrl(): string | Object {
         return !this.isObject(this.url) ? { path: this.url } : this.url;
+    }
+
+    private get routerEvent(): string {
+        return this.disabled ? '' : 'click';
     }
 
     private isObject(a): boolean {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [X] Provide a small description of the changes introduced by this PR
Un MLink en mode RouterLink ET disabled ne navigue plus vers sa destination lorsque cliqué.
- [X] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-561
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
