### PR TITLE
MODUL-582 - Fixed parent auto-select multinode, added a test

### DIFF
--- a/src/components/tree/tree-node/tree-node.spec.ts
+++ b/src/components/tree/tree-node/tree-node.spec.ts
@@ -190,6 +190,15 @@ describe('MTreeNode', () => {
                             expect(wrapper.emitted('click')).toBeFalsy();
                         });
 
+                        it(`Should unselect parent when all children were selected but one changed`, () => {
+                            wrapper.find(CHECKBOX).trigger('click');
+                            expect(wrapper.vm.isIndeterminate).toBeFalsy();
+                            wrapper.setProps({
+                                selectedNodes: TREE_NODE_CHECKBOX_FIRST_CHILD.map(x => x)
+                            });
+                            expect(wrapper.vm.isIndeterminate).toBeTruthy();
+                        });
+
 
                     });
 

--- a/src/components/tree/tree-node/tree-node.ts
+++ b/src/components/tree/tree-node/tree-node.ts
@@ -52,7 +52,7 @@ export class MTreeNode extends ModulVue {
     @Watch('isSelected')
     public notifyParentOfChildCheckboxState(): void {
         if (this.withCheckboxes) {
-            if (!this.hasChildren) {
+            if (!this.hasChildren || this.isParentAutoSelect) {
                 this.$emit('auto-select-child-checkbox-change', this.isSelected);
             } else if (this.isButtonAutoSelect && this.hasChildren) {
                 this.onAutoSelectChildCheckboxChange(this.isSelected, true);


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
I noticed a small bug I propably added while refactoring code during my last pull request. 
ParentAutoSelectMode will now react to children going from selected to unselected by switching to indeterminated or off. 

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-582

- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
