### PR TITLE
Feature/modul 615 show more more flexible

### DIFF
--- a/src/components/show-more/__snapshots__/show-more.spec.ts.snap
+++ b/src/components/show-more/__snapshots__/show-more.spec.ts.snap
@@ -17,4 +17,6 @@ exports[`m-show-more Given nbVisible == nbTotal Should render correctly 1`] = `
 
 exports[`m-show-more With nbTotal equals to 0 Should not render anything 1`] = `""`;
 
+exports[`m-show-more With nbTotal inferior to 0 Should not render anything 1`] = `""`;
+
 exports[`m-show-more Without nbTotal specified Should not render anything 1`] = `""`;

--- a/src/components/show-more/__snapshots__/show-more.spec.ts.snap
+++ b/src/components/show-more/__snapshots__/show-more.spec.ts.snap
@@ -15,4 +15,6 @@ exports[`m-show-more Given nbVisible == nbTotal Should render correctly 1`] = `
 </div>
 `;
 
+exports[`m-show-more With nbTotal equals to 0 Should not render anything 1`] = `""`;
+
 exports[`m-show-more Without nbTotal specified Should not render anything 1`] = `""`;

--- a/src/components/show-more/show-more.sandbox.html
+++ b/src/components/show-more/show-more.sandbox.html
@@ -1,16 +1,19 @@
 <div>
+    <h3>m-show-more - With nbTotal > 0</h3>
     <m-show-more :nb-visible="data.length"
                  :nb-total="total"
                  :loading.sync="loading"
                  @click="fetchData">
     </m-show-more>
 
+    <h3>m-show-more - With nbTotal = undefined</h3>
     <m-show-more :nb-visible="totalZero"
                  :nb-total="totalUndefined"
                  :loading.sync="loading"
                  @click="fetchData">
     </m-show-more>
 
+    <h3>m-show-more - With nbTotal = 0</h3>
     <m-show-more :nb-visible="totalZero"
                  :nb-total="totalZero"
                  :loading.sync="loading"

--- a/src/components/show-more/show-more.sandbox.html
+++ b/src/components/show-more/show-more.sandbox.html
@@ -1,5 +1,19 @@
-<m-show-more :nb-visible="data.length"
-             :nb-total="total"
-             :loading.sync="loading"
-             @click="fetchData">
-</m-show-more>
+<div>
+    <m-show-more :nb-visible="data.length"
+                 :nb-total="total"
+                 :loading.sync="loading"
+                 @click="fetchData">
+    </m-show-more>
+
+    <m-show-more :nb-visible="totalZero"
+                 :nb-total="totalUndefined"
+                 :loading.sync="loading"
+                 @click="fetchData">
+    </m-show-more>
+
+    <m-show-more :nb-visible="totalZero"
+                 :nb-total="totalZero"
+                 :loading.sync="loading"
+                 @click="fetchData">
+    </m-show-more>
+</div>

--- a/src/components/show-more/show-more.sandbox.ts
+++ b/src/components/show-more/show-more.sandbox.ts
@@ -8,6 +8,8 @@ import WithRender from './show-more.sandbox.html';
 export class MShowMoreSandbox extends Vue {
     data: number[] = [];
     total: number = 20;
+    totalZero: number = 0;
+    totalUndefined: undefined = undefined;
     loading: boolean = false;
 
     fetchData(): void {

--- a/src/components/show-more/show-more.spec.ts
+++ b/src/components/show-more/show-more.spec.ts
@@ -29,11 +29,34 @@ describe(SHOW_MORE_NAME, () => {
     });
 
     describe(`With nbTotal equals to 0`, () => {
-        it(`Should not render anything`, () => {
-            initializeShallowWrapper();
-            wrapper.setProps({ nbVisible: 0, nbTotal: 0 });
 
+        beforeEach(() => {
+            initializeShallowWrapper();
+            wrapper.setProps({ nbVisible: 0, nbTotal: -2 });
+        });
+
+        it(`Should not render anything`, () => {
             expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
+        });
+
+        it(`Should not be visible`, () => {
+            expect(wrapper.vm.isVisible).toBeFalsy();
+        });
+    });
+
+    describe(`With nbTotal inferior to 0`, () => {
+
+        beforeEach(() => {
+            initializeShallowWrapper();
+            wrapper.setProps({ nbVisible: 0, nbTotal: -2 });
+        });
+
+        it(`Should not render anything`, () => {
+            expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
+        });
+
+        it(`Should not be visible`, () => {
+            expect(wrapper.vm.isVisible).toBeFalsy();
         });
     });
 
@@ -67,6 +90,10 @@ describe(SHOW_MORE_NAME, () => {
 
         it(`Should render correctly`, () => {
             expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
+        });
+
+        it(`Should be visible`, () => {
+            expect(wrapper.vm.isVisible).toBeTruthy();
         });
 
         it(`Should render a button`, () => {

--- a/src/components/show-more/show-more.spec.ts
+++ b/src/components/show-more/show-more.spec.ts
@@ -28,6 +28,13 @@ describe(SHOW_MORE_NAME, () => {
         });
     });
 
+    describe(`With nbTotal equals to 0`, () => {
+        it(`Should not render anything`, () => {
+            initializeShallowWrapper();
+            expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
+        });
+    });
+
     describe(`Given nbVisible and nbTotal`, () => {
         beforeEach(() => {
             initializeShallowWrapper();

--- a/src/components/show-more/show-more.spec.ts
+++ b/src/components/show-more/show-more.spec.ts
@@ -31,6 +31,8 @@ describe(SHOW_MORE_NAME, () => {
     describe(`With nbTotal equals to 0`, () => {
         it(`Should not render anything`, () => {
             initializeShallowWrapper();
+            wrapper.setProps({ nbVisible: 0, nbTotal: 0 });
+
             expect(renderComponent(wrapper.vm)).resolves.toMatchSnapshot();
         });
     });

--- a/src/components/show-more/show-more.ts
+++ b/src/components/show-more/show-more.ts
@@ -20,7 +20,7 @@ export class MShowMore extends ModulVue {
     loading: boolean;
 
     get isVisible(): boolean {
-        return this.nbTotal !== undefined;
+        return this.nbTotal !== undefined && this.nbTotal !== 0;
     }
 
     get status(): string {

--- a/src/components/show-more/show-more.ts
+++ b/src/components/show-more/show-more.ts
@@ -20,7 +20,7 @@ export class MShowMore extends ModulVue {
     loading: boolean;
 
     get isVisible(): boolean {
-        return this.nbTotal !== undefined && this.nbTotal !== 0;
+        return this.nbTotal !== undefined && this.nbTotal > 0;
     }
 
     get status(): string {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Dans Brio, nous ne pouvons initialiser le champ nbResultatsTotal (API) de type number à undefined dans le but de masquer le show-more. 

Il est aussi étrange de pouvoir afficher le show-more si le nombre est à 0.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-615
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
