### PR TITLE
P1 - Problème lors dans le positionnement du m-option

### DIFF
--- a/src/utils/modul/modul.ts
+++ b/src/utils/modul/modul.ts
@@ -269,7 +269,6 @@ export class Modul {
             this.bodyStyle.bottom = '0'; // --- Added bug in IE11 --- Added to fix edge case where showed contents through popper/portal are hidden when page content isn't high enough to stretch the body.
             this.bodyStyle.height = '100%';
             this.htmlEl.style.overflow = 'hidden';
-            this.bodyStyle.overflow = 'hidden';
             this.bodyEl.scrollTop = this.stopScrollPosition; // Overflow hidden must be applied on <body> and the <html> before "scrollTop"
         }
         return uuid.generate();


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Il s'agit d'un P1 dans Brio!
Lorsqu'on scroll dans la page, qu'on ouvre un m-overlay et qu'on ouvre le menu d'options, il n'apparaît pas à la bonne place. Il se positionne en fonction du scroll qu'on a effectué dans la page. Voir le billet modul pour une vidéo du problème. @raphpare a trouvé la solution!
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-593
https://jira.dti.ulaval.ca/browse/ENA2-3652
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
