### PR TITLE
Added special chars for translations

### DIFF
--- a/src/utils/i18n/i18n.spec.lang.fr.json
+++ b/src/utils/i18n/i18n.spec.lang.fr.json
@@ -14,5 +14,11 @@
         "decompte_athletes_olympiques_canada.p": "Il y a %(nbAthletes)s athlètes olympiques canadiens.",
         "decompte_athletes_olympiques_pays": "Il y a %(nbAthletes)s athlètes olympiques et %(nbPays)s pays participants.",
         "decompte_athletes_olympiques_pays_default_formatting": "Il y a {0} athlètes olympiques et {1} pays participants."
+    },
+    "exemples_avec_characteres_speciaux": {
+        "decompte_medailles_olympiques_canada": "Le Canada a gagné %(nbMedailles)s%(_NBSP_)smédailles.",
+        "decompte_medailles_olympiques_canada_usa": "Le Canada s'est placé %(nieme)s<sup>e</sup>, devançant les États%(_NBHYPHEN_)sUnis d'Amérique.",
+        "decompte_medailles_olympiques": "L'équipe olympique canadienne %(_EMDASH_)s l'une des meilleures au monde %(_EMDASH_)s a obtenue%(_NBSP_)smédailles.",
+        "olympiques_rivalite": "La rivalitalié Canada%(_ENDASH_)sÉtats-Unis est a son plus fort depuis plusieurs années."
     }
 }

--- a/src/utils/i18n/i18n.spec.lang.fr.json
+++ b/src/utils/i18n/i18n.spec.lang.fr.json
@@ -18,7 +18,8 @@
     "exemples_avec_characteres_speciaux": {
         "decompte_medailles_olympiques_canada": "Le Canada a gagné %(nbMedailles)s%(_NBSP_)smédailles.",
         "decompte_medailles_olympiques_canada_usa": "Le Canada s'est placé %(nieme)s<sup>e</sup>, devançant les États%(_NBHYPHEN_)sUnis d'Amérique.",
-        "decompte_medailles_olympiques": "L'équipe olympique canadienne %(_EMDASH_)s l'une des meilleures au monde %(_EMDASH_)s a obtenue%(_NBSP_)smédailles.",
-        "olympiques_rivalite": "La rivalitalié Canada%(_ENDASH_)sÉtats-Unis est a son plus fort depuis plusieurs années."
+        "decompte_medailles_olympiques": "L'équipe olympique canadienne %(_EMDASH_)s l'une des meilleures au monde %(_EMDASH_)s a obtenue médailles.",
+        "olympiques_rivalite": "La rivalitalié Canada%(_ENDASH_)sÉtats-Unis est a son plus fort depuis plusieurs années.",
+        "v2": "%(_ENDASH_)s"
     }
 }

--- a/src/utils/i18n/i18n.spec.ts
+++ b/src/utils/i18n/i18n.spec.ts
@@ -1,7 +1,8 @@
 import Vue from 'vue';
-import I18nPlugin, { Messages, ENGLISH, I18nPluginOptions, FormatMode } from './i18n';
 import { resetModulPlugins } from '../../../tests/helpers/component';
 import { addMessages } from '../../../tests/helpers/lang';
+import I18nPlugin, { ENGLISH, FormatMode, I18nPluginOptions, Messages, SpecialCharacter } from './i18n';
+
 
 describe('i18n plugin', () => {
     describe('when not installed', () => {
@@ -89,6 +90,44 @@ describe('i18n plugin', () => {
         });
         it(`calling translate with params modifier should return the string with the params applied`, () => {
             expect(Vue.prototype.$i18n.translate('exemples_avec_parametres:decompte_athletes_olympiques_pays', { nbAthletes: 2925, nbPays: 93 })).toEqual('Il y a 2925 athlètes olympiques et 93 pays participants.');
+        });
+    });
+
+    describe(`When special character`, () => {
+        beforeEach(() => {
+            resetModulPlugins();
+            addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
+        });
+        describe(`Non-breaking space is used`, () => {
+            it(`then will be replaced in translation`, () => {
+                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada', { nbMedailles: 30 });
+                expect(translation.indexOf(SpecialCharacter.NBSP)).toBeGreaterThan(-1);
+                expect(translation.indexOf('_NBSP_')).toBe(-1);
+            });
+        });
+
+        describe(`Non-breaking hypen is used`, () => {
+            it(`then will be replaced in translation`, () => {
+                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada_usa', { nieme: 3 });
+                expect(translation.indexOf(SpecialCharacter.NBHYPHEN)).toBeGreaterThan(-1);
+                expect(translation.indexOf('_NBHYPHEN_')).toBe(-1);
+            });
+        });
+
+        describe(`Em-Dash is used`, () => {
+            it(`then will be replaced in translation`, () => {
+                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques', { nbMedailles: 3 });
+                expect(translation.indexOf(SpecialCharacter.EMDASH)).toBeGreaterThan(-1);
+                expect(translation.indexOf('_EMDASH_')).toBe(-1);
+            });
+        });
+
+        describe(`En-Dash is used`, () => {
+            it(`then will be replaced in translation`, () => {
+                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:olympiques_rivalite');
+                expect(translation.indexOf(SpecialCharacter.ENDASH)).toBeGreaterThan(-1);
+                expect(translation.indexOf('_ENDASH_')).toBe(-1);
+            });
         });
     });
 

--- a/src/utils/i18n/i18n.spec.ts
+++ b/src/utils/i18n/i18n.spec.ts
@@ -94,39 +94,131 @@ describe('i18n plugin', () => {
     });
 
     describe(`When special character`, () => {
-        beforeEach(() => {
-            resetModulPlugins();
-            addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
-        });
-        describe(`Non-breaking space is used`, () => {
-            it(`then will be replaced in translation`, () => {
-                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada', { nbMedailles: 30 });
-                expect(translation.indexOf(SpecialCharacter.NBSP)).toBeGreaterThan(-1);
-                expect(translation.indexOf('_NBSP_')).toBe(-1);
+        describe(`in Vsprintf mode`, () => {
+            beforeEach(() => {
+                let options: I18nPluginOptions = {
+                    formatMode: FormatMode.Vsprintf
+                };
+
+                resetModulPlugins();
+                Vue.use(I18nPlugin, options);
+                addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
+            });
+            describe(`Non-breaking space is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada', { nbMedailles: 30 });
+                    expect(translation.indexOf(SpecialCharacter.NBSP)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_NBSP_')).toBe(-1);
+                });
+            });
+
+            describe(`Non-breaking hypen is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada_usa', { nieme: 3 });
+                    expect(translation.indexOf(SpecialCharacter.NBHYPHEN)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_NBHYPHEN_')).toBe(-1);
+                });
+            });
+
+            describe(`Em-Dash is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques', { nbMedailles: 3 });
+                    expect(translation.indexOf(SpecialCharacter.EMDASH)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_EMDASH_')).toBe(-1);
+                });
+            });
+
+            describe(`En-Dash is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:olympiques_rivalite', {});
+                    expect(translation.indexOf(SpecialCharacter.ENDASH)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_ENDASH_')).toBe(-1);
+
+                });
             });
         });
+        describe(`in Sprintf mode`, () => {
+            beforeEach(() => {
+                let options: I18nPluginOptions = {
+                    formatMode: FormatMode.Sprintf
+                };
 
-        describe(`Non-breaking hypen is used`, () => {
-            it(`then will be replaced in translation`, () => {
-                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada_usa', { nieme: 3 });
-                expect(translation.indexOf(SpecialCharacter.NBHYPHEN)).toBeGreaterThan(-1);
-                expect(translation.indexOf('_NBHYPHEN_')).toBe(-1);
+                resetModulPlugins();
+                Vue.use(I18nPlugin, options);
+                addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
+            });
+            describe(`Non-breaking space is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada', { nbMedailles: 30 });
+                    expect(translation.indexOf(SpecialCharacter.NBSP)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_NBSP_')).toBe(-1);
+                });
+            });
+
+            describe(`Non-breaking hypen is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada_usa', { nieme: 3 });
+                    expect(translation.indexOf(SpecialCharacter.NBHYPHEN)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_NBHYPHEN_')).toBe(-1);
+                });
+            });
+
+            describe(`Em-Dash is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques', { nbMedailles: 3 });
+                    expect(translation.indexOf(SpecialCharacter.EMDASH)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_EMDASH_')).toBe(-1);
+                });
+            });
+
+            describe(`En-Dash is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:olympiques_rivalite', {});
+                    expect(translation.indexOf(SpecialCharacter.ENDASH)).toBeGreaterThan(-1);
+                    expect(translation.indexOf('_ENDASH_')).toBe(-1);
+                });
             });
         });
+        describe(`in Default mode`, () => {
+            beforeEach(() => {
+                let options: I18nPluginOptions = {
+                    formatMode: FormatMode.Default
+                };
 
-        describe(`Em-Dash is used`, () => {
-            it(`then will be replaced in translation`, () => {
-                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques', { nbMedailles: 3 });
-                expect(translation.indexOf(SpecialCharacter.EMDASH)).toBeGreaterThan(-1);
-                expect(translation.indexOf('_EMDASH_')).toBe(-1);
+                resetModulPlugins();
+                Vue.use(I18nPlugin, options);
+                addMessages(Vue, ['utils/i18n/i18n.spec.lang.fr.json']);
             });
-        });
+            describe(`Non-breaking space is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada', { nbMedailles: 30 });
+                    expect(translation.indexOf(SpecialCharacter.NBSP)).toBe(-1);
+                    expect(translation.indexOf('_NBSP_')).toBeGreaterThan(-1);
+                });
+            });
 
-        describe(`En-Dash is used`, () => {
-            it(`then will be replaced in translation`, () => {
-                const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:olympiques_rivalite');
-                expect(translation.indexOf(SpecialCharacter.ENDASH)).toBeGreaterThan(-1);
-                expect(translation.indexOf('_ENDASH_')).toBe(-1);
+            describe(`Non-breaking hypen is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques_canada_usa', { nieme: 3 });
+                    expect(translation.indexOf(SpecialCharacter.NBHYPHEN)).toBe(-1);
+                    expect(translation.indexOf('_NBHYPHEN_')).toBeGreaterThan(-1);
+                });
+            });
+
+            describe(`Em-Dash is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:decompte_medailles_olympiques', { nbMedailles: 3 });
+                    expect(translation.indexOf(SpecialCharacter.EMDASH)).toBe(-1);
+                    expect(translation.indexOf('_EMDASH_')).toBeGreaterThan(-1);
+                });
+            });
+
+            describe(`En-Dash is used`, () => {
+                it(`then will be replaced in translation`, () => {
+                    const translation: string = Vue.prototype.$i18n.translate('exemples_avec_characteres_speciaux:olympiques_rivalite', {});
+                    expect(translation.indexOf(SpecialCharacter.ENDASH)).toBe(-1);
+                    expect(translation.indexOf('_ENDASH_')).toBeGreaterThan(-1);
+                });
             });
         });
     });

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -1,6 +1,6 @@
 import Vue, { PluginObject } from 'vue';
-
 import { sprintf, vsprintf } from '../str/str';
+
 
 /**
  * This package provides language and locales utilities.
@@ -21,6 +21,12 @@ export const ENGLISH: string = 'en';
  */
 const FORMAT_REGEX: RegExp = /{\d+}/g;
 
+/**
+ * String used as a special characters wrapper
+ */
+const SPECIAL_CHARACTER_PREFIXE: string = '_';
+const SPECIAL_CHARACTER_SUFIXE: string = '_';
+
 export type MessageMap = {
     [key: string]: string;
 };
@@ -32,6 +38,20 @@ export type BundleMessagesMap = {
 type LanguageBundlesMap = {
     [language: string]: BundleMessagesMap;
 };
+
+type SpecialCharacterMap = {
+    [key: string]: SpecialCharacter
+};
+
+/**
+ * Special characters must be represented as their unicode equivalent \u00xxxx
+ */
+export enum SpecialCharacter {
+    NBSP = '\u00a0', // non-breaking space
+    NBHYPHEN = '\u002011', // non-breaking hyphen
+    EMDASH = '\u002014', // em dash
+    ENDASH = '\u002013' // en dash
+}
 
 export enum DebugMode {
     Throw,
@@ -55,6 +75,7 @@ export class Messages {
     private curLang: string = ENGLISH;
     private formatMode: FormatMode;
     private messages: LanguageBundlesMap = {};
+    private specialCharacterDict: SpecialCharacterMap = {};
 
     constructor(private options?: I18nPluginOptions) {
         if (options) {
@@ -65,6 +86,7 @@ export class Messages {
                 this.formatMode = options.formatMode;
             }
         }
+        this.initSpecialCharactersDict();
     }
 
     /**
@@ -115,6 +137,12 @@ export class Messages {
         }
 
         let val: string = this.resolveKey(this.curLang, key, nb, modifier);
+
+        Object.keys(this.specialCharacterDict).forEach((key: string) => {
+            if (!params[key]) {
+                params[key] = this.specialCharacterDict[key];
+            }
+        });
 
         if (htmlEncodeParams && params.length) {
             for (let i: number = 0; i < params.length; ++i) {
@@ -216,6 +244,19 @@ export class Messages {
             return key;
         }
     }
+
+    /**
+     * Build the list of special characters that are automatically replaced to the desired pattern
+     *
+     * Example with '_' as PREFIXE and SUFIXE
+     * NBSP => _NBSP_ : '\xOA'
+     */
+    private initSpecialCharactersDict(): void {
+        Object.keys(SpecialCharacter).forEach((key: string) => {
+            this.specialCharacterDict[`${SPECIAL_CHARACTER_PREFIXE}${key}${SPECIAL_CHARACTER_SUFIXE}`] = SpecialCharacter[key];
+        });
+    }
+
 
     /**
      * Finds a key in the available messages or returns null.

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -138,11 +138,13 @@ export class Messages {
 
         let val: string = this.resolveKey(this.curLang, key, nb, modifier);
 
-        Object.keys(this.specialCharacterDict).forEach((key: string) => {
-            if (!params[key]) {
-                params[key] = this.specialCharacterDict[key];
-            }
-        });
+        if (FormatMode.Sprintf || FormatMode.Vsprintf) {
+            Object.keys(this.specialCharacterDict).forEach((key: string) => {
+                if (!params.hasOwnProperty(key)) {
+                    params[key] = this.specialCharacterDict[key];
+                }
+            });
+        }
 
         if (htmlEncodeParams && params.length) {
             for (let i: number = 0; i < params.length; ++i) {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

CANCEL AND REPLACE PR : https://github.com/ulaval/modul-components/pull/528

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Cas d'utilisation ayant mené à cette amélioration:
Possibilité de formatter une chaine de caractère avec des espaces insécable et rendre ce formattage plus explicite dans les fichiers de traduction.

Actuellement dans les fichiers de traduction, un espace insécable est représenté comme:
%(date)s à %(time)s

La proposition de changement:
%(date)s à%(\_NBSP\_)s%(time)s

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-523

- [x] Include this section in the release notes
### i18n
Added special characters support for translation string. These special characters can only be used with `FormatMode.Sprintf` and `FormatMode.Vsprintf`.

```
| Character           | unicode symbol | HTML symbol | usage in translation file 
| Non-breaking space  | `\u00a0`       | `&nbsp;`    | %(_NBSP_)s                    
| Non-breaking hyphen | `\u002011`     | --          | %(_NBHYPHEN_)s          
| Em-Dash             | `\u002014`     | `&mdash;`   | %(_EMDASH_)s              
| En-Dash             | `\u002013`     | `&ndash;`   | %(_ENDASH_)s               
```
- [ ] Openshift deployment requested
