### PR TITLE
MODUL-643 - Un champ de saisie avec la prop valid="true" devrait être vert

### DIFF
--- a/src/components/input-style/input-style.scss
+++ b/src/components/input-style/input-style.scss
@@ -66,13 +66,7 @@
     }
 
     &.m--is-valid {
-        &::before {
-            border-color: $m-input-style--color-valid;
-        }
-
-        &::after {
-            background: $m-input-style--color-valid;
-        }
+        border-color: $m-input-style--color-valid;
 
         .m-input-style__label,
         .m-icon-button.m-icon-button,

--- a/src/components/textfield/textfield.sandbox.html
+++ b/src/components/textfield/textfield.sandbox.html
@@ -111,6 +111,10 @@
                  helper-message="this message is helping you understand the component awesome feature">
     </m-textfield>
 
+    <h3 class="m-u--h6">Valid message</h3>
+    <m-textfield label="label"
+                 valid-message="Valid textfield"></m-textfield>
+
     <h2>Word-wrap</h2>
     <p class="m-u--margin-top">The <b>type</b> of the textfield must be <b>text</b> and have the prop <b>word-wrap</b> set at <b>true</b> </p>
     <m-textfield class="m-u--margin-top"


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Ajustement du visuel du m-input-style lorsque la prop `:valid="true"`.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-643
https://jira.dti.ulaval.ca/browse/GIN-321

<!-- Thanks for contributing! -->
