### PR TITLE
Feature/toast manager

### DIFF
--- a/src/components/toast/toast.sandbox.html
+++ b/src/components/toast/toast.sandbox.html
@@ -9,10 +9,11 @@
 
     <h3>Toast with timeout</h3>
     <p class="m-u--margin-bottom">
-        A toast with a 2 seconds timeout.
+        A toast with a 5 seconds timeout.
     </p>
     <m-button @click="testOpenTimeout = !testOpenTimeout">Toggle Toast</m-button>
-    <m-toast :timeout="2000" :open.sync="testOpenTimeout">This toast lasts 2 seconds</m-toast>
+    <m-toast timeout="short"
+             :open.sync="testOpenTimeout">This toast lasts 5 seconds (fast)</m-toast>
 
     <h3>Automatic Toast</h3>
     <p class="m-u--margin-bottom">
@@ -25,35 +26,56 @@
         Multiple positions are available: top-right, top-center, top-left, bottom-left, bottom-center, bottom-right
     </p>
     <m-button @click="positionOpen = !positionOpen">Toggle Toast</m-button>
-    <m-toast position="top-right" :open.sync="positionOpen">This toast has position: top right</m-toast>
-    <m-toast position="top-center" :open.sync="positionOpen">This toast has position: top center</m-toast>
-    <m-toast position="top-left" :open.sync="positionOpen">This toast has position: top left</m-toast>
-    <m-toast position="bottom-left" :open.sync="positionOpen">This toast has position: bottom left</m-toast>
-    <m-toast position="bottom-center" :open.sync="positionOpen">This toast has position: bottom center</m-toast>
-    <m-toast position="bottom-right" :open.sync="positionOpen">This toast has position: bottom right</m-toast>
+    <m-toast position="top-right"
+             :open.sync="positionOpen">This toast has position: top right</m-toast>
+    <m-toast position="top-center"
+             :open.sync="positionOpen">This toast has position: top center</m-toast>
+    <m-toast position="top-left"
+             :open.sync="positionOpen">This toast has position: top left</m-toast>
+    <m-toast position="bottom-left"
+             :open.sync="positionOpen">This toast has position: bottom left</m-toast>
+    <m-toast position="bottom-center"
+             :open.sync="positionOpen">This toast has position: bottom center</m-toast>
+    <m-toast position="bottom-right"
+             :open.sync="positionOpen">This toast has position: bottom right</m-toast>
 
     <h3>Toast with offsets</h3>
     <p class="m-u--margin-bottom">
         Toast have a offset Prop that can be used to stack multiple toasts.
     </p>
     <m-button @click="offSetOpen = !offSetOpen">Toggle Toast</m-button>
-    <m-toast state="information" position="bottom-right" :open.sync="offSetOpen">First message</m-toast>
-    <m-toast state="information" position="bottom-right" :open.sync="offSetOpen" offset="-80px">Second message</m-toast>
-    <m-toast state="information" position="bottom-right" :open.sync="offSetOpen" offset="-160px">Third message</m-toast>
+    <m-toast state="information"
+             position="bottom-right"
+             :open.sync="offSetOpen">First message</m-toast>
+    <m-toast state="information"
+             position="bottom-right"
+             :open.sync="offSetOpen"
+             offset="-80px">Second message</m-toast>
+    <m-toast state="information"
+             position="bottom-right"
+             :open.sync="offSetOpen"
+             offset="-160px">Third message</m-toast>
 
     <h3>Toast with a custom action</h3>
     <p class="m-u--margin-bottom">
         Toast can be passed an action-label and they emit a action-button event.
     </p>
     <m-button @click="actionOpen = !actionOpen">Toggle Toast</m-button>
-    <m-toast state="warning" position="bottom-right" :open.sync="actionOpen" @action-button="doSomething('funny')" action-label="Alert">Toast with an action</m-toast>
+    <m-toast state="warning"
+             position="bottom-right"
+             :open.sync="actionOpen"
+             @action-button="doSomething('funny')"
+             action-label="Alert">Toast with an action</m-toast>
 
     <h3>Toast without an icon</h3>
     <p class="m-u--margin-bottom">
         Icons are present by default, but you can remove them.
     </p>
     <m-button @click="iconOpen = !iconOpen">Toggle Toast</m-button>
-    <m-toast :icon="false" state="information" position="bottom-right" :open.sync="iconOpen">Toast without icône</m-toast>
+    <m-toast :icon="false"
+             state="information"
+             position="bottom-right"
+             :open.sync="iconOpen">Toast without icône</m-toast>
 
     <h3>Toast with multiple options</h3>
     <p class="m-u--margin-bottom">
@@ -65,14 +87,14 @@
              :open.sync="allOpen"
              action-label="Réessayer de faire le questionnaire"
              @action-button="doSomething('funny')">
-            Les 3 informations en rouge sont à revoir pour continuer. On pourrait même mettre un texte plus long
+        Les 3 informations en rouge sont à revoir pour continuer. On pourrait même mettre un texte plus long
     </m-toast>
     <m-toast state="information"
              position="bottom-center"
-            :open.sync="allOpen"
-            :is-same-line="true"
-            action-label="Yay!"
-            @action-button="doSomething('funny')">
-            Give him a friend, we forget the trees get lonely too. We'll do another happy little painting. Absolutely no pressure. You are just a whisper floating across a mountain.
+             :open.sync="allOpen"
+             :is-same-line="true"
+             action-label="Yay!"
+             @action-button="doSomething('funny')">
+        Give him a friend, we forget the trees get lonely too. We'll do another happy little painting. Absolutely no pressure. You are just a whisper floating across a mountain.
     </m-toast>
 </div>

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -20,7 +20,6 @@ $m-toast-max-width: 768px;
 .m-toast {
     text-align: left;
     position: fixed;
-    z-index: 2;
 
     &__wrap {
         position: relative;

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -122,7 +122,7 @@ $m-toast-max-width: 768px;
     }
 
     &.m--is-top {
-        top: 60px;
+        top: 0;
 
         .m-toast__wrap {
             border-bottom: $m-border-width--l solid;

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -68,23 +68,11 @@ $m-toast-max-width: 768px;
         }
     }
 
-    &.m--is-enter-active,
-    &.m--is-leave-active {
-        transition: background linear;
-    }
-
-    &.m--is-enter-active {
-        .m-toast__wrap {
-            transition: $m-transition-duration--xl;
-            transition-timing-function: ease-out;
-        }
-    }
-
     &.m--is-leave-active {
         &,
         .m-toast__wrap {
-            transition: $m-transition-duration--s;
-            transition-timing-function: ease-in;
+            opacity: 0;
+            transition: opacity $m-transition-duration ease-in-out;
         }
     }
 
@@ -133,12 +121,6 @@ $m-toast-max-width: 768px;
                 transform: translateY(-130%);
             }
         }
-
-        &.m--is-leave-active {
-            .m-toast__wrap {
-                transform: translateY(-130%);
-            }
-        }
     }
 
     &.m--is-bottom {
@@ -147,12 +129,6 @@ $m-toast-max-width: 768px;
         }
 
         &.m--is-enter-active {
-            .m-toast__wrap {
-                transform: translateY(130%);
-            }
-        }
-
-        &.m--is-leave-active {
             .m-toast__wrap {
                 transform: translateY(130%);
             }

--- a/src/components/toast/toast.spec.ts
+++ b/src/components/toast/toast.spec.ts
@@ -3,8 +3,7 @@ import Vue, { VueConstructor } from 'vue';
 import { resetModulPlugins } from '../../../tests/helpers/component';
 import { PortalStub } from '../../../tests/helpers/render';
 import { Portal, PortalMixin } from '../../mixins/portal/portal';
-import { MMessageState } from '../message/message';
-import ToastPlugin, { MToast, MToastPosition } from './toast';
+import ToastPlugin, { MToast, MToastPosition, MToastState } from './toast';
 
 jest.useFakeTimers();
 let wrapper: Wrapper<MToast>;
@@ -48,7 +47,7 @@ describe(`MToast`, () => {
             });
 
             it(`Should be in Confirmation state`, () => {
-                expect(wrapper.vm.state).toEqual(MMessageState.Confirmation);
+                expect(wrapper.vm.state).toEqual(MToastState.Confirmation);
             });
 
             it(`Should be in the bottom-right position`, () => {

--- a/src/components/toast/toast.spec.ts
+++ b/src/components/toast/toast.spec.ts
@@ -55,8 +55,8 @@ describe(`MToast`, () => {
                 expect(wrapper.vm.position).toEqual(MToastPosition.BottomRight);
             });
 
-            it(`Should have a timeout set to 0`, () => {
-                expect(wrapper.vm.timeout).toEqual(0);
+            it(`Should have a timeout set to none`, () => {
+                expect(wrapper.vm.timeout).toEqual('none');
             });
 
             it(`Should have an icon`, () => {
@@ -110,7 +110,7 @@ describe(`MToast`, () => {
             it(`Should appear and then disappear`, () => {
                 initializeWrapper();
                 wrapper.setProps({
-                    timeout: 5000
+                    timeout: 'short'
                 });
                 jest.runOnlyPendingTimers(); // wait for component to be instancialized
 

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -12,7 +12,6 @@ import I18nPlugin from '../i18n/i18n';
 import IconButtonPlugin from '../icon-button/icon-button';
 import IconPlugin from '../icon/icon';
 import { MLinkMode } from '../link/link';
-import { MMessageState } from '../message/message';
 import WithRender from './toast.html?style=./toast.scss';
 
 export enum MToastTimeout {
@@ -30,20 +29,27 @@ export enum MToastPosition {
     BottomRight = 'bottom-right'
 }
 
+export enum MToastState {
+    Confirmation = 'confirmation',
+    Information = 'information',
+    Warning = 'warning',
+    Error = 'error'
+}
+
 @WithRender
 @Component({
     mixins: [MediaQueries, Portal]
 })
 export class MToast extends ModulVue implements PortalMixinImpl {
     @Prop({
-        default: MMessageState.Confirmation,
+        default: MToastState.Confirmation,
         validator: value =>
-            value === MMessageState.Confirmation ||
-            value === MMessageState.Information ||
-            value === MMessageState.Warning ||
-            value === MMessageState.Error
+            value === MToastState.Confirmation ||
+            value === MToastState.Information ||
+            value === MToastState.Warning ||
+            value === MToastState.Error
     })
-    public state: MMessageState;
+    public state: MToastState;
 
     @Prop({
         default: MToastPosition.BottomRight,
@@ -146,19 +152,19 @@ export class MToast extends ModulVue implements PortalMixinImpl {
     }
 
     private get isStateInformation(): boolean {
-        return this.state === MMessageState.Information;
+        return this.state === MToastState.Information;
     }
 
     private get isStateWarning(): boolean {
-        return this.state === MMessageState.Warning;
+        return this.state === MToastState.Warning;
     }
 
     private get isStateError(): boolean {
-        return this.state === MMessageState.Error;
+        return this.state === MToastState.Error;
     }
 
     private get isStateConfirmation(): boolean {
-        return this.state === MMessageState.Confirmation;
+        return this.state === MToastState.Confirmation;
     }
 
     public get isTop(): boolean {
@@ -185,16 +191,16 @@ export class MToast extends ModulVue implements PortalMixinImpl {
     private getIcon(): string {
         let icon: string = '';
         switch (this.state) {
-            case MMessageState.Confirmation:
+            case MToastState.Confirmation:
                 icon = 'm-svg__confirmation';
                 break;
-            case MMessageState.Information:
+            case MToastState.Information:
                 icon = 'm-svg__information';
                 break;
-            case MMessageState.Warning:
+            case MToastState.Warning:
                 icon = 'm-svg__warning';
                 break;
-            case MMessageState.Error:
+            case MToastState.Error:
                 icon = 'm-svg__error';
                 break;
             default:

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -124,24 +124,20 @@ export class MToast extends ModulVue implements PortalMixinImpl {
         }
     }
 
-    @Emit('action-button')
-    private actionButton(event: Event): void {
-    }
-
     private convertTimeout(timeout: MToastTimeout): number {
         switch (timeout) {
-            case 'long':
+            case MToastTimeout.long:
                 return 15000;
-            case 'short':
+            case MToastTimeout.short:
                 return 5000;
-            case 'none':
+            case MToastTimeout.none:
             default:
                 return 0;
         }
     }
 
-    private onAction($event): void {
-        this.$emit('action-button', $event);
+    @Emit('action-button')
+    private onAction(event: Event): void {
         this.onClose();
     }
 

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -141,7 +141,7 @@ export class MToast extends ModulVue implements PortalMixinImpl {
         return this.state === MMessageState.Confirmation;
     }
 
-    private get isTop(): boolean {
+    public get isTop(): boolean {
         return this.position === MToastPosition.TopLeft ||
             this.position === MToastPosition.TopCenter ||
             this.position === MToastPosition.TopRight;

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -15,6 +15,11 @@ import { MLinkMode } from '../link/link';
 import { MMessageState } from '../message/message';
 import WithRender from './toast.html?style=./toast.scss';
 
+export enum MToastTimeout {
+    none = 'none',
+    short = 'short',
+    long = 'long'
+}
 
 export enum MToastPosition {
     TopLeft = 'top-left',
@@ -53,9 +58,13 @@ export class MToast extends ModulVue implements PortalMixinImpl {
     public position: MToastPosition;
 
     @Prop({
-        default: 0
+        default: MToastTimeout.none,
+        validator: value =>
+            value === MToastTimeout.none ||
+            value === MToastTimeout.short ||
+            value === MToastTimeout.long
     })
-    public timeout: number;
+    public timeout: MToastTimeout;
 
     @Prop()
     public open: boolean;
@@ -78,6 +87,7 @@ export class MToast extends ModulVue implements PortalMixinImpl {
     };
 
     private buttonMode: MLinkMode = MLinkMode.Button;
+    private internalTimeout: number;
 
     public doCustomPropOpen(value: boolean, el: HTMLElement): boolean {
         if (value) {
@@ -85,10 +95,12 @@ export class MToast extends ModulVue implements PortalMixinImpl {
                 this.getPortalElement().style.transform = `translateY(${this.offset})`;
             }
 
-            if (this.timeout) {
+            this.internalTimeout = this.convertTimeout(this.timeout);
+
+            if (this.internalTimeout > 0) {
                 setTimeout(() => {
                     this.onClose();
-                }, this.timeout);
+                }, this.internalTimeout);
             }
         }
         return true;
@@ -114,6 +126,18 @@ export class MToast extends ModulVue implements PortalMixinImpl {
 
     @Emit('action-button')
     private actionButton(event: Event): void {
+    }
+
+    private convertTimeout(timeout: MToastTimeout): number {
+        switch (timeout) {
+            case 'long':
+                return 15000;
+            case 'short':
+                return 5000;
+            case 'none':
+            default:
+                return 0;
+        }
     }
 
     private onAction($event): void {

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -96,6 +96,7 @@ export class MToast extends ModulVue implements PortalMixinImpl {
     private internalTimeout: number;
 
     public doCustomPropOpen(value: boolean, el: HTMLElement): boolean {
+        el.style.position = 'absolute';
         if (value) {
             if (this.offset !== '0') {
                 this.getPortalElement().style.transform = `translateY(${this.offset})`;

--- a/src/mixins/portal/portal.ts
+++ b/src/mixins/portal/portal.ts
@@ -115,7 +115,10 @@ export class Portal extends ModulVue implements PortalMixin {
         return this.internalTrigger;
     }
 
-    public tryClose(): void {
+    public async tryClose(): Promise<void> {
+        if (this.$toast) {
+            await this.$toast.clear();
+        }
         if (this.$modul.peekElement() === this.stackId) {
             if (this.$listeners && this.$listeners.beforeClose) {
                 this.$emit('beforeClose', (close: boolean) => {

--- a/src/utils/toast/toast-service.sandbox.html
+++ b/src/utils/toast/toast-service.sandbox.html
@@ -1,0 +1,12 @@
+<div>
+    <h3>Toast Manager</h3>
+    <p class="m-u--margin-bottom">
+        Sandbox Parameters
+    </p>
+    <div>
+        <button @click="init()">Show toast</button>
+        <button @click="otherToast()">Show other toast</button>
+        <button @click="complex()">Show a complex toast</button>
+    </div>
+    <button @click="clear()">Clear</button>
+</div>

--- a/src/utils/toast/toast-service.sandbox.html
+++ b/src/utils/toast/toast-service.sandbox.html
@@ -4,10 +4,27 @@
         Sandbox Parameters
     </p>
     <div>
-        <button @click="init()">Show toast</button>
-        <button @click="otherToast()">Show other toast</button>
-        <button @click="complex()">Show a complex toast</button>
-        <button @click="error()">Show an error toast</button>
+        <m-button @click="init()">Show toast</m-button>
+        <m-button @click="otherToast()">Show other toast</m-button>
+        <m-button @click="complex()">Show a complex toast</m-button>
+        <m-button @click="error()">Show an error toast</m-button>
     </div>
-    <button @click="clear()">Clear</button>
+    <p class="m-u--margin-bottom">
+        Show toast over a modal/overlay
+    </p>
+    <div>
+        <m-overlay title="Overlay">
+            <m-button slot="trigger">Open the Overlay</m-button>
+            <m-button @click="successToast()">Do Action</m-button>
+        </m-overlay>
+
+        <m-modal title="Modal">
+            <m-button slot="trigger">Open the modal</m-button>
+            <m-button @click="successToast()">Do Action</m-button>
+        </m-modal>
+    </div>
+    <p class="m-u--margin-bottom">
+        Remove active toast
+    </p>
+    <m-button @click="clear()">Clear</m-button>
 </div>

--- a/src/utils/toast/toast-service.sandbox.html
+++ b/src/utils/toast/toast-service.sandbox.html
@@ -7,6 +7,7 @@
         <button @click="init()">Show toast</button>
         <button @click="otherToast()">Show other toast</button>
         <button @click="complex()">Show a complex toast</button>
+        <button @click="error()">Show an error toast</button>
     </div>
     <button @click="clear()">Clear</button>
 </div>

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -53,6 +53,15 @@ export class MToastServiceSandbox extends ModulVue {
         });
     }
 
+    public error(): void {
+        this.$toast.error({
+            text: 'You have an error',
+            actionLabel: 'retry',
+            action: this.action,
+            icon: true
+        });
+    }
+
     public action(event: Event): void {
         alert(`Type of event ${event.type}`);
     }

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -16,6 +16,14 @@ export class MToastServiceSandbox extends ModulVue {
         actionLabel: 'txt'
     };
 
+    created(): void {
+        this.$toast.baseTopPosition = '60px';
+    }
+
+    destroy(): void {
+        this.clear();
+    }
+
     public init(): void {
         this.$toast.show(this.simpleToastParams);
     }

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -2,7 +2,7 @@
 import { Component } from 'vue-property-decorator';
 import { PluginObject } from 'vue/types/plugin';
 import { MMessageState } from '../../components/message/message';
-import { MToastPosition } from '../../components/toast/toast';
+import { MToastPosition, MToastTimeout } from '../../components/toast/toast';
 import { ModulVue } from '../../utils/vue/vue';
 import { TOAST } from '../utils-names';
 import { ToastParams } from './toast-service';
@@ -48,17 +48,18 @@ export class MToastServiceSandbox extends ModulVue {
             action: this.action,
             icon: true,
             state: MMessageState.Warning,
-            timeout: 2000,
+            timeout: MToastTimeout.short,
             text: 'Test of a Toast'
         });
     }
 
     public error(): void {
-        this.$toast.error({
+        this.$toast.show({
             text: 'You have an error',
             actionLabel: 'retry',
             action: this.action,
-            icon: true
+            icon: true,
+            state: MMessageState.Error
         });
     }
 

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -1,0 +1,52 @@
+
+import { Component } from 'vue-property-decorator';
+import { PluginObject } from 'vue/types/plugin';
+import { MMessageState } from '../../components/message/message';
+import { MToastPosition } from '../../components/toast/toast';
+import { ModulVue } from '../../utils/vue/vue';
+import { TOAST } from '../utils-names';
+import { ToastParams } from './toast-service';
+import WithRender from './toast-service.sandbox.html';
+
+@WithRender
+@Component
+export class MToastServiceSandbox extends ModulVue {
+    public simpleToastParams: ToastParams = {
+        text: 'A simple toast with text',
+        actionLabel: 'txt'
+    };
+
+    public init(): void {
+        this.$toast.show(this.simpleToastParams);
+    }
+
+    public otherToast(): void {
+        this.$toast.show({
+            text: 'Other toast',
+            actionLabel: 'Action'
+        });
+    }
+
+    public clear(): void {
+        this.$toast.clear();
+    }
+
+    public complex(): void {
+        this.$toast.show({
+            position: MToastPosition.TopCenter,
+            actionLabel: 'ACTION',
+            icon: true,
+            state: MMessageState.Warning,
+            timeout: 2000,
+            text: 'Test of a Toast'
+        });
+    }
+}
+
+const MToastServiceSandboxPlugin: PluginObject<any> = {
+    install(v, options): void {
+        v.component(`${TOAST}-sandbox`, MToastServiceSandbox);
+    }
+};
+
+export default MToastServiceSandboxPlugin;

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -13,7 +13,8 @@ import WithRender from './toast-service.sandbox.html';
 export class MToastServiceSandbox extends ModulVue {
     public simpleToastParams: ToastParams = {
         text: 'A simple toast with text',
-        actionLabel: 'txt'
+        actionLabel: 'txt',
+        action: this.action
     };
 
     created(): void {
@@ -31,7 +32,8 @@ export class MToastServiceSandbox extends ModulVue {
     public otherToast(): void {
         this.$toast.show({
             text: 'Other toast',
-            actionLabel: 'Action'
+            actionLabel: 'Action',
+            action: this.action
         });
     }
 
@@ -43,11 +45,16 @@ export class MToastServiceSandbox extends ModulVue {
         this.$toast.show({
             position: MToastPosition.TopCenter,
             actionLabel: 'ACTION',
+            action: this.action,
             icon: true,
             state: MMessageState.Warning,
             timeout: 2000,
             text: 'Test of a Toast'
         });
+    }
+
+    public action(event: Event): void {
+        alert(`Type of event ${event.type}`);
     }
 }
 

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -1,8 +1,7 @@
 
 import { Component } from 'vue-property-decorator';
 import { PluginObject } from 'vue/types/plugin';
-import { MMessageState } from '../../components/message/message';
-import { MToastPosition, MToastTimeout } from '../../components/toast/toast';
+import { MToastPosition, MToastState, MToastTimeout } from '../../components/toast/toast';
 import { ModulVue } from '../../utils/vue/vue';
 import { TOAST } from '../utils-names';
 import { ToastParams } from './toast-service';
@@ -47,7 +46,7 @@ export class MToastServiceSandbox extends ModulVue {
             actionLabel: 'ACTION',
             action: this.action,
             icon: true,
-            state: MMessageState.Warning,
+            state: MToastState.Warning,
             timeout: MToastTimeout.short,
             text: 'Test of a Toast'
         });
@@ -59,7 +58,7 @@ export class MToastServiceSandbox extends ModulVue {
             actionLabel: 'retry',
             action: this.action,
             icon: true,
-            state: MMessageState.Error
+            state: MToastState.Error
         });
     }
 

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -36,6 +36,14 @@ export class MToastServiceSandbox extends ModulVue {
         });
     }
 
+    public successToast(): void {
+        this.$toast.show({
+            text: 'success toast',
+            actionLabel: 'UNDO',
+            action: this.action
+        });
+    }
+
     public clear(): void {
         this.$toast.clear();
     }

--- a/src/utils/toast/toast-service.spec.ts
+++ b/src/utils/toast/toast-service.spec.ts
@@ -23,8 +23,9 @@ describe(`The Toast Manager`, () => {
         mockToast = {
             text: '1st',
             $createElement: jest.fn(),
-            $slots: {}
-
+            $slots: {},
+            $destroy: jest.fn(),
+            $on: jest.fn()
         };
         toastManager = new ToastService();
         mockCreateElement.mockClear();
@@ -73,15 +74,13 @@ describe(`The Toast Manager`, () => {
         });
 
         describe(`When the service is called to clear the toast`, () => {
-            it(`Should turn off the toast`, () => {
-                const toast: MToast = toastManager.activeToast;
-
+            it(`Should contain no toasts`, () => {
                 toastManager.clear();
 
-                expect(toast.open).toBe(false);
+                expect(toastManager.toasts.length).toBe(0);
             });
 
-            it(`Should contain no toast`, () => {
+            it(`Should contain no active toast`, () => {
                 toastManager.clear();
 
                 expect(toastManager.activeToast).toBeFalsy();

--- a/src/utils/toast/toast-service.spec.ts
+++ b/src/utils/toast/toast-service.spec.ts
@@ -1,0 +1,93 @@
+import { MToast } from '../../components/toast/toast';
+import { ToastParams, ToastService } from './toast-service';
+
+let mockToast: any = {};
+jest.mock('../../components/toast/toast', () => {
+    return {
+        MToast: jest.fn().mockImplementation(() => {
+            return mockToast;
+        })
+    };
+});
+
+const mockCreateElement: jest.Mock = jest.fn();
+document.createElement = mockCreateElement;
+
+const simpleToastParams: ToastParams = {
+    text: 'txt'
+};
+
+describe(`The Toast Manager`, () => {
+    let toastManager: ToastService;
+    beforeEach(() => {
+        mockToast = {
+            text: '1st',
+            $createElement: jest.fn(),
+            $slots: {}
+
+        };
+        toastManager = new ToastService();
+        mockCreateElement.mockClear();
+        ((MToast as unknown) as jest.Mock).mockClear();
+    });
+
+    describe(`Given the service has never been called`, () => {
+
+        it(`should not have a toast`, () => {
+            expect(toastManager.activeToast).toBeFalsy();
+        });
+
+        it(`When the service is called to show a toast, it should show a Toast`, () => {
+            toastManager.show(simpleToastParams);
+
+            expect(toastManager.activeToast).toBeTruthy();
+            expect(document.createElement).toHaveBeenCalledTimes(1);
+            expect(document.createElement).toHaveBeenCalledWith('div');
+        });
+
+    });
+
+    describe(`Given the service has been called once`, () => {
+        let firstToast: MToast;
+        const secondToastParams: ToastParams = {
+            text: 'otherTxt'
+        };
+        beforeEach(() => {
+            toastManager.show(simpleToastParams);
+            firstToast = { ...toastManager.activeToast } as any;
+        });
+
+        describe(`When the service is called twice`, () => {
+            it(`should only show one toast`, () => {
+                toastManager.show(secondToastParams);
+
+                expect(toastManager.toasts.length).toBe(1);
+            });
+
+            it(`should change the toast`, () => {
+                toastManager.show(secondToastParams);
+
+                const secondToast: MToast = toastManager.activeToast;
+                expect(firstToast).not.toBe(secondToast);
+            });
+        });
+
+        describe(`When the service is called to clear the toast`, () => {
+            it(`Should turn off the toast`, () => {
+                const toast: MToast = toastManager.activeToast;
+
+                toastManager.clear();
+
+                expect(toast.open).toBe(false);
+            });
+
+            it(`Should contain no toast`, () => {
+                toastManager.clear();
+
+                expect(toastManager.activeToast).toBeFalsy();
+            });
+        });
+
+    });
+
+});

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -1,7 +1,7 @@
 import { PluginObject } from 'vue/types/plugin';
 import { VNode } from 'vue/types/vnode';
 import { MMessageState } from '../../components/message/message';
-import { MToast, MToastPosition } from '../../components/toast/toast';
+import { MToast, MToastPosition, MToastTimeout } from '../../components/toast/toast';
 
 export interface ToastParams {
     text: string;
@@ -9,16 +9,7 @@ export interface ToastParams {
     action?: (event: Event) => any;
     state?: MMessageState;
     position?: MToastPosition;
-    timeout?: number;
-    icon?: boolean;
-}
-
-export interface ToastErrorParams {
-    text: string;
-    actionLabel?: string;
-    action?: (event: Event) => any;
-    position?: MToastPosition;
-    timeout?: number;
+    timeout?: MToastTimeout;
     icon?: boolean;
 }
 
@@ -28,12 +19,6 @@ export class ToastService {
     public activeToast?: MToast;
     public toasts: MToast[] = [];
     public baseTopPosition: string = '0';
-
-    public error(errorParams: ToastErrorParams): void {
-        let params: ToastParams = { ...errorParams };
-        params.state = MMessageState.Error;
-        this.show(params);
-    }
 
     public show(params: ToastParams): void {
         const toast: MToast = this.createToast(params);

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -32,12 +32,15 @@ export class ToastService {
         }
     }
 
-    public clear(): void {
+    public async clear(): Promise<void> {
         if (this.activeToast) {
             this.activeToast.open = false;
         }
         this.toasts = [];
         this.activeToast = undefined;
+        return new Promise(resolve => {
+            setTimeout(() => resolve(), TIME_BEFORE_ANIMATION_IS_OVER);
+        }).then(() => { });
     }
 
     private createToast(params: ToastParams): MToast {

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -38,9 +38,9 @@ export class ToastService {
         }
         this.toasts = [];
         this.activeToast = undefined;
-        return new Promise(resolve => {
+        return new Promise<void>(resolve => {
             setTimeout(() => resolve(), TIME_BEFORE_ANIMATION_IS_OVER);
-        }).then(() => { });
+        });
     }
 
     private createToast(params: ToastParams): MToast {

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -1,13 +1,12 @@
 import { PluginObject } from 'vue/types/plugin';
 import { VNode } from 'vue/types/vnode';
-import { MMessageState } from '../../components/message/message';
-import { MToast, MToastPosition, MToastTimeout } from '../../components/toast/toast';
+import { MToast, MToastPosition, MToastState, MToastTimeout } from '../../components/toast/toast';
 
 export interface ToastParams {
     text: string;
     actionLabel?: string;
     action?: (event: Event) => any;
-    state?: MMessageState;
+    state?: MToastState;
     position?: MToastPosition;
     timeout?: MToastTimeout;
     icon?: boolean;

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -12,12 +12,28 @@ export interface ToastParams {
     timeout?: number;
     icon?: boolean;
 }
-const TIME_BEFORE_ANIMATION_IS_OVER: number = 200;
+
+export interface ToastErrorParams {
+    text: string;
+    actionLabel?: string;
+    action?: (event: Event) => any;
+    position?: MToastPosition;
+    timeout?: number;
+    icon?: boolean;
+}
+
+const TIME_BEFORE_ANIMATION_IS_OVER: number = 300;
 
 export class ToastService {
     public activeToast?: MToast;
     public toasts: MToast[] = [];
     public baseTopPosition: string = '0';
+
+    public error(errorParams: ToastErrorParams): void {
+        let params: ToastParams = { ...errorParams };
+        params.state = MMessageState.Error;
+        this.show(params);
+    }
 
     public show(params: ToastParams): void {
         const toast: MToast = this.createToast(params);
@@ -32,7 +48,7 @@ export class ToastService {
         }
     }
 
-    public async clear(): Promise<any> {
+    public clear(): void {
         if (this.activeToast) {
             this.activeToast.open = false;
         }

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -1,0 +1,62 @@
+import { PluginObject } from 'vue/types/plugin';
+import { VNode } from 'vue/types/vnode';
+import { MMessageState } from '../../components/message/message';
+import { MToast, MToastPosition } from '../../components/toast/toast';
+
+export interface ToastParams {
+    text: string;
+    actionLabel?: string;
+    state?: MMessageState;
+    position?: MToastPosition;
+    timeout?: number;
+    icon?: boolean;
+}
+export class ToastService {
+    public activeToast: MToast;
+    public toasts: MToast[] = [];
+    public show(params: ToastParams): void {
+        const toast: MToast = this.createToast(params);
+        this.toasts.push(toast);
+
+        if (!this.activeToast) {
+            this.activeToast = this.toasts[0];
+        } else {
+            this.activeToast.open = false;
+            this.activeToast = this.toasts[1];
+            this.toasts.splice(0, 1);
+        }
+    }
+
+    public clear(): void {
+        this.activeToast.open = false;
+        this.toasts = [];
+        delete (this.activeToast);
+    }
+
+    private createToast(params: ToastParams): MToast {
+        const toast: MToast = new MToast({
+            el: document.createElement('div'),
+            propsData: {
+                ['open.sync']: true,
+                state: params.state,
+                position: params.position,
+                timeout: params.timeout,
+                actionLabel: params.actionLabel,
+                icon: params.icon
+            }
+        });
+
+        const vnode: VNode = toast.$createElement('p', [params.text]);
+        toast.$slots.default = [vnode];
+        return toast;
+    }
+}
+
+const ToastPlugin: PluginObject<any> = {
+    install(v): void {
+        let toast: ToastService = new ToastService();
+        (v.prototype as any).$toast = toast;
+    }
+};
+
+export default ToastPlugin;

--- a/src/utils/utils-names.ts
+++ b/src/utils/utils-names.ts
@@ -9,3 +9,4 @@ export const MODUL: string = 'modul';
 export const MQ: string = 'mq';
 export const SCROLL_TO: string = 'scrollTo';
 export const SVG: string = 'svg';
+export const TOAST: string = 'toast';

--- a/src/utils/utils-plugin.ts
+++ b/src/utils/utils-plugin.ts
@@ -1,7 +1,6 @@
 import { PortalPluginInstall } from 'portal-vue';
 import Vue, { PluginObject } from 'vue';
 import * as TouchPlugin from 'vue-touch';
-
 import AlertPlugin from './dialog/alert';
 import ConfirmPlugin from './dialog/confirm';
 import { WindowErrorHandler } from './errors/window-error-handler';
@@ -13,6 +12,7 @@ import MediaQueriesPlugin from './media-queries/media-queries';
 import ModulPlugin from './modul/modul';
 import ScrollToPlugin from './scroll-to/scroll-to';
 import SpritesPlugin from './svg/sprites';
+import ToastPlugin from './toast/toast-service';
 
 export interface UtilsPluginOptions {
     httpPluginOptions?: HttpPluginOptions;
@@ -47,6 +47,7 @@ const UtilsPlugin: PluginObject<any> = {
         Vue.use(AlertPlugin);
         Vue.use(FilePlugin);
         Vue.use(ScrollToPlugin);
+        Vue.use(ToastPlugin);
     }
 };
 

--- a/src/utils/vue/vue.ts
+++ b/src/utils/vue/vue.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
-
 import { AlertFunction } from '../dialog/alert';
 import { ConfirmFunction } from '../dialog/confirm';
 import { FileService } from '../file/file';
@@ -11,6 +10,7 @@ import { Logger } from '../logger/logger';
 import { MediaQueries } from '../media-queries/media-queries';
 import { Modul } from '../modul/modul';
 import { ScrollTo } from '../scroll-to/scroll-to';
+import { ToastService } from '../toast/toast-service';
 
 // TODO: explore usage of TS declare syntax
 // declare module 'vue/types/vue' {
@@ -31,6 +31,7 @@ export class ModulVue extends Vue {
     public $file: FileService;
     public $log: Logger;
     public $license: Licenses;
+    public $toast: ToastService;
 
     protected getParent<T extends Vue>(test: (obj: Vue) => boolean): T | undefined {
         let p: Vue = this.$parent;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Add a service to wrap the toast component, so you can conveniently use Vue.prototype.$toast.show() and Vue.prototype.$toast.clear(). Or this.$toast when in a ModulVue. It only shows one toast at a time.

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/ENA2-3388
- [ x] Openshift deployment requested
http://feature-toast-manager-ul-modul-dv01.pca.svc.ulaval.ca

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
BREAKING CHANGE: For the toast component, timeout is now a enum (none, short, long) => (0, 5 or 15 secondes) instead of numerical value.
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
