### PR TITLE
MODUL-590: Faciliter l'utilisation de composant m-tooltip en mode link

### DIFF
--- a/src/components/icon-button/icon-button.sandbox.html
+++ b/src/components/icon-button/icon-button.sandbox.html
@@ -1,13 +1,44 @@
 <div>
-    <!-- Sandbox template -->
-    <h3>Test Title</h3>
-    <p class="m-u--margin-bottom">
-        Test description
-        <!-- if relevant, add link to PR
-        </br>From <a href="https://github.com/ulaval/modul-components/pull/000" target="blank">PR description</a>
-        -->
-    </p>
+    <h2 class="m-u--no-margin">Prop skin</h2>
+    <h3 class="m-u--h5">skin="light" (default)</h3>
     <p>
-        <m-icon-button><!-- Test case --></m-icon-button>
+        <m-icon-button>
+        </m-icon-button>
+    </p>
+
+    <h3 class="m-u--h5">skin="dark"</h3>
+    <p>
+        <m-icon-button skin="dark">
+        </m-icon-button>
+    </p>
+
+    <h3 class="m-u--h5">skin="primary"</h3>
+    <p>
+        <m-icon-button skin="primary">
+        </m-icon-button>
+    </p>
+
+    <h3 class="m-u--h5">skin="secondary"</h3>
+    <p>
+        <m-icon-button skin="secondary">
+        </m-icon-button>
+    </p>
+
+    <h3 class="m-u--h5">skin="link"</h3>
+    <p>
+        <m-icon-button skin="link">
+        </m-icon-button>
+    </p>
+
+    <h2>Prop icon-size</h2>
+    <h3 class="m-u--h5">icon-size="10px"</h3>
+    <p>
+        <m-icon-button icon-size="10px">
+        </m-icon-button>
+    </p>
+    <h3 class="m-u--h5">icon-size="30px"</h3>
+    <p>
+        <m-icon-button icon-size="30px">
+        </m-icon-button>
     </p>
 </div>

--- a/src/components/tooltip/__snapshots__/tooltip.spec.ts.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.ts.snap
@@ -2,13 +2,9 @@
 
 exports[`tooltip should render correctly 1`] = `
 <m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" icon-name="m-svg__information" title="Open tooltip" button-size="22px" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="Close tooltip" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="Open tooltip" button-size="22px" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body"></div>
     </div>
 </m-popup>
@@ -16,13 +12,9 @@ exports[`tooltip should render correctly 1`] = `
 
 exports[`tooltip should render correctly when close title is set 1`] = `
 <m-popup open="open" placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" aria-expanded="true" icon-name="m-svg__information" title="test close" button-size="22px" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="test close" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="test close" button-size="22px" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" aria-expanded="true" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">test close</m-icon-button>
         <div class="m-tooltip__body"></div>
     </div>
 </m-popup>
@@ -30,8 +22,9 @@ exports[`tooltip should render correctly when close title is set 1`] = `
 
 exports[`tooltip should render correctly when close-button is false 1`] = `
 <m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" icon-name="m-svg__information" title="Open tooltip" button-size="22px" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container">
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="Open tooltip" button-size="22px" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body"></div>
     </div>
 </m-popup>
@@ -39,13 +32,9 @@ exports[`tooltip should render correctly when close-button is false 1`] = `
 
 exports[`tooltip should render correctly when disabled 1`] = `
 <m-popup placement="bottom" disabled="disabled" close-on-backdrop="true" class="m-tooltip m--is-disabled">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" icon-name="m-svg__information" title="Open tooltip" button-size="22px" disabled="disabled" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="Close tooltip" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="Open tooltip" disabled="disabled" button-size="22px" aria-controls="mTooltip-uuid-controls" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body"></div>
     </div>
 </m-popup>
@@ -53,27 +42,19 @@ exports[`tooltip should render correctly when disabled 1`] = `
 
 exports[`tooltip should render correctly when is open 1`] = `
 <m-popup open="open" placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" aria-expanded="true" icon-name="m-svg__information" title="Close tooltip" button-size="22px" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="Close tooltip" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="Close tooltip" button-size="22px" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" aria-expanded="true" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body"></div>
     </div>
 </m-popup>
 `;
 
-exports[`tooltip should render correctly when mode is link 1`] = `
+exports[`tooltip should render correctly when mode is text 1`] = `
 <m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <a href="#" tabindex="1" slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-link m-tooltip__link m--is-unvisited m--is-button"> <span class="m-link__text">Link</span> </a>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="Close tooltip" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <router-link to="[object Object]" tabindex="1" event="click" slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-link m-tooltip__link m--is-unvisited"> <span class="m-link__text">Link</span> </router-link>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body">Tooltip text</div>
     </div>
 </m-popup>
@@ -81,13 +62,9 @@ exports[`tooltip should render correctly when mode is link 1`] = `
 
 exports[`tooltip should render correctly when open title is set 1`] = `
 <m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" icon-name="m-svg__information" title="test open" button-size="22px" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="Close tooltip" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="test open" button-size="22px" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body"></div>
     </div>
 </m-popup>
@@ -95,13 +72,9 @@ exports[`tooltip should render correctly when open title is set 1`] = `
 
 exports[`tooltip should render correctly with default slot 1`] = `
 <m-popup placement="bottom" close-on-backdrop="true" class="m-tooltip">
-    <m-icon-button slot="trigger" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" icon-name="m-svg__information" title="Open tooltip" button-size="22px" class="m-tooltip__icon"></m-icon-button>
-    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
-        <div tabindex="0" class="m-tooltip__close-button">
-            <svg aria-hidden="true" width="12px" height="12px" svg-tile="Close tooltip" class="m-icon">
-                <use aria-hidden="true"></use>
-            </svg>
-        </div>
+    <m-icon-button slot="trigger" id="mTooltip-uuid" icon-name="m-svg__information" title="Open tooltip" button-size="22px" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-tooltip__icon"></m-icon-button>
+    <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--is-default-size m--has-close-button">
+        <m-icon-button skin="link" icon-size="14px" class="m-tooltip__close-button">Close tooltip</m-icon-button>
         <div class="m-tooltip__body">Tooltip text</div>
     </div>
 </m-popup>

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -10,45 +10,41 @@
          :focus-management="isMqMaxS"
          @open="onOpen"
          @close="onClose">
+    <m-link :id="id"
+            class="m-tooltip__link"
+            v-if="$slots.text"
+            slot="trigger"
+            @click="onClick"
+            :underline="true"
+            :unvisited="true"
+            :disabled="disabled"
+            :aria-haspopup="!disabled"
+            :aria-controls="ariaControls"
+            :aria-expanded="propOpen">
+        <slot name="text"></slot>
+    </m-link>
     <m-icon-button :id="id"
                    class="m-tooltip__icon"
+                   v-else
                    @click="onClick"
-                   aria-haspopup="true"
-                   :aria-controls="ariaControls"
-                   :aria-expanded="propOpen"
                    slot="trigger"
                    icon-name="m-svg__information"
                    :title="propTitle"
-                   button-size="22px"
                    :disabled="disabled"
-                   v-if="propMode === 'icon'">
+                   button-size="22px"
+                   :aria-haspopup="!disabled"
+                   :aria-controls="ariaControls"
+                   :aria-expanded="propOpen">
     </m-icon-button>
-    <m-link :id="id"
-            class="m-tooltip__link"
-            @click="onClick"
-            aria-haspopup="true"
-            :aria-controls="ariaControls"
-            :aria-expanded="propOpen"
-            slot="trigger"
-            mode="button"
-            :underline="underline"
-            :disabled="disabled"
-            v-if="propMode !== 'icon'">
-        <slot name="link"></slot>
-    </m-link>
     <div :id="ariaControls"
          class="m-tooltip__body-container"
-         :class="{ 'm--has-close-button': propCloseButton }"
+         :class="[ 'm--is-' + size + '-size', { 'm--has-close-button': propCloseButton }]"
          :aria-labelledby="id">
-        <div class="m-tooltip__close-button"
-             tabindex="0"
-             @keyup.enter="close"
-             @click="close"
-             v-if="propCloseButton">
-            <m-icon name="m-svg__close-clear"
-                    size="12px"
-                    :svg-tile="getCloseTitle()"></m-icon>
-        </div>
+        <m-icon-button class="m-tooltip__close-button"
+                       @click="close"
+                       skin="link"
+                       :ripple="false"
+                       icon-size="14px">{{ getCloseTitle() }}</m-icon-button>
         <div class="m-tooltip__body">
             <slot></slot>
         </div>

--- a/src/components/tooltip/tooltip.sandbox.html
+++ b/src/components/tooltip/tooltip.sandbox.html
@@ -20,13 +20,15 @@
     </p>
     <p>
         <m-tooltip>
-            <a href="https://fr.wikipedia.org/wiki/Cath%C3%A9drale_de_Brasilia" target="_blank">https://fr.wikipedia.org/wiki/Cath%C3%A9drale_de_Brasilia</a>
+            <a href="https://fr.wikipedia.org/wiki/Cath%C3%A9drale_de_Brasilia"
+               target="_blank">https://fr.wikipedia.org/wiki/Cath%C3%A9drale_de_Brasilia</a>
         </m-tooltip>
     </p>
     <h3>Tooltip with a link inside without link tag</h3>
     <p class="m-u--margin-bottom">
         The tooltip has a link inside.
-        </br>From <a href="https://github.com/ulaval/modul-components/pull/482" target="blank">PR 482</a>
+        </br>From <a href="https://github.com/ulaval/modul-components/pull/482"
+           target="blank">PR 482</a>
     </p>
     <p>
         <m-tooltip>https://fr.wikipedia.org/wiki/Cath%C3%A9drale_de_Brasilia</m-tooltip>
@@ -37,6 +39,6 @@
     </p>
     <h3>Mode link</h3>
     <p>
-        <m-tooltip mode="link"><span slot="link">link</span>test</m-tooltip>
+        <m-tooltip size="large"><span slot="text">link</span>test</m-tooltip>
     </p>
 </div>

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -1,5 +1,6 @@
 @import 'abstracts/variables';
 $m-tooltip--width: 320px !default;
+$m-tooltip--width--l: 540px !default;
 $m-tooltip--max-height: 280px !default;
 
 .m-tooltip {
@@ -43,28 +44,19 @@ $m-tooltip--max-height: 280px !default;
 
     &__close-button {
         position: absolute;
-        top: 1px; // Magic number: border-width
-        right: 1px; // Magic number: border-width
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: $m-touch-size;
-        height: $m-touch-size;
-        color: $m-color--interactive;
-        outline: none;
-        cursor: pointer;
-
-        &:hover,
-        &:focus {
-            color: $m-color--interactive-darker;
-        }
+        top: 0;
+        right: 0;
     }
 
     &__body {
-        padding: $m-padding;
+        padding: $m-spacing;
         background: $m-color--information;
         word-break: break-word;
         user-select: text;
+
+        > :first-child {
+            margin-top: 0;
+        }
 
         @media (max-width: $m-mq--max--s) {
             position: relative;
@@ -101,7 +93,15 @@ $m-tooltip--max-height: 280px !default;
                 position: relative;
 
                 .m-tooltip__body {
-                    padding-right: $m-padding--l;
+                    padding-right: $m-touch-size;
+                }
+            }
+
+            &.m--is-large-size {
+                .m-tooltip__body {
+                    @media (min-width: $m-mq--min--s) {
+                        width: $m-tooltip--width--l;
+                    }
                 }
             }
         }

--- a/src/components/tooltip/tooltip.spec.ts
+++ b/src/components/tooltip/tooltip.spec.ts
@@ -1,11 +1,11 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue, { VueConstructor } from 'vue';
-
 import { resetModulPlugins } from '../../../tests/helpers/component';
 import { addMessages } from '../../../tests/helpers/lang';
 import { renderComponent } from '../../../tests/helpers/render';
 import uuid from '../../utils/uuid/uuid';
-import TooltipPlugin, { MTooltip, MTooltipMode } from './tooltip';
+import TooltipPlugin, { MTooltip } from './tooltip';
+
 
 jest.mock('../../utils/uuid/uuid');
 (uuid.generate as jest.Mock).mockReturnValue('uuid');
@@ -55,15 +55,12 @@ describe('tooltip', () => {
         return expect(renderComponent(tooltip.vm)).resolves.toMatchSnapshot();
     });
 
-    it('should render correctly when mode is link', () => {
+    it('should render correctly when mode is text', () => {
         const tooltip: Wrapper<MTooltip> = mount(MTooltip, {
             localVue: localVue,
-            propsData: {
-                mode: MTooltipMode.Link
-            },
             slots: {
                 default: 'Tooltip text',
-                link: 'Link'
+                text: 'Link'
             }
         });
 

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -1,7 +1,6 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-
 import { MediaQueries, MediaQueriesMixin } from '../../mixins/media-queries/media-queries';
 import MediaQueriesPlugin from '../../utils/media-queries/media-queries';
 import uuid from '../../utils/uuid/uuid';
@@ -13,9 +12,9 @@ import LinkPlugin from '../link/link';
 import { MPopperPlacement } from '../popper/popper';
 import WithRender from './tooltip.html?style=./tooltip.scss';
 
-export enum MTooltipMode {
-    Icon = 'icon',
-    Link = 'link'
+export enum MTooltipSize {
+    Default = 'default',
+    Large = 'large'
 }
 
 @WithRender
@@ -25,13 +24,6 @@ export enum MTooltipMode {
 export class MTooltip extends ModulVue {
     @Prop()
     public open: boolean;
-    @Prop({
-        default: MTooltipMode.Icon,
-        validator: value =>
-            value === MTooltipMode.Icon ||
-            value === MTooltipMode.Link
-    })
-    public mode: MTooltipMode;
     @Prop({
         default: MPopperPlacement.Bottom,
         validator: value =>
@@ -51,14 +43,19 @@ export class MTooltip extends ModulVue {
     public placement: MPopperPlacement;
     @Prop({ default: true })
     public closeButton: boolean;
+    @Prop({
+        default: MTooltipSize.Default,
+        validator: value =>
+            value === MTooltipSize.Default ||
+            value === MTooltipSize.Large
+    })
+    public size: MTooltipSize;
     @Prop()
     public disabled: boolean;
     @Prop()
     public openTitle: string;
     @Prop()
     public closeTitle: string;
-    @Prop({ default: true })
-    public underline: boolean;
     @Prop()
     public className: string;
 
@@ -72,10 +69,6 @@ export class MTooltip extends ModulVue {
     @Watch('open')
     private openChanged(open: boolean): void {
         this.propOpen = open;
-    }
-
-    private get propMode(): string {
-        return this.mode;
     }
 
     private get propCloseButton(): boolean {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
**Ajouter la prop size: sring**
Ajouter la prop size: sring avec ces deux valeur possible : 'defaut' et 'lage'

**Supprimer le mode**
Remplacer le mode="link" par l'utilisation de la $slot.text

**Utilisation actuelle du mode link**
```
<m-tooltip mode="link">
   <span slot="link">Je suis le lien du m-tooltip</span>
   <p>Je suis le contenu du m-tooltip</p>
</m-tooltip>

```
 
**Nouvelle façon de fonctionner avec la slot text**
```
<m-tooltip>
   <span slot="text">Je suis le lien du m-tooltip</span>
   <p>Je suis le contenu du m-tooltip</p>
</m-tooltip>
```
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-590
https://jira.dti.ulaval.ca/browse/P387-991

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
**Supprimer le mode**
Remplacer le **mode="link"** par l'utilisation de la **$slot.text**


<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
