### PR TITLE
Add immediate watch on portal components

### DIFF
--- a/src/mixins/portal/portal.ts
+++ b/src/mixins/portal/portal.ts
@@ -298,7 +298,9 @@ export class Portal extends ModulVue implements PortalMixin {
         }
     }
 
-    @Watch('open')
+    @Watch('open', {
+        immediate: true
+    })
     private openChanged(open: boolean): void {
         this.propOpen = open;
     }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Watch is now immediate, so when the component is instancialized, it checks immediatly the value of the 'open' prop instead of waiting for a change.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-576
https://jira.dti.ulaval.ca/browse/ENA2-3591
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
The watch of the prop 'Open' on portal components (dialog, modal, popper, sidebar) is now immediate.
- [x] Other info
BREAKING CHANGE: If your variable that was binded to the prop Open was at true during instancialization of the portal component, it will now show the component instead of now showing the component.
Minimalist example that will now work: `<m-dialog :open="true">Text<m-dialog>`

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
