### PR TITLE
MODUL-563 - Améliorer le composant "m-link" avant la création des composants "m-add" et "m-back"

### DIFF
--- a/src/components/accordion-group/__snapshots__/accordion-group.spec.ts.snap
+++ b/src/components/accordion-group/__snapshots__/accordion-group.spec.ts.snap
@@ -3,9 +3,8 @@
 exports[`MAcordionGroup should not render both close all and open all link when state is mixed 1`] = `
 <article class="m-accordion-group">
     <div class="m-accordion-group__header m--no-title">
-        <div>
-            <a href="#" tabindex="1" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
-            </a>
+        <div><span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
+            </span>
         </div>
     </div>
     <div class="m-accordion-group__body">
@@ -27,9 +26,8 @@ exports[`MAcordionGroup should not render both close all and open all link when 
 exports[`MAcordionGroup should not render close all link when all accordions are opened 1`] = `
 <article class="m-accordion-group">
     <div class="m-accordion-group__header m--no-title">
-        <div>
-            <a href="#" tabindex="1" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Close all</span></span>
-            </a>
+        <div> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Close all</span></span>
+            </span>
         </div>
     </div>
     <div class="m-accordion-group__body">
@@ -55,9 +53,8 @@ exports[`MAcordionGroup should not render close all link when all accordions are
 exports[`MAcordionGroup should not render open all link when all accordions are closed 1`] = `
 <article class="m-accordion-group">
     <div class="m-accordion-group__header m--no-title">
-        <div>
-            <a href="#" tabindex="1" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
-            </a>
+        <div><span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
+            </span>
         </div>
     </div>
     <div class="m-accordion-group__body">
@@ -89,9 +86,8 @@ exports[`MAcordionGroup should not render toggle links when concurrent 1`] = `
 exports[`MAcordionGroup should render correctly 1`] = `
 <article class="m-accordion-group">
     <div class="m-accordion-group__header m--no-title">
-        <div>
-            <a href="#" tabindex="1" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
-            </a>
+        <div><span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
+            </span>
         </div>
     </div>
     <div class="m-accordion-group__body">
@@ -110,9 +106,8 @@ exports[`MAcordionGroup should render correctly with title 1`] = `
 <article class="m-accordion-group">
     <div class="m-accordion-group__header">
         <div class="m-accordion-group__header__title">title</div>
-        <div>
-            <a href="#" tabindex="1" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
-            </a>
+        <div><span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Open all</span></span>
+            </span>
         </div>
     </div>
     <div class="m-accordion-group__body">

--- a/src/components/accordion-group/accordion-group.html
+++ b/src/components/accordion-group/accordion-group.html
@@ -1,14 +1,21 @@
 <article class="m-accordion-group">
-    <div class="m-accordion-group__header" :class="{ 'm--no-title' : !hasTitleSlot }" v-if="hasTitleSlot || !concurrent">
-        <div class="m-accordion-group__header__title" v-if="hasTitleSlot">
+    <div class="m-accordion-group__header"
+         :class="{ 'm--no-title' : !hasTitleSlot }"
+         v-if="hasTitleSlot || !concurrent">
+        <div class="m-accordion-group__header__title"
+             v-if="hasTitleSlot">
             <slot name="title"></slot>
         </div>
         <div v-if="!concurrent && !disabled">
-            <m-link mode="button" @click="openAllAccordions" v-if="!propAllOpen">
+            <m-link @click="openAllAccordions"
+                    v-if="!propAllOpen"
+                    ref="buttonAllOpen">
                 <m-i18n k="m-accordion-group:open-all"></m-i18n>
             </m-link>
             <template v-if="!propAllOpen && !propAllClosed">&nbsp;&nbsp;|&nbsp;&nbsp;</template>
-            <m-link mode="button" @click="closeAllAccordions" v-if="!propAllClosed">
+            <m-link @click="closeAllAccordions"
+                    v-if="!propAllClosed"
+                    ref="buttonAllClose">
                 <m-i18n k="m-accordion-group:close-all"></m-i18n>
             </m-link>
         </div>

--- a/src/components/accordion-group/accordion-group.spec.ts
+++ b/src/components/accordion-group/accordion-group.spec.ts
@@ -1,10 +1,8 @@
-import '../../utils/polyfills';
-
 import { mount, Slots, Wrapper, WrapperArray } from '@vue/test-utils';
 import Vue from 'vue';
-
 import { addMessages } from '../../../tests/helpers/lang';
 import { renderComponent } from '../../../tests/helpers/render';
+import '../../utils/polyfills';
 import uuid from '../../utils/uuid/uuid';
 import { MAccordion, MAccordionSkin } from '../accordion/accordion';
 import AccordionGroupPlugin, { MAccordionGroup } from './accordion-group';
@@ -86,7 +84,7 @@ describe('MAcordionGroup', () => {
         const acn: Wrapper<MAccordionGroup> = mountGroup();
         acn.update();
 
-        acn.find('.m-accordion-group__header a').trigger('click');
+        acn.find({ ref: 'buttonAllOpen' }).trigger('click');
 
         const acrds: WrapperArray<MAccordion> = acn.findAll<MAccordion>({ name: 'MAccordion' });
         expect(acrds.length).toBeGreaterThan(0);
@@ -108,7 +106,7 @@ describe('MAcordionGroup', () => {
         });
         acn.update();
 
-        acn.find('.m-accordion-group__header a').trigger('click');
+        acn.find({ ref: 'buttonAllClose' }).trigger('click');
 
         const acrds: WrapperArray<MAccordion> = acn.findAll<MAccordion>({ name: 'MAccordion' });
         expect(acrds.length).toBeGreaterThan(0);

--- a/src/components/dialog/dialog.html
+++ b/src/components/dialog/dialog.html
@@ -1,36 +1,43 @@
-<div class="m-dialog" ref="baseWindow">
+<div class="m-dialog"
+     ref="baseWindow">
     <slot name="trigger"></slot>
-    <portal :target-el="portalTargetSelector" v-if="portalCreated">
+    <portal :target-el="portalTargetSelector"
+            v-if="portalCreated">
         <transition name="m--is">
             <div class="m-dialog__wrap m-u--app-body"
-                    :class="[{ 'm--is-disabled': disabled }, className ]"
-                    v-show="propOpen"
-                    v-if="portalMounted"
-                    ref="modalWrap">
+                 :class="[{ 'm--is-disabled': disabled }, className ]"
+                 v-show="propOpen"
+                 v-if="portalMounted"
+                 ref="modalWrap">
                 <article class="m-dialog__article"
-                            :class="{ 'm--has-width-large': hasWidthLarge }"
-                            ref="article">
+                         :class="{ 'm--has-width-large': hasWidthLarge }"
+                         ref="article">
                     <header class="m-dialog__header"
                             v-if="hasTitle">
                         <h2>{{ title }}</h2>
                     </header>
                     <div class="m-dialog__body"
-                            v-if="hasDefaultSlot || hasMessage">
-                        <p v-if="hasMessage" v-html="message"></p>
+                         v-if="hasDefaultSlot || hasMessage">
+                        <p v-if="hasMessage"
+                           v-html="message"></p>
                         <slot></slot>
                     </div>
                     <footer class="m-dialog__footer">
                         <slot name="footer"></slot>
                         <nav class="m-dialog__footer__nav"
-                                v-if="!hasFooterSlot">
+                             v-if="!hasFooterSlot">
                             <m-button @click="onOk()">
                                 <template v-if="hasOkLabel">{{ okLabel }}</template>
-                                <m-i18n v-else k="m-dialog:ok"></m-i18n>
-                                <template slot="precision" v-if="hasOkPrecision">{{ okPrecision }}</template>
+                                <m-i18n v-else
+                                        k="m-dialog:ok"></m-i18n>
+                                <template slot="precision"
+                                          v-if="hasOkPrecision">{{ okPrecision }}</template>
                             </m-button>
-                            <m-link mode="button" @click="onCancel()" v-if="negativeLink">
+                            <m-link @click="onCancel()"
+                                    v-if="negativeLink">
                                 <template v-if="hasCancelLabel">{{ cancelLabel }}</template>
-                                <m-i18n v-else k="m-dialog:cancel"></m-i18n>
+                                <m-i18n v-else
+                                        k="m-dialog:cancel"></m-i18n>
                             </m-link>
                         </nav>
                     </footer>

--- a/src/components/error-message/__snapshots__/error-message.spec.ts.snap
+++ b/src/components/error-message/__snapshots__/error-message.spec.ts.snap
@@ -17,12 +17,13 @@ exports[`MErrorMessage given error should render correctly expanded 1`] = `
     <p><span class="m-i18n">Vous pouvez attendre quelques minutes et réessayer.</span></p>
     <p><span class="m-i18n">Si le problème persiste, vous pouvez contacter le soutien technique en leur fournissant le détail de l'erreur.</span></p>
     <div skin="light" icon-size="small"><span class="m-i18n">Détails de l'erreur</span>
-        <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
-        <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
+        <p><strong><span class="m-i18n">Navigateur</span>:
+            </strong>modul-user-agent</p>
+        <p><strong><span class="m-i18n">No référence de l'erreur</span>:
+            </strong>123456879</p>
         <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
-    </div>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
-    </a>
+    </div> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
+    </span>
 </div>
 `;
 
@@ -43,13 +44,14 @@ exports[`MErrorMessage given error should render correctly expanded with stack t
     <p><span class="m-i18n">Vous pouvez attendre quelques minutes et réessayer.</span></p>
     <p><span class="m-i18n">Si le problème persiste, vous pouvez contacter le soutien technique en leur fournissant le détail de l'erreur.</span></p>
     <div skin="light" icon-size="small"><span class="m-i18n">Détails de l'erreur</span>
-        <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
-        <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
+        <p><strong><span class="m-i18n">Navigateur</span>:
+            </strong>modul-user-agent</p>
+        <p><strong><span class="m-i18n">No référence de l'erreur</span>:
+            </strong>123456879</p>
         <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
         <div class="m-error-message__stacktrace"><pre></pre></div>
-    </div>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
-    </a>
+    </div> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
+    </span>
 </div>
 `;
 
@@ -70,12 +72,13 @@ exports[`MErrorMessage given error with stack trace should render correctly expa
     <p><span class="m-i18n">Vous pouvez attendre quelques minutes et réessayer.</span></p>
     <p><span class="m-i18n">Si le problème persiste, vous pouvez contacter le soutien technique en leur fournissant le détail de l'erreur.</span></p>
     <div skin="light" icon-size="small"><span class="m-i18n">Détails de l'erreur</span>
-        <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
-        <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
+        <p><strong><span class="m-i18n">Navigateur</span>:
+            </strong>modul-user-agent</p>
+        <p><strong><span class="m-i18n">No référence de l'erreur</span>:
+            </strong>123456879</p>
         <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
-    </div>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
-    </a>
+    </div> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
+    </span>
 </div>
 `;
 
@@ -96,13 +99,14 @@ exports[`MErrorMessage given error with stack trace should render correctly expa
     <p><span class="m-i18n">Vous pouvez attendre quelques minutes et réessayer.</span></p>
     <p><span class="m-i18n">Si le problème persiste, vous pouvez contacter le soutien technique en leur fournissant le détail de l'erreur.</span></p>
     <div skin="light" icon-size="small"><span class="m-i18n">Détails de l'erreur</span>
-        <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
-        <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
+        <p><strong><span class="m-i18n">Navigateur</span>:
+            </strong>modul-user-agent</p>
+        <p><strong><span class="m-i18n">No référence de l'erreur</span>:
+            </strong>123456879</p>
         <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
         <div class="m-error-message__stacktrace"><pre>This is a stack trace</pre></div>
-    </div>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
-    </a>
+    </div> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
+    </span>
 </div>
 `;
 
@@ -125,9 +129,8 @@ exports[`MErrorMessage should render correctly collapsed 1`] = `
     <article class="m-accordion m--is-light m--is-closed m--has-icon-left">
         <div tabindex="0" id="uuid" role="tab" aria-controls="uuid-controls" class="m-accordion__header m--has-padding">
             <div class="m-accordion__header__content"><span class="m-i18n">Détails de l'erreur</span> <span class="m-i18n m-accordion__hidden">m-accordion:open</span> </div> <span aria-hidden="true" class="m-plus m-accordion__header-icon m--is-skin-default m--has-border m--is-left"></span></div>
-    </article>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
-    </a>
+    </article> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
+    </span>
 </div>
 `;
 
@@ -148,11 +151,12 @@ exports[`MErrorMessage should render correctly expanded 1`] = `
     <p><span class="m-i18n">Vous pouvez attendre quelques minutes et réessayer.</span></p>
     <p><span class="m-i18n">Si le problème persiste, vous pouvez contacter le soutien technique en leur fournissant le détail de l'erreur.</span></p>
     <div skin="light" icon-size="small"><span class="m-i18n">Détails de l'erreur</span>
-        <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
-        <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
+        <p><strong><span class="m-i18n">Navigateur</span>:
+            </strong>modul-user-agent</p>
+        <p><strong><span class="m-i18n">No référence de l'erreur</span>:
+            </strong>123456879</p>
         <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
-    </div>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
-    </a>
+    </div> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span>
+    </span>
 </div>
 `;

--- a/src/components/error-message/error-message.html
+++ b/src/components/error-message/error-message.html
@@ -2,18 +2,30 @@
     <m-message state="error">
         <m-i18n k="m-error-message:message"></m-i18n>
     </m-message>
-    <p><m-i18n k="m-error-message:directions.primary"></m-i18n></p>
-    <p><m-i18n k="m-error-message:directions.secondary"></m-i18n></p>
-    <m-accordion skin="light" icon-size="small">
-        <m-i18n slot="header" k="m-error-message:details"></m-i18n>
-        <p><strong><m-i18n k="m-error-message:browser"></m-i18n>: </strong>{{userAgent}}</p>
-        <p v-if="!!referenceNumber"><strong><m-i18n k="m-error-message:reference-number"></m-i18n>: </strong>{{referenceNumber}}</p>
+    <p>
+        <m-i18n k="m-error-message:directions.primary"></m-i18n>
+    </p>
+    <p>
+        <m-i18n k="m-error-message:directions.secondary"></m-i18n>
+    </p>
+    <m-accordion skin="light"
+                 icon-size="small">
+        <m-i18n slot="header"
+                k="m-error-message:details"></m-i18n>
+        <p><strong>
+                <m-i18n k="m-error-message:browser"></m-i18n>:
+            </strong>{{userAgent}}</p>
+        <p v-if="!!referenceNumber"><strong>
+                <m-i18n k="m-error-message:reference-number"></m-i18n>:
+            </strong>{{referenceNumber}}</p>
         <p>{{i18nDate}}</p>
-        <m-panel  class="m-error-message__stacktrace" :padding="false" v-if="propStacktrace">
+        <m-panel class="m-error-message__stacktrace"
+                 :padding="false"
+                 v-if="propStacktrace">
             <pre>{{error.stack}}</pre>
         </m-panel>
     </m-accordion>
-    <m-link mode="link">
+    <m-link>
         <m-i18n k="m-error-message:help"></m-i18n>
     </m-link>
 </div>

--- a/src/components/file-upload/__snapshots__/file-upload.spec.ts.snap
+++ b/src/components/file-upload/__snapshots__/file-upload.spec.ts.snap
@@ -135,7 +135,8 @@ exports[`MFileUpload validation should render accepted file extensions 1`] = `
                     <m-icon name="m-svg__arrow--down" size="32px"></m-icon> <span class="m-i18n">Drop your files here or</span></h3>
                 <m-file-select skin="secondary" multiple="multiple" store-name="DEFAULT" keep-store="true" class="m-file-upload__drop-zone__instructions__button"></m-file-select>
             </div>
-            <p class="m-file-upload__drop-zone__format"><span class="m-i18n m-file-upload__drop-zone__format__label">Accepted formats</span>: jpg, png, mp4</p>
+            <p class="m-file-upload__drop-zone__format"><span class="m-i18n m-file-upload__drop-zone__format__label">Accepted formats</span>: jpg, png, mp4
+            </p>
         </div>
     </div>
     <template>
@@ -197,7 +198,8 @@ exports[`MFileUpload validation validation messages should render rejected files
                     </svg> <span class="m-i18n">Drop your files here or</span></h3>
                 <m-file-select skin="secondary" multiple="multiple" store-name="DEFAULT" keep-store="true" class="m-file-upload__drop-zone__instructions__button"></m-file-select>
             </div>
-            <p class="m-file-upload__drop-zone__format"><span class="m-i18n m-file-upload__drop-zone__format__label">Accepted formats</span>: jpg, png, mp4</p>
+            <p class="m-file-upload__drop-zone__format"><span class="m-i18n m-file-upload__drop-zone__format__label">Accepted formats</span>: jpg, png, mp4
+            </p>
         </div>
     </div>
     <template>

--- a/src/components/file-upload/file-upload.html
+++ b/src/components/file-upload/file-upload.html
@@ -1,97 +1,163 @@
-<m-modal :title="title" ref="modal" :open.sync="propOpen" @open="onOpen" @close="onClose" @portal-content-visible="onPortalContentVisible" :close-on-backdrop="false" :padding-body="false">
+<m-modal :title="title"
+         ref="modal"
+         :open.sync="propOpen"
+         @open="onOpen"
+         @close="onClose"
+         @portal-content-visible="onPortalContentVisible"
+         :close-on-backdrop="false"
+         :padding-body="false">
 
     <span slot="trigger">
         <slot></slot>
     </span>
 
-    <div class="m-file-upload" v-m-file-drop.keep-store="storeName">
+    <div class="m-file-upload"
+         v-m-file-drop.keep-store="storeName">
 
-        <m-message class="m-file-upload__error-message" state="error" v-if="hasRejectedFiles" :close-button="true" @close="onMessageClose">
+        <m-message class="m-file-upload__error-message"
+                   state="error"
+                   v-if="hasRejectedFiles"
+                   :close-button="true"
+                   @close="onMessageClose">
             <p class="m-file-upload__error-message__title">
-                <m-i18n :nb="rejectedFiles.length" k="m-file-upload:rejectFileMsg"></m-i18n>
+                <m-i18n :nb="rejectedFiles.length"
+                        k="m-file-upload:rejectFileMsg"></m-i18n>
             </p>
             <ul class="m-file-upload__error-message__list">
-                <li v-for="file in rejectedFiles" :key="file.uid">
+                <li v-for="file in rejectedFiles"
+                    :key="file.uid">
                     <p class="m-file-upload__error-message__file-name">{{file.name}}</p>
-                    <p class="m-file-upload__error-message__error" v-if="hasExtensionsRejection(file)">
+                    <p class="m-file-upload__error-message__error"
+                       v-if="hasExtensionsRejection(file)">
                         <m-i18n k="m-file-upload:extensionFileMsg"></m-i18n>
                     </p>
-                    <p class="m-file-upload__error-message__error" v-else-if="hasSizeRejection(file)">
+                    <p class="m-file-upload__error-message__error"
+                       v-else-if="hasSizeRejection(file)">
                         <m-i18n k="m-file-upload:maxSizeMsg"></m-i18n> ({{maxSizeKb * 1024 | f-m-filesize}}).
                     </p>
-                    <p class="m-file-upload__error-message__error" v-else-if="hasMaxFilesRejection(file)">
+                    <p class="m-file-upload__error-message__error"
+                       v-else-if="hasMaxFilesRejection(file)">
                         <m-i18n k="m-file-upload:maxNumberMsg"></m-i18n> ({{propMaxFiles}}
-                        <m-i18n :nb="propMaxFiles" k="m-file-upload:file"></m-i18n>)
+                        <m-i18n :nb="propMaxFiles"
+                                k="m-file-upload:file"></m-i18n>)
                     </p>
                 </li>
             </ul>
         </m-message>
 
-        <div class="m-file-upload__drop-zone" v-if="isDropZoneEnabled">
+        <div class="m-file-upload__drop-zone"
+             v-if="isDropZoneEnabled">
             <div class="m-file-upload__drop-zone__instructions">
                 <h3 class="m-file-upload__drop-zone__instructions__title">
-                    <m-icon name="m-svg__arrow--down" size="32px"></m-icon>
-                    <m-i18n k="m-file-upload:title" :nb="propMaxFiles"></m-i18n>
+                    <m-icon name="m-svg__arrow--down"
+                            size="32px"></m-icon>
+                    <m-i18n k="m-file-upload:title"
+                            :nb="propMaxFiles"></m-i18n>
                 </h3>
-                <m-file-select class="m-file-upload__drop-zone__instructions__button" skin="secondary" :multiple="multipleSelection" :store-name="storeName"
-                    keep-store="true"></m-file-select>
+                <m-file-select class="m-file-upload__drop-zone__instructions__button"
+                               skin="secondary"
+                               :multiple="multipleSelection"
+                               :store-name="storeName"
+                               keep-store="true"></m-file-select>
             </div>
-            <p class="m-file-upload__drop-zone__format" v-if="hasAllowedExtensions">
-                <m-i18n class="m-file-upload__drop-zone__format__label" k="m-file-upload:format" :nb="allowedExtensions.length"></m-i18n>: {{fileAllowedExtensions}}</p>
+            <p class="m-file-upload__drop-zone__format"
+               v-if="hasAllowedExtensions">
+                <m-i18n class="m-file-upload__drop-zone__format__label"
+                        k="m-file-upload:format"
+                        :nb="allowedExtensions.length"></m-i18n>: {{fileAllowedExtensions}}
+            </p>
         </div>
-        <div class="m-file-upload__no-drop-zone" v-else>
-            <m-file-select class="m-file-upload__no-drop-zone__instructions__button" skin="primary" :multiple="maxFiles > 1 ? true : false" :store-name="storeName"
-                keep-store="true"></m-file-select>
-            <p class="m-file-upload__no-drop-zone__format" v-if="hasAllowedExtensions">
-                <m-i18n class="m-file-upload__no-drop-zone__format__label" k="m-file-upload:format" :nb="allowedExtensions.length"></m-i18n>: {{fileAllowedExtensions}}</p>
+        <div class="m-file-upload__no-drop-zone"
+             v-else>
+            <m-file-select class="m-file-upload__no-drop-zone__instructions__button"
+                           skin="primary"
+                           :multiple="maxFiles > 1 ? true : false"
+                           :store-name="storeName"
+                           keep-store="true"></m-file-select>
+            <p class="m-file-upload__no-drop-zone__format"
+               v-if="hasAllowedExtensions">
+                <m-i18n class="m-file-upload__no-drop-zone__format__label"
+                        k="m-file-upload:format"
+                        :nb="allowedExtensions.length"></m-i18n>: {{fileAllowedExtensions}}
+            </p>
         </div>
 
-        <h3 class="m-file-upload__title" v-if="!hasUploadingFiles">
+        <h3 class="m-file-upload__title"
+            v-if="!hasUploadingFiles">
             <m-i18n k="m-file-upload:import"></m-i18n> ({{uploadingFiles.length}}
-            <m-i18n :nb="uploadingFiles.length" k="m-file-upload:file"></m-i18n>)
+            <m-i18n :nb="uploadingFiles.length"
+                    k="m-file-upload:file"></m-i18n>)
         </h3>
 
-        <div class="m-file-upload__import-list" v-if="!hasUploadingFiles">
-            <transition-group class="m-file-upload__import-list__wrap" name="m--is" tag="ul">
-                <li v-for="(file, index) in uploadingFiles" :key="file.uid">
+        <div class="m-file-upload__import-list"
+             v-if="!hasUploadingFiles">
+            <transition-group class="m-file-upload__import-list__wrap"
+                              name="m--is"
+                              tag="ul">
+                <li v-for="(file, index) in uploadingFiles"
+                    :key="file.uid">
                     <div class="m-file-upload__import-list__content">
                         <div class="m-file-upload__import-list__file-icon">
-                            <m-icon-file v-m-badge="{ state: getBadgeState(file) }" :extension="file.extension" size="30px"></m-icon-file>
+                            <m-icon-file v-m-badge="{ state: getBadgeState(file) }"
+                                         :extension="file.extension"
+                                         size="30px"></m-icon-file>
                         </div>
                         <div class="m-file-upload__import-list__progress-wrap">
                             <div class="m-file-upload__import-list__infos">
                                 <p class="m-file-upload__import-list__name">{{file.name}}</p>
                                 <p class="m-file-upload__import-list__size">{{file.file.size | f-m-filesize}}</p>
                             </div>
-                            <m-progress :value="file.progress" :state="getFileStatus(file)"></m-progress>
-                            <p class="m-file-upload__import-list__error-message" v-if="getFileStatus(file) === 'error'">
+                            <m-progress :value="file.progress"
+                                        :state="getFileStatus(file)"></m-progress>
+                            <p class="m-file-upload__import-list__error-message"
+                               v-if="getFileStatus(file) === 'error'">
                                 <m-i18n k="m-file-upload:errorMsg"></m-i18n>
                             </p>
                         </div>
                         <div class="m-file-upload__import-list__delete">
-                            <m-icon-button class="m-file-upload__import-list__button" :title="tooltipCancel" icon-name="m-svg__close-clear" button-size="32px" icon-size="12px" @click="onUploadCancel(file)"></m-icon-button>
+                            <m-icon-button class="m-file-upload__import-list__button"
+                                           :title="tooltipCancel"
+                                           icon-name="m-svg__close-clear"
+                                           button-size="32px"
+                                           icon-size="12px"
+                                           @click="onUploadCancel(file)"></m-icon-button>
                         </div>
                     </div>
                 </li>
             </transition-group>
         </div>
 
-        <div class="m-file-upload__completed-list" v-if="!hasCompletedFiles" :class="{ 'm--has-border': !hasUploadingFiles }">
-            <transition-group class="m-file-upload__completed-list__wrap" name="m--is" tag="ul">
-                <li v-for="(file, index) in completedFiles" :key="file.uid">
+        <div class="m-file-upload__completed-list"
+             v-if="!hasCompletedFiles"
+             :class="{ 'm--has-border': !hasUploadingFiles }">
+            <transition-group class="m-file-upload__completed-list__wrap"
+                              name="m--is"
+                              tag="ul">
+                <li v-for="(file, index) in completedFiles"
+                    :key="file.uid">
                     <div class="m-file-upload__completed-list__content">
                         <div class="m-file-upload__completed-list__file-icon">
-                            <m-icon-file v-m-badge="{ state: getBadgeState(file) }" :extension="file.extension" size="30px"></m-icon-file>
+                            <m-icon-file v-m-badge="{ state: getBadgeState(file) }"
+                                         :extension="file.extension"
+                                         size="30px"></m-icon-file>
                         </div>
                         <div class="m-file-upload__completed-list__infos">
                             <p class="m-file-upload__completed-list__infos-label">
-                                <m-link :url="file.url" mode="link" target="_blank" v-if="file.url">{{file.name}}</m-link>
+                                <m-link :url="file.url"
+                                        :extern="true"
+                                        target="_blank"
+                                        v-if="file.url">{{file.name}}</m-link>
                                 <template v-else>{{file.name}}</template>
                             </p>
                             <p class="m-file-upload__completed-list__infos-size">{{file.file.size | f-m-filesize}}</p>
                         </div>
                         <div class="m-file-upload__completed-list__delete">
-                            <m-icon-button class="m-file-upload__completed-list__button" :title="tooltipDelete" icon-name="m-svg__delete" button-size="32px" icon-size="20px" @click="onFileRemove(file)"></m-icon-button>
+                            <m-icon-button class="m-file-upload__completed-list__button"
+                                           :title="tooltipDelete"
+                                           icon-name="m-svg__delete"
+                                           button-size="32px"
+                                           icon-size="20px"
+                                           @click="onFileRemove(file)"></m-icon-button>
                         </div>
                     </div>
                 </li>
@@ -101,12 +167,18 @@
     </div>
     <template slot="footer">
         <div :style="buttonCompletedStyle">
-            <m-button @click="onAddClick" :disabled="!isAddBtnEnabled" class="m-file-upload__footer-add">{{ buttonAdd }}
-                <span slot="precision" v-show="completedFiles.length > 0">{{completedFiles.length}}
-                    <m-i18n :nb="completedFiles.length" k="m-file-upload:file"></m-i18n>
+            <m-button @click="onAddClick"
+                      :disabled="!isAddBtnEnabled"
+                      class="m-file-upload__footer-add">{{ buttonAdd }}
+                <span slot="precision"
+                      v-show="completedFiles.length > 0">{{completedFiles.length}}
+                    <m-i18n :nb="completedFiles.length"
+                            k="m-file-upload:file"></m-i18n>
                 </span>
             </m-button>
-            <m-button @click="onCancelClick" skin="secondary" class="m-file-upload__footer-cancel">
+            <m-button @click="onCancelClick"
+                      skin="secondary"
+                      class="m-file-upload__footer-cancel">
                 <m-i18n k="m-file-upload:cancel"></m-i18n>
             </m-button>
         </div>

--- a/src/components/limit-text/limit-text.ts
+++ b/src/components/limit-text/limit-text.ts
@@ -1,7 +1,6 @@
-import Vue, { PluginObject } from 'vue';
+import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { MediaQueries } from '../../mixins/media-queries/media-queries';
 import MediaQueriesPlugin from '../../utils/media-queries/media-queries';
@@ -10,6 +9,7 @@ import { LIMIT_TEXT_NAME } from '../component-names';
 import I18nPlugin from '../i18n/i18n';
 import LinkPlugin from '../link/link';
 import WithRender from './limit-text.html?style=./limit-text.scss';
+
 
 @WithRender
 @Component({
@@ -83,7 +83,7 @@ export class MLimitText extends ModulVue {
             // Generate the full content - Add the close link if an HTML tag is present
             if (this.testingContent.match('</')) {
                 let tagIndex: number = this.testingContent.lastIndexOf('</');
-                this.fullContent = this.testingContent.substring(0,tagIndex) + this.closeLink + this.testingContent.substring(tagIndex);
+                this.fullContent = this.testingContent.substring(0, tagIndex) + this.closeLink + this.testingContent.substring(tagIndex);
             } else {
                 this.fullContent = this.testingContent + this.closeLink;
             }
@@ -182,18 +182,18 @@ export class MLimitText extends ModulVue {
     }
 
     private get openLinkOriginal(): string {
-        return this.openLabel ? `...&nbsp;<m-link style="font-weight:400;" mode="button" title="` + this.getOpenLabelTitle + `" hiddenText="` + this.getOpenLabelTitle + `" :underline="false">[` + this.openLabel.replace(/\s/g, '\xa0') + `]</m-link>` :
-                                `...&nbsp;<m-link style="font-weight:400;" mode="button" title="` + this.getOpenLabelTitle + `" hiddenText="` + this.getOpenLabelTitle + `" :underline="false">[` + '\xa0+\xa0' + `]</m-link>`;
+        return this.openLabel ? `...&nbsp;<m-link style="font-weight:400;" title="` + this.getOpenLabelTitle + `" hiddenText="` + this.getOpenLabelTitle + `" :underline="false">[` + this.openLabel.replace(/\s/g, '\xa0') + `]</m-link>` :
+            `...&nbsp;<m-link style="font-weight:400;" title="` + this.getOpenLabelTitle + `" hiddenText="` + this.getOpenLabelTitle + `" :underline="false">[` + '\xa0+\xa0' + `]</m-link>`;
     }
 
     private get openLink(): string {
-        return this.openLabel ? `...&nbsp;<m-link mode="button" title="` + this.openLabel.replace(/\s/g, '\xa0') + `" hiddenText="` + this.openLabel.replace(/\s/g, '\xa0') + `" :underline="false">[` + this.openLabel.replace(/\s/g, '\xa0') + `]</m-link>` :
-                                `...&nbsp;<m-link mode="button" title="` + this.$i18n.translate('m-limit-text:open') + `" hiddenText="` + this.$i18n.translate('m-limit-text:open') + `" :underline="false">[` + '\xa0+\xa0' + `]</m-link>`;
+        return this.openLabel ? `...&nbsp;<m-link title="` + this.openLabel.replace(/\s/g, '\xa0') + `" hiddenText="` + this.openLabel.replace(/\s/g, '\xa0') + `" :underline="false">[` + this.openLabel.replace(/\s/g, '\xa0') + `]</m-link>` :
+            `...&nbsp;<m-link title="` + this.$i18n.translate('m-limit-text:open') + `" hiddenText="` + this.$i18n.translate('m-limit-text:open') + `" :underline="false">[` + '\xa0+\xa0' + `]</m-link>`;
     }
 
     private get closeLink(): string {
-        return this.closeLabel ? `<m-link mode="button" title="` + this.getCloseLabelTitle + `" hiddenText="` + this.getCloseLabelTitle + `" :underline="false">[` + this.closeLabel.replace(/\s/g, '\xa0') + `]</m-link>` :
-                                 `<m-link mode="button" title="` + this.getCloseLabelTitle + `" hiddenText="` + this.getCloseLabelTitle + `" :underline="false">[` + '\xa0-\xa0' + `]</m-link>`;
+        return this.closeLabel ? `<m-link title="` + this.getCloseLabelTitle + `" hiddenText="` + this.getCloseLabelTitle + `" :underline="false">[` + this.closeLabel.replace(/\s/g, '\xa0') + `]</m-link>` :
+            `<m-link title="` + this.getCloseLabelTitle + `" hiddenText="` + this.getCloseLabelTitle + `" :underline="false">[` + '\xa0-\xa0' + `]</m-link>`;
     }
 
     private get getOpenLabelTitle(): string {

--- a/src/components/link/__snapshots__/link.spec.ts.snap
+++ b/src/components/link/__snapshots__/link.spec.ts.snap
@@ -1,91 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MLink Button mode should render correctly 1`] = `<a href="#" tabindex="1" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link use as button should render correctly 1`] = `<span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"></span> </span>`;
 
-exports[`MLink Link mode should render content correctly 1`] = `<a href="/" tabindex="1" class="m-link"> <span class="m-link__text">Link</span> </a>`;
+exports[`MLink Link using RouterLink should pass route values to router-link using url prop 1`] = `<a tabindex="0" class="m-link"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink Link mode should render correctly 1`] = `<a href="/" tabindex="1" class="m-link"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link using RouterLink should render content correctly 1`] = `<a tabindex="0" class="m-link router-link-active"> <span class="m-link__text">Link</span> </a>`;
 
-exports[`MLink Link mode should render correctly all icon style: left 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-left-icon">
+exports[`MLink Link using RouterLink should render correctly 1`] = `<a tabindex="0" class="m-link router-link-active"> <span class="m-link__text"></span> </a>`;
+
+exports[`MLink Link using RouterLink should render correctly all icon style: left 1`] = `
+<a tabindex="0" class="m-link router-link-active m--has-left-icon">
     <svg aria-hidden="true" width="12px" height="12px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink Link mode should render correctly all icon style: name 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-left-icon">
+exports[`MLink Link using RouterLink should render correctly all icon style: name 1`] = `
+<a tabindex="0" class="m-link router-link-active m--has-left-icon">
     <svg aria-hidden="true" width="12px" height="12px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink Link mode should render correctly all icon style: right 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-right-icon">
+exports[`MLink Link using RouterLink should render correctly all icon style: right 1`] = `
+<a tabindex="0" class="m-link router-link-active m--has-right-icon">
     <svg aria-hidden="true" width="12px" height="12px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink Link mode should render correctly all icon style: size 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-left-icon">
+exports[`MLink Link using RouterLink should render correctly all icon style: size 1`] = `
+<a tabindex="0" class="m-link router-link-active m--has-left-icon">
     <svg aria-hidden="true" width="24px" height="24px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink Link mode should render correctly all link status: disabled 1`] = `<a tabindex="-1" class="m-link m--is-disabled"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link using RouterLink should render correctly all link status: disabled 1`] = `<span role="button" tabindex="-1" class="m-link m--is-unvisited m--is-disabled m--is-button"> <span class="m-link__text"></span> </span>`;
 
-exports[`MLink Link mode should render correctly all link status: underline 1`] = `<a href="/" tabindex="1" class="m-link m--no-underline"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link using RouterLink should render correctly all link status: underline 1`] = `<span role="button" tabindex="0" class="m-link m--is-unvisited m--no-underline m--is-button"> <span class="m-link__text"></span> </span>`;
 
-exports[`MLink Link mode should render correctly all link status: unvisited 1`] = `<a href="/" tabindex="1" class="m-link m--is-unvisited"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link using RouterLink should render correctly all link status: unvisited 1`] = `<span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text"></span> </span>`;
 
-exports[`MLink Link mode should render link target when prop is set 1`] = `<a href="/" target="_self" tabindex="1" class="m-link"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link using RouterLink should render correctly when url prop is a string 1`] = `<a tabindex="0" class="m-link"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink Link mode should render open in new tab hidden text when target is _blank 1`] = `<a href="/" target="_blank" tabindex="1" class="m-link"> <span class="m-link__text"></span> <span class="m-i18n m-link__hidden">This hyperlink will open in a new tab.</span></a>`;
+exports[`MLink Link using RouterLink should render link target when prop is set 1`] = `<a target="_self" tabindex="0" class="m-link router-link-active"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink RouterLink mode should pass route values to router-link using url prop 1`] = `<a href="/named/123" tabindex="1" class="m-link"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link using RouterLink should render open in new tab hidden text when target is _blank 1`] = `<a target="_blank" tabindex="0" class="m-link router-link-active"> <span class="m-link__text"></span> <span class="m-i18n m-link__hidden">This hyperlink will open in a new tab.</span></a>`;
 
-exports[`MLink RouterLink mode should render content correctly 1`] = `<a href="/" tabindex="1" class="m-link router-link-active"> <span class="m-link__text">Link</span> </a>`;
+exports[`MLink Link with extern prop should render content correctly 1`] = `<a href="/" tabindex="0" class="m-link"> <span class="m-link__text">Link</span> </a>`;
 
-exports[`MLink RouterLink mode should render correctly 1`] = `<a href="/" tabindex="1" class="m-link router-link-active"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link with extern prop should render correctly 1`] = `<a href="/" tabindex="0" class="m-link"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink RouterLink mode should render correctly all icon style: left 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-left-icon">
+exports[`MLink Link with extern prop should render correctly all icon style: left 1`] = `
+<a href="/" tabindex="0" class="m-link m--has-left-icon">
     <svg aria-hidden="true" width="12px" height="12px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink RouterLink mode should render correctly all icon style: name 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-left-icon">
+exports[`MLink Link with extern prop should render correctly all icon style: name 1`] = `
+<a href="/" tabindex="0" class="m-link m--has-left-icon">
     <svg aria-hidden="true" width="12px" height="12px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink RouterLink mode should render correctly all icon style: right 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-right-icon">
+exports[`MLink Link with extern prop should render correctly all icon style: right 1`] = `
+<a href="/" tabindex="0" class="m-link m--has-right-icon">
     <svg aria-hidden="true" width="12px" height="12px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink RouterLink mode should render correctly all icon style: size 1`] = `
-<a href="/" tabindex="1" class="m-link m--has-left-icon">
+exports[`MLink Link with extern prop should render correctly all icon style: size 1`] = `
+<a href="/" tabindex="0" class="m-link m--has-left-icon">
     <svg aria-hidden="true" width="24px" height="24px" class="m-icon m-link__icon">
         <use aria-hidden="true"></use>
     </svg> <span class="m-link__text"></span> </a>
 `;
 
-exports[`MLink RouterLink mode should render correctly all link status: disabled 1`] = `<a href="/" tabindex="-1" class="m-link router-link-active m--is-disabled"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link with extern prop should render correctly all link status: disabled 1`] = `<span role="button" tabindex="-1" class="m-link m--is-unvisited m--is-disabled m--is-button"> <span class="m-link__text"></span> </span>`;
 
-exports[`MLink RouterLink mode should render correctly all link status: underline 1`] = `<a href="/" tabindex="1" class="m-link router-link-active m--no-underline"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link with extern prop should render correctly all link status: underline 1`] = `<a href="/" tabindex="0" class="m-link m--no-underline"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink RouterLink mode should render correctly all link status: unvisited 1`] = `<a href="/" tabindex="1" class="m-link router-link-active m--is-unvisited"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link with extern prop should render correctly all link status: unvisited 1`] = `<a href="/" tabindex="0" class="m-link m--is-unvisited"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink RouterLink mode should render correctly when url prop is a string 1`] = `<a href="/test" tabindex="1" class="m-link"> <span class="m-link__text"></span> </a>`;
+exports[`MLink Link with extern prop should render link target when prop is set 1`] = `<a href="/" target="_self" tabindex="0" class="m-link"> <span class="m-link__text"></span> </a>`;
 
-exports[`MLink RouterLink mode should render link target when prop is set 1`] = `<a href="/" target="_self" tabindex="1" class="m-link router-link-active"> <span class="m-link__text"></span> </a>`;
-
-exports[`MLink RouterLink mode should render open in new tab hidden text when target is _blank 1`] = `<a href="/" target="_blank" tabindex="1" class="m-link router-link-active"> <span class="m-link__text"></span> <span class="m-i18n m-link__hidden">This hyperlink will open in a new tab.</span></a>`;
+exports[`MLink Link with extern prop should render open in new tab hidden text when target is _blank 1`] = `<a href="/" target="_blank" tabindex="0" class="m-link"> <span class="m-link__text"></span> <span class="m-i18n m-link__hidden">This hyperlink will open in a new tab.</span></a>`;

--- a/src/components/link/link.html
+++ b/src/components/link/link.html
@@ -1,25 +1,5 @@
-<transition :css="false">
-    <router-link class="m-link"
-                 :class="{ 'm--is-unvisited': isUnvisited,
-                           'm--is-disabled': disabled,
-                           'm--no-underline': !underline,
-                           'm--is-skin-text': isSkinText,
-                           'm--is-skin-light': isSkinLight,
-                           'm--has-right-icon' : isIconPositionRight,
-                           'm--has-left-icon' : isIconPositionLeft }"
-                 :to="routerLinkUrl"
-                 :target="target"
-                 v-if="isRouterLink"
-                 :tabindex="disabled ? '-1' : tabindex"
-                 ref="router">
-        <m-icon :name="propIconName" :size="iconSize" class="m-link__icon" v-if="hasIcon" aria-hidden="true"></m-icon>
-        <span class="m-link__text">
-            <slot></slot>
-        </span>
-        <m-i18n class="m-link__hidden" v-if="isTargetBlank" k="m-link:open-new-tab"></m-i18n>
-    </router-link>
-    <a class="m-link"
-       :class="{ 'm--is-unvisited': isUnvisited,
+<component class="m-link"
+           :class="{ 'm--is-unvisited': isUnvisited,
                  'm--is-disabled': disabled,
                  'm--no-underline': !underline,
                  'm--is-button': isButton,
@@ -27,17 +7,25 @@
                  'm--is-skin-light': isSkinLight,
                  'm--has-right-icon' : isIconPositionRight,
                  'm--has-left-icon' : isIconPositionLeft }"
-       :href="propUrl"
-       :target="target"
-       @click="onClick"
-       v-if="!isRouterLink"
-       @keyup="onKeyup"
-       :tabindex="disabled ? '-1' : tabindex"
-       ref="link">
-        <m-icon class="m-link__icon" :name="propIconName" :size="iconSize" v-if="hasIcon" aria-hidden="true"></m-icon>
-        <span class="m-link__text">
-            <slot></slot>
-        </span>
-        <m-i18n class="m-link__hidden" v-if="isTargetBlank" k="m-link:open-new-tab"></m-i18n>
-    </a>
-</transition>
+           :is="componentToShow"
+           :href="href"
+           :to="routerLinkUrl"
+           :target="target"
+           :role="buttonRole"
+           @click="onClick"
+           @keyup.enter="onClick"
+           @keyup.space="onClick"
+           :tabindex="propTabindex"
+           ref="link">
+    <m-icon class="m-link__icon"
+            :name="propIconName"
+            :size="iconSize"
+            v-if="hasIcon"
+            aria-hidden="true"></m-icon>
+    <span class="m-link__text">
+        <slot></slot>
+    </span>
+    <m-i18n class="m-link__hidden"
+            v-if="isTargetBlank"
+            k="m-link:open-new-tab"></m-i18n>
+</component>

--- a/src/components/link/link.sandbox.html
+++ b/src/components/link/link.sandbox.html
@@ -1,34 +1,145 @@
-<div>
-    <h2>Utilisation du composant m-link</h2>
-    <p><m-link>Bonjour</m-link></p>
-
-    <h2>Icon name "m-svg__clock"</h2>
-    <p><m-link icon-name="m-svg__clock">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eius reiciendis tempore modi rerum beatae. Placeat nam iure cupiditate ipsum non ipsa! Sequi enim ab, est tenetur a aliquam officiis cupiditate!</m-link></p>
-
-    <p><m-link icon-name="m-svg__clock" :disabled="true">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eius reiciendis tempore modi rerum beatae. Placeat nam iure cupiditate ipsum non ipsa! Sequi enim ab, est tenetur a aliquam officiis cupiditate!</m-link></p>
-
-    <h2>Skin text</h2>
-    <p><m-link skin="text" icon-name="m-svg__clock">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eius reiciendis tempore modi rerum beatae. Placeat nam iure cupiditate ipsum non ipsa! Sequi enim ab, est tenetur a aliquam officiis cupiditate!</m-link></p>
-    <div class="m-u--margin-top--l" style="background: grey; padding: 16px;">
-        <h2 class="m-u--no-margin">Skin light</h2>
-        <p><m-link skin="light" icon-name="m-svg__clock">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eius reiciendis tempore modi rerum beatae. Placeat nam iure cupiditate ipsum non ipsa! Sequi enim ab, est tenetur a aliquam officiis cupiditate!</m-link></p>
-    </div>
-    <h2>Utilisation de la classe .m-u--link</h2>
+<div class="m-link-sandbox">
+    <h2>Default link</h2>
     <p>
-        <a href="#" class="m-u--link">
-            <span class="m-u--link-text">Lien (.m-u--link)</span>
+        <m-link>I am default m-link</m-link>
+    </p>
+
+    <h2>Link use as button</h2>
+    <p>
+        <m-link @click="openWindow01 = true">Open window</m-link>
+    </p>
+    <m-dialog :open.sync="openWindow01">
+        <p>Do you want to close the window?</p>
+    </m-dialog>
+
+    <h2>Link use as router-link</h2>
+    <p>
+        <m-link url="/">Home page</m-link>
+    </p>
+    <p>
+        <m-link url="m-button">m-button sandbox</m-link>
+    </p>
+    <p>
+        <m-link url="/components/m-dialog">m-dialog sandbox</m-link>
+    </p>
+    <h3 class="m-u--h5">Link with prop unvisited = true</h3>
+    <p>
+        <m-link url="/"
+                :unvisited="true">Home page</m-link>
+    </p>
+    <h3 class="m-u--h5">Link with prop underline = false</h3>
+    <p>
+        <m-link url="/"
+                :underline="false">Home page</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Link with prop disabled = true</h3>
+    <p>
+        <m-link url="/"
+                :disabled="true">Home page</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Open link in new tab</h3>
+    <p>Use <strong>target="_blank"</strong></p>
+    <p>
+        <m-link url="/"
+                target="_blank">Home page</m-link>
+    </p>
+
+
+    <h2>Link with prop <strong>extern: <i>boolean</i></strong></h2>
+    <h3 class="m-u--h5 m-u--margin-top--s">Link use whitout router-link</h3>
+    <p>When <strong>extern = true</strong>, the page will be reloaded after each navigation.</p>
+    <p>
+        <m-link url="/"
+                :extern="true">Home page</m-link>
+    </p>
+    <p>
+        <m-link url="m-button"
+                :extern="true">m-button sandbox</m-link>
+    </p>
+    <p>
+        <m-link url="https://www.google.ca/"
+                :extern="true">Google</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Never use external link width prop extern = false</h3>
+    <p>
+        <m-link url="https://www.google.ca/">Google (this link will not work)</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Open link in new tab</h3>
+    <p>Use <strong>target="_blank"</strong></p>
+    <p>
+        <m-link url="https://www.google.ca/"
+                :extern="true"
+                target="_blank">Google</m-link>
+    </p>
+
+    <h2>Link with a icon</h2>
+
+    <h3 class="m-u--h5">Link use with <strong>icon-name = "m-svg__clock"</strong></h3>
+    <p>
+        <m-link icon-name="m-svg__clock"
+                url="m-timepicker">m-timepicker sandbox</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Link use with <strong>icon-position = "right"</strong></h3>
+    <p>
+        <m-link icon-name="m-svg__clock"
+                icon-position="right"
+                url="m-timepicker">m-timepicker sandbox</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Link use with <strong>icon = "true"</strong></h3>
+    <p>
+        <m-link icon="true">Link with icon="true"</m-link>
+    </p>
+
+    <h3 class="m-u--h5">Link use with <strong>icon-size = "24px"</strong></h3>
+    <p>
+        <m-link icon-name="m-svg__clock"
+                icon-size="24px">Link with icon-size="24px"</m-link>
+
+    </p>
+
+    <h2>Link use with skin prop</h2>
+    <h3 class="m-u--h5 m-u--margin-top--s">skin = "default"</strong></h3>
+    <p>
+        <m-link skin="default">I am a link with default skin</m-link>
+    </p>
+
+    <h3 class="m-u--h5">skin = "text"</strong></h3>
+    <p>
+        <m-link skin="text">I am a link with text skin</m-link>
+    </p>
+
+    <h3 class="m-u--h5 ">skin = "light"</h3>
+    <p style="background: black; padding: 16px;">
+        <m-link skin="light">I am a link with light skin</m-link>
+    </p>
+
+    <h2>Using the class .m-u--link</h2>
+    <p>
+        <a href="#"
+           class="m-u--link">
+            <span class="m-u--link-text">Link (.m-u--link)</span>
         </a>
     </p>
     <p>
-        <a href="#" class="m-u--link">
-            <m-icon class="m-u--link-icon-left" name="m-svg__clock"></m-icon>
-            <span class="m-u--link-text">Icône à gauche (.m-u--link-icon-left)</span>
+        <a href="#"
+           class="m-u--link">
+            <m-icon class="m-u--link-icon-left"
+                    name="m-svg__clock"></m-icon>
+            <span class="m-u--link-text">Link width icon on the left (.m-u--link-icon-left)</span>
         </a>
     </p>
     <p>
-        <a href="#" class="m-u--link">
-            <span class="m-u--link-text">Icône à droite (.m-u--link-icon-right)</span>
-            <m-icon class="m-u--link-icon-right" name="m-svg__clock"></m-icon>
+        <a href="#"
+           class="m-u--link">
+            <span class="m-u--link-text">Link width icon on the right (.m-u--link-icon-right)</span>
+            <m-icon class="m-u--link-icon-right"
+                    name="m-svg__clock"></m-icon>
         </a>
     </p>
 </div>

--- a/src/components/link/link.sandbox.ts
+++ b/src/components/link/link.sandbox.ts
@@ -1,12 +1,13 @@
-import Vue, { PluginObject } from 'vue';
+import { PluginObject } from 'vue';
 import { Component } from 'vue-property-decorator';
-
+import { ModulVue } from '../../utils/vue/vue';
 import { LINK_NAME } from '../component-names';
 import WithRender from './link.sandbox.html';
 
 @WithRender
 @Component
-export class MLinkSandbox extends Vue {
+export class MLinkSandbox extends ModulVue {
+    private openWindow01: boolean = false;
 }
 
 const LinkSandboxPlugin: PluginObject<any> = {

--- a/src/components/link/link.scss
+++ b/src/components/link/link.scss
@@ -34,6 +34,8 @@
     }
 
     &:not(.m--is-disabled) {
+        cursor: pointer;
+
         &:not(.m--no-underline) {
             &:hover,
             &:focus {

--- a/src/components/link/link.spec.ts
+++ b/src/components/link/link.spec.ts
@@ -1,10 +1,10 @@
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vue, { VueConstructor } from 'vue';
 import VueRouter from 'vue-router';
-
 import { addMessages } from '../../../tests/helpers/lang';
 import { renderComponent } from '../../../tests/helpers/render';
-import LinkPlugin, { MLink, MLinkIconPosition, MLinkMode } from './link';
+import LinkPlugin, { MLink, MLinkIconPosition } from './link';
+
 
 describe('MLink', () => {
     let localVue: VueConstructor<Vue>;
@@ -26,13 +26,13 @@ describe('MLink', () => {
         addMessages(localVue, ['components/link/link.lang.en.json']);
     });
 
-    describe('RouterLink mode', () => {
+    describe('Link using RouterLink', () => {
         it('should render correctly', () => {
             const link: Wrapper<MLink> = mount(MLink, {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.RouterLink
+                    url: '/'
                 }
             });
 
@@ -44,7 +44,7 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.RouterLink
+                    url: '/'
                 },
                 slots: {
                     default: 'Link'
@@ -59,8 +59,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.RouterLink,
-                    target: '_self'
+                    target: '_self',
+                    url: '/'
                 }
             });
 
@@ -72,8 +72,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.RouterLink,
-                    target: '_blank'
+                    target: '_blank',
+                    url: '/'
                 }
             });
 
@@ -85,7 +85,6 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.RouterLink,
                     url: '/test'
                 }
             });
@@ -98,7 +97,6 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.RouterLink,
                     url: { name: 'named', params: { paramId: 123 } }
                 }
             });
@@ -109,10 +107,7 @@ describe('MLink', () => {
         it('should render correctly all link status', async () => {
             const link: Wrapper<MLink> = mount(MLink, {
                 router: router,
-                localVue: localVue,
-                propsData: {
-                    mode: MLinkMode.RouterLink
-                }
+                localVue: localVue
             });
 
             await renderAllLinkStyles(link);
@@ -123,7 +118,7 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link,
+                    url: '/',
                     icon: true
                 }
             });
@@ -132,13 +127,14 @@ describe('MLink', () => {
         });
     });
 
-    describe('Link mode', () => {
+    describe('Link with extern prop', () => {
         it('should render correctly', () => {
             const link: Wrapper<MLink> = mount(MLink, {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link
+                    extern: true,
+                    url: '/'
                 }
             });
 
@@ -150,7 +146,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link,
+                    extern: true,
+                    url: '/',
                     target: '_self'
                 }
             });
@@ -163,7 +160,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link,
+                    extern: true,
+                    url: '/',
                     target: '_blank'
                 }
             });
@@ -176,7 +174,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link
+                    extern: true,
+                    url: '/'
                 },
                 slots: {
                     default: 'Link'
@@ -191,7 +190,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link
+                    extern: true,
+                    url: '/'
                 }
             });
 
@@ -203,7 +203,8 @@ describe('MLink', () => {
                 router: router,
                 localVue: localVue,
                 propsData: {
-                    mode: MLinkMode.Link,
+                    extern: true,
+                    url: '/',
                     icon: true
                 }
             });
@@ -212,14 +213,11 @@ describe('MLink', () => {
         });
     });
 
-    describe('Button mode', () => {
+    describe('Link use as button', () => {
         it('should render correctly', () => {
             const link: Wrapper<MLink> = mount(MLink, {
                 router: router,
-                localVue: localVue,
-                propsData: {
-                    mode: MLinkMode.Button
-                }
+                localVue: localVue
             });
 
             return expect(renderComponent(link.vm)).resolves.toMatchSnapshot();

--- a/src/components/message-page/__snapshots__/message-page.spec.ts.snap
+++ b/src/components/message-page/__snapshots__/message-page.spec.ts.snap
@@ -14,10 +14,10 @@ exports[`message-page integration tests Given an error with all props and slots 
         </div>
         <ul class="m-message-page__links">
             <li>
-                <a icon-name="m-svg__chevron--right" mode="link" url="an Url" target="" class="m-message-page__link">a link</a>
+                <a icon-name="m-svg__chevron--right" extern="true" url="an Url" target="" class="m-message-page__link">a link</a>
             </li>
             <li>
-                <a icon-name="m-svg__chevron--right" mode="link" url="another Url" target="" class="m-message-page__link">another link</a>
+                <a icon-name="m-svg__chevron--right" extern="true" url="another Url" target="" class="m-message-page__link">another link</a>
             </li>
         </ul>
     </div>

--- a/src/components/message-page/message-page.html
+++ b/src/components/message-page/message-page.html
@@ -12,9 +12,9 @@
         <div class="m-message-page__icon-container"
              aria-hidden="true">
             <div class="m-message-page__icon"
-                :style="styleObject"
-                v-html="svg"
-                v-if="isSvg"></div>
+                 :style="styleObject"
+                 v-html="svg"
+                 v-if="isSvg"></div>
             <m-icon class="m-message-page__icon"
                     :name="iconNameProp"
                     :size="propImageSize"
@@ -24,12 +24,12 @@
     <div class="m-message-page__body"
          v-if="hasBody">
         <p class="m-message-page__hints"
-            :class="{'m--no-content': !hasLinksAndSlot}"
-            v-if="hasHints"
-            v-for="hint in hints"
-            ref="hint">{{hint}}</p>
+           :class="{'m--no-content': !hasLinksAndSlot}"
+           v-if="hasHints"
+           v-for="hint in hints"
+           ref="hint">{{hint}}</p>
         <div class="m-message-page__details"
-            v-if="$slots.default">
+             v-if="$slots.default">
             <slot></slot>
         </div>
         <ul class="m-message-page__links"
@@ -38,7 +38,8 @@
                 v-for="link in links">
                 <m-link class="m-message-page__link"
                         icon-name="m-svg__chevron--right"
-                        mode="link" :url="link.url"
+                        :extern="true"
+                        :url="link.url"
                         :target="isTargetExternal(link.external)">{{link.label}}</m-link>
             </li>
         </ul>

--- a/src/components/page-not-found/__snapshots__/page-not-found.spec.ts.snap
+++ b/src/components/page-not-found/__snapshots__/page-not-found.spec.ts.snap
@@ -16,10 +16,9 @@ exports[`MPageNotFound should render correctly 1`] = `
             </div>
         </div>
     </div>
-    <p>m-page-not-found:directions</p>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text">
+    <p>m-page-not-found:directions</p> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text">
         m-page-not-found:back-to-portal
-    </span> </a>
+    </span> </span>
 </div>
 `;
 
@@ -39,9 +38,8 @@ exports[`MPageNotFound should render correctly with back-to-label override 1`] =
             </div>
         </div>
     </div>
-    <p>m-page-not-found:directions</p>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text">
+    <p>m-page-not-found:directions</p> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text">
         Some back to label
-    </span> </a>
+    </span> </span>
 </div>
 `;

--- a/src/components/page-not-found/page-not-found.html
+++ b/src/components/page-not-found/page-not-found.html
@@ -3,7 +3,7 @@
         <p>{{'m-page-not-found:message' | f-m-i18n}}</p>
     </m-message>
     <p>{{'m-page-not-found:directions' | f-m-i18n}}</p>
-    <m-link mode="link">
+    <m-link>
         {{backToLabel}}
     </m-link>
 </div>

--- a/src/components/session-expired/__snapshots__/session-expired.spec.ts.snap
+++ b/src/components/session-expired/__snapshots__/session-expired.spec.ts.snap
@@ -15,10 +15,9 @@ exports[`MSessionExpired should render correctly 1`] = `
         </div>
     </div>
     <p><span class="m-i18n">m-session-expired:directions-1</span></p>
-    <p><span class="m-i18n">m-session-expired:directions-2</span></p>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text">
+    <p><span class="m-i18n">m-session-expired:directions-2</span></p> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text">
         m-session-expired:back-to-portal
-    </span> </a>
+    </span> </span>
 </div>
 `;
 
@@ -37,9 +36,8 @@ exports[`MSessionExpired should render correctly with back-to-label override 1`]
         </div>
     </div>
     <p><span class="m-i18n">m-session-expired:directions-1</span></p>
-    <p><span class="m-i18n">m-session-expired:directions-2</span></p>
-    <a href="/" tabindex="1" class="m-link"> <span class="m-link__text">
+    <p><span class="m-i18n">m-session-expired:directions-2</span></p> <span role="button" tabindex="0" class="m-link m--is-unvisited m--is-button"> <span class="m-link__text">
         Some back to label
-    </span> </a>
+    </span> </span>
 </div>
 `;

--- a/src/components/session-expired/session-expired.html
+++ b/src/components/session-expired/session-expired.html
@@ -2,9 +2,13 @@
     <m-message state="information">
         <m-i18n k="m-session-expired:message"></m-i18n>
     </m-message>
-    <p><m-i18n k="m-session-expired:directions-1"></m-i18n></p>
-    <p><m-i18n k="m-session-expired:directions-2"></m-i18n></p>
-    <m-link mode="link">
+    <p>
+        <m-i18n k="m-session-expired:directions-1"></m-i18n>
+    </p>
+    <p>
+        <m-i18n k="m-session-expired:directions-2"></m-i18n>
+    </p>
+    <m-link :extern="true">
         {{backToLabel}}
     </m-link>
 </div>

--- a/src/components/timepicker/timepicker.html
+++ b/src/components/timepicker/timepicker.html
@@ -32,36 +32,62 @@
                        button-size="22px"
                        :aria-controls="id"
                        @keydown.enter.prevent="open = !isDisabled">
-            <m-i18n k="m-timepicker:open" v-if="!open"></m-i18n>
-            <m-i18n k="m-timepicker:close" v-if="open"></m-i18n>
+            <m-i18n k="m-timepicker:open"
+                    v-if="!open"></m-i18n>
+            <m-i18n k="m-timepicker:close"
+                    v-if="open"></m-i18n>
         </m-icon-button>
     </m-input-style>
-    <m-validation-message
-        :disabled="isDisabled"
-        :waiting="isWaiting"
-        :error="timeError"
-        :error-message="timeErrorMessage"
-        :valid-message="validMessage"
-        :helper-message="helperMessage"></m-validation-message>
+    <m-validation-message :disabled="isDisabled"
+                          :waiting="isWaiting"
+                          :error="timeError"
+                          :error-message="timeErrorMessage"
+                          :valid-message="validMessage"
+                          :helper-message="helperMessage"></m-validation-message>
     <m-popup ref="popup"
              :open.sync="open"
              :disabled="!active"
              :padding="false"
              :focus-management="isMqMaxS">
-        <div slot="header" class="m-timepicker__header">
-            <m-i18n k="m-timepicker:hours" class="m-timepicker__header__hours"></m-i18n>:
-            <m-i18n k="m-timepicker:minutes" class="m-timepicker__header__minutes"></m-i18n>
+        <div slot="header"
+             class="m-timepicker__header">
+            <m-i18n k="m-timepicker:hours"
+                    class="m-timepicker__header__hours"></m-i18n>:
+            <m-i18n k="m-timepicker:minutes"
+                    class="m-timepicker__header__minutes"></m-i18n>
         </div>
-        <div :id="ariaControls" class="m-timepicker__body" :aria-labelledby="id">
-            <ul class="m-timepicker__body__hours" ref="hours" @scroll="onScroll" @mousedown="onMousedown" @mouseup="onMouseup">
-                <li role="option" v-for="(h, i) in hours"><a href role="option" :aria-selected="i == tempHour" class="m-timepicker__body__hours-item" :class="{'m--is-selected': i == tempHour}" @click.stop.prevent="selectHour(i)">{{formatHour(i)}}</a></li>
+        <div :id="ariaControls"
+             class="m-timepicker__body"
+             :aria-labelledby="id">
+            <ul class="m-timepicker__body__hours"
+                ref="hours"
+                @scroll="onScroll"
+                @mousedown="onMousedown"
+                @mouseup="onMouseup">
+                <li role="option"
+                    v-for="(h, i) in hours"><a href
+                       role="option"
+                       :aria-selected="i == tempHour"
+                       class="m-timepicker__body__hours-item"
+                       :class="{'m--is-selected': i == tempHour}"
+                       @click.stop.prevent="selectHour(i)">{{formatHour(i)}}</a></li>
             </ul>
-            <ul class="m-timepicker__body__minutes" ref="minutes" @scroll="onScroll" @mousedown="onMousedown" @mouseup="onMouseup">
-                <li v-for="m in minutes"><a href role="option" :aria-selected="m == tempMinute" class="m-timepicker__body__minutes-item" :class="{'m--is-selected': m == tempMinute}" @click.stop.prevent="selectMinute(m)">{{formatMinute(m)}}</a></li>
+            <ul class="m-timepicker__body__minutes"
+                ref="minutes"
+                @scroll="onScroll"
+                @mousedown="onMousedown"
+                @mouseup="onMouseup">
+                <li v-for="m in minutes"><a href
+                       role="option"
+                       :aria-selected="m == tempMinute"
+                       class="m-timepicker__body__minutes-item"
+                       :class="{'m--is-selected': m == tempMinute}"
+                       @click.stop.prevent="selectMinute(m)">{{formatMinute(m)}}</a></li>
             </ul>
         </div>
-        <div slot="footer" class="m-timepicker__footer">
-            <m-link mode="button" @click="onOk">{{okButtonText}}</m-link>
+        <div slot="footer"
+             class="m-timepicker__footer">
+            <m-link @click="onOk">{{okButtonText}}</m-link>
         </div>
     </m-popup>
 </div>

--- a/src/components/tooltip/__snapshots__/tooltip.spec.ts.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.ts.snap
@@ -94,9 +94,9 @@ exports[`tooltip should render correctly when is open 1`] = `
 `;
 
 exports[`tooltip should render correctly when mode is link 1`] = `
-<m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <a href="#" tabindex="1" slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-link m-tooltip__link m--is-unvisited m--is-button"> <span class="m-link__text">Link</span> </a>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
+<m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip"> <span role="button" tabindex="0" slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-link m-tooltip__link m--is-unvisited m--is-button"> <span class="m-link__text">Link</span> </span>
+    <div id="mTooltip-uuid-controls"
+        aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
         <div tabindex="0" class="m-tooltip__close-button">
             <svg aria-hidden="true" width="12px" height="12px" svg-tile="function boundFn(a) {
     var l = arguments.length;

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -30,7 +30,6 @@
             :aria-controls="ariaControls"
             :aria-expanded="propOpen"
             slot="trigger"
-            mode="button"
             :underline="underline"
             :disabled="disabled"
             v-if="propMode !== 'icon'">
@@ -40,8 +39,14 @@
          class="m-tooltip__body-container"
          :class="{ 'm--has-close-button': propCloseButton }"
          :aria-labelledby="id">
-        <div class="m-tooltip__close-button" tabindex="0"  @keyup.enter="close" @click="close" v-if="propCloseButton">
-            <m-icon name="m-svg__close-clear" size="12px" :svg-tile="getCloseTitle"></m-icon>
+        <div class="m-tooltip__close-button"
+             tabindex="0"
+             @keyup.enter="close"
+             @click="close"
+             v-if="propCloseButton">
+            <m-icon name="m-svg__close-clear"
+                    size="12px"
+                    :svg-tile="getCloseTitle"></m-icon>
         </div>
         <div class="m-tooltip__body">
             <slot></slot>

--- a/tests/app/app-frame/app-frame.html
+++ b/tests/app/app-frame/app-frame.html
@@ -1,10 +1,14 @@
 <m-flex-template>
-    <div class="m-app-frame__header m-u--box-shadow--s" slot="header">
+    <div class="m-app-frame__header m-u--box-shadow--s"
+         slot="header">
         <h1 class="m-app-frame__titre">
             <span class="m-app-frame__logo">Mod<b class="m-app-frame__logo-gras">ul</b></span>
             <span class="m-app-frame__sous-titre">Components</span>
         </h1>
-        <m-link class="m-u--font-size--s m-u--margin-left" mode="link" target="_blank" url="https://ulaval.github.io/modul/">Documentation</m-link>
+        <m-link class="m-u--font-size--s m-u--margin-left"
+                :extern="true"
+                target="_blank"
+                url="https://ulaval.github.io/modul/">Documentation</m-link>
     </div>
     <main class="m-app-frame__content">
         <router-view></router-view>

--- a/tests/app/media-queries/media-queries.html
+++ b/tests/app/media-queries/media-queries.html
@@ -1,27 +1,48 @@
-
 <m-template>
     <div slot="header">
-        <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Menu</m-link>
+        <m-link url="/"
+                :underline="false"
+                :unvisited="true"
+                icon-name="m-svg__chevron--left">Menu</m-link>
         <h1>Media Queries</h1>
     </div>
     <div>
-        <h2 v-if="isMqMinXS || isMqMinS || isMqMinM || isMqMinL || isMqMinXL" >min-width</h2>
-        <p id="min480" v-if="isMqMinXS">480px >= ... <strong>isMqMinXS</strong></p>
-        <p id="min768" v-if="isMqMinS">768px >= ... <strong>isMqMinS</strong></p>
-        <p id="min1024" v-if="isMqMinM">1024px >= ... <strong>isMqMinM</strong></p>
-        <p id="min1200" v-if="isMqMinL"> 1200px >= ... <strong>isMqMinL</strong></p>
-        <p id="min1600" v-if="isMqMinXL">1600px >= ... <strong>isMqXL</strong></p>
+        <h2 v-if="isMqMinXS || isMqMinS || isMqMinM || isMqMinL || isMqMinXL">min-width</h2>
+        <p id="min480"
+           v-if="isMqMinXS">480px >= ... <strong>isMqMinXS</strong></p>
+        <p id="min768"
+           v-if="isMqMinS">768px >= ... <strong>isMqMinS</strong></p>
+        <p id="min1024"
+           v-if="isMqMinM">1024px >= ... <strong>isMqMinM</strong></p>
+        <p id="min1200"
+           v-if="isMqMinL"> 1200px >= ... <strong>isMqMinL</strong></p>
+        <p id="min1600"
+           v-if="isMqMinXL">1600px >= ... <strong>isMqXL</strong></p>
 
         <h2 v-if="isMqMaxXS || isMqMaxS || isMqMaxM || isMqMaxL || isMqMaxXL">max-width</h2>
-        <p id="max480" v-if="isMqMaxXS"><strong>isMqXS</strong> ... < 480px</p>
-        <p id="max768" v-if="isMqMaxS"><strong>isMqMaxS</strong> ... < 768px</p>
-        <p id="max1024" v-if="isMqMaxM"><strong>isMqMaxM</strong> ... < 1024px</p>
-        <p id="max1200" v-if="isMqMaxL"><strong>isMqMaxL</strong> ... < 1200px</p>
-        <p id="max1600" v-if="isMqMaxXL"><strong>isMqMaxXL</strong> ... < 1600px</p>
-
-        <h2 v-if="isMqS || isMqM || isMqL" >min-width and max-width</h2>
-        <p id="in480-768" v-if="isMqS">480px =­> ... <strong>isMqS</strong> ... < 768px</p>
-        <p id="in768-1024" v-if="isMqM">768px => ... <strong>isMqM</strong>... < 1024px</p>
-        <p id="in1024-1600" v-if="isMqL">1024px => ... <strong>isMqL</strong> ... < 1600px</p>
-    </div>
-</m-template>
+        <p id="max480"
+           v-if="isMqMaxXS"><strong>isMqXS</strong> ... < 480px</p>
+              <p
+              id="max768"
+              v-if="isMqMaxS"><strong>isMqMaxS</strong> ... < 768px</p>
+                  <p
+                  id="max1024"
+                  v-if="isMqMaxM"><strong>isMqMaxM</strong> ... < 1024px</p>
+                      <p
+                      id="max1200"
+                      v-if="isMqMaxL"><strong>isMqMaxL</strong> ... < 1200px</p>
+                          <p
+                          id="max1600"
+                          v-if="isMqMaxXL"><strong>isMqMaxXL</strong> ... < 1600px</p>
+                              <h2
+                              v-if="isMqS || isMqM || isMqL">min-width and max-width</h2>
+                                <p id="in480-768"
+                                   v-if="isMqS">480px =­> ... <strong>isMqS</strong> ... < 768px</p>
+                                      <p
+                                      id="in768-1024"
+                                      v-if="isMqM">768px => ... <strong>isMqM</strong>... < 1024px</p>
+                                          <p
+                                          id="in1024-1600"
+                                          v-if="isMqL">1024px => ... <strong>isMqL</strong> ... < 1600px</p>
+                                              </div>
+                                              </m-template>

--- a/tests/app/navigation/navigation.html
+++ b/tests/app/navigation/navigation.html
@@ -4,26 +4,31 @@
         <nav class="m-u--margin-top">
             <ul class="m-navigation__submenu">
                 <li>
-                    <m-link mode="link" href="#component">Components</m-link>
+                    <m-link url="#component">Components</m-link>
                 </li>
                 <li>
-                    <m-link mode="link" href="#directives">Directives</m-link>
+                    <m-link url="#directives">Directives</m-link>
                 </li>
                 <li>
-                    <m-link mode="link" href="#filters">Filters</m-link>
+                    <m-link url="#filters">Filters</m-link>
                 </li>
                 <li>
-                    <m-link mode="link" href="#mixins">Mixins</m-link>
+                    <m-link url="#mixins">Mixins</m-link>
                 </li>
                 <li>
-                    <m-link mode="link" href="#services">Services</m-link>
+                    <m-link url="#services">Services</m-link>
                 </li>
             </ul>
         </nav>
     </div>
 
-    <a class="anchor" id="component"></a>
-    <h2 class="m-u--no-margin">Components <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    <a class="anchor"
+       id="component"></a>
+    <h2 class="m-u--no-margin">Components <m-link href="#"
+                @click="scrollToTop()">
+            <m-icon name="m-svg__arrow-thin--up"
+                    size="16px"></m-icon>
+        </m-link>
     </h2>
     <nav class="m-u--margin-top">
         <ul class="m-u--bullet-list">
@@ -32,8 +37,13 @@
             </li>
         </ul>
     </nav>
-    <a class="anchor" id="directives"></a>
-    <h2>Directives <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px" ></m-icon></m-link>
+    <a class="anchor"
+       id="directives"></a>
+    <h2>Directives <m-link href="#"
+                @click="scrollToTop()">
+            <m-icon name="m-svg__arrow-thin--up"
+                    size="16px"></m-icon>
+        </m-link>
     </h2>
     <nav class="m-u--margin-top">
         <ul class="m-u--bullet-list">
@@ -42,8 +52,13 @@
             </li>
         </ul>
     </nav>
-    <a class="anchor" id="filters"></a>
-    <h2>Filters  <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    <a class="anchor"
+       id="filters"></a>
+    <h2>Filters <m-link href="#"
+                @click="scrollToTop()">
+            <m-icon name="m-svg__arrow-thin--up"
+                    size="16px"></m-icon>
+        </m-link>
     </h2>
     <nav class="m-u--margin-top">
         <ul class="m-u--bullet-list">
@@ -52,8 +67,13 @@
             </li>
         </ul>
     </nav>
-    <a class="anchor" id="mixins"></a>
-    <h2>Mixins <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    <a class="anchor"
+       id="mixins"></a>
+    <h2>Mixins <m-link href="#"
+                @click="scrollToTop()">
+            <m-icon name="m-svg__arrow-thin--up"
+                    size="16px"></m-icon>
+        </m-link>
     </h2>
     <nav class="m-u--margin-top">
         <ul class="m-u--bullet-list">
@@ -63,8 +83,13 @@
         </ul>
 
     </nav>
-    <a class="anchor" id="services"></a>
-    <h2>Services  <m-link href="#" mode="link" @click="scrollToTop()"><m-icon name="m-svg__arrow-thin--up" size="16px"></m-icon></m-link>
+    <a class="anchor"
+       id="services"></a>
+    <h2>Services <m-link href="#"
+                @click="scrollToTop()">
+            <m-icon name="m-svg__arrow-thin--up"
+                    size="16px"></m-icon>
+        </m-link>
     </h2>
     <nav class="m-u--margin-top">
         <ul class="m-u--bullet-list">

--- a/tests/app/viewer/viewer.html
+++ b/tests/app/viewer/viewer.html
@@ -1,6 +1,9 @@
 <m-template>
     <div slot="header">
-        <m-link :underline="false" :unvisited="true" icon-name="m-svg__chevron--left">Retour</m-link>
+        <m-link url="/"
+                :underline="false"
+                :unvisited="true"
+                icon-name="m-svg__chevron--left">Retour</m-link>
         <h1>{{$route.meta}}</h1>
     </div>
     <m-dynamic-template :template="tag"></m-dynamic-template>


### PR DESCRIPTION
…prop extern:boolean)

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Voici les ajustements qui seront apportés:
- Supprimer la prop mode pour simplifier l'utilisation du composant
- Ajouter la prop extern: boolean
- Lorsque extern = true, ne pas utiliser le composant <router-link> de vue, mais plutôt une balise <a>
- Gérer automatiquement l'ajout du role="button" au lien lorsque la prop url est undefined
- Améliorer le balisage du composant (exemple: utilisation du composant <component> pour ne pas dupliquer le balisage)

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-563
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
1) La prop `extern: boolean` a été ajouté.
2) La prop `mode` du composant **m-link** a été supprimé.
2.1) La prop `extern=true` vient remplacer la prop `mode="link"`
2.2) La prop `extern=false` vient remplacer la prop `mode="router-link"`
2.3) Le `mode="bouton"` n'existe plus. C'est le composant qui s'occupe d'ajouter le `role="button" ` lorsque nécessaire. Par exemple, lorsque la prop `url` n'est pas défini, le `role="button" `est automatiquement ajouté.

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
