### PR TITLE
addSprites returns the div ID, so it can be used with any sprite

### DIFF
--- a/src/utils/svg/sprites.ts
+++ b/src/utils/svg/sprites.ts
@@ -1,9 +1,8 @@
 import { PluginObject } from 'vue';
-
 import uuid from '../uuid/uuid';
 
 export class SpritesService {
-    public addSprites(sprites: string): void {
+    public addSprites(sprites: string): string {
         let div: HTMLDivElement = document.createElement('div');
         let id: string = uuid.generate();
         div.id = id;
@@ -11,6 +10,8 @@ export class SpritesService {
         div.style.display = 'none';
         div.innerHTML = sprites;
         document.body.insertBefore(div, document.body.childNodes[0]);
+
+        return id;
     }
 }
 


### PR DESCRIPTION
- [x ] Provide a small description of the changes introduced by this PR
SpritesService's addSprite methode returns the div id, so it can be used in m-icon
- [x ] Include links to issues
https://github.com/ulaval/modul-components/issues/654