### PR TITLE
MODUL-647 - fix @font-face not working inside @support rule in edge

### DIFF
--- a/src/styles/base/_base.scss
+++ b/src/styles/base/_base.scss
@@ -1,17 +1,14 @@
 // ======================================================================
 //  font-face import
 // ======================================================================
-@supports (font-variation-settings: normal) {
-    @include font-face('Source Sans Variable', 'source-sans-variable/SourceSansVariable-Roman', $m-font-weight-range);
-    @include font-face('Source Sans Variable', 'source-sans-variable/SourceSansVariable-Italic', $m-font-weight-range, italic);
-}
 
-@supports not (font-variation-settings: normal) {
-    @include font-face('Source Sans Pro', 'source-sans-pro/SourceSansPro-Regular');
-    @include font-face('Source Sans Pro', 'source-sans-pro/SourceSansPro-Light', 300);
-    @include font-face('Source Sans Pro', 'source-sans-pro/SourceSansPro-Semibold', 600);
-}
-//
+// fallback
+@include font-face('Source Sans Pro', 'source-sans-pro/SourceSansPro-Regular');
+@include font-face('Source Sans Pro', 'source-sans-pro/SourceSansPro-Light', 300);
+@include font-face('Source Sans Pro', 'source-sans-pro/SourceSansPro-Semibold', 600);
+// font variable
+@include font-face('Source Sans Variable', 'source-sans-variable/SourceSansVariable-Roman', $m-font-weight-range);
+@include font-face('Source Sans Variable', 'source-sans-variable/SourceSansVariable-Italic', $m-font-weight-range, italic);
 
 .m-u--app-body {
     @supports (font-variation-settings: normal) {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
fix @font-face not working inside @support rule in edge
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-647
- [x]  Openshift deployment requested
http://feature-modul-647-font-face-ul-modul-dv01.pca.svc.ulaval.ca/typo-and-styles