### PR TITLE
MODUL-665 - M-Table - word-break: break-word

### DIFF
--- a/src/components/table/table.sandbox.html
+++ b/src/components/table/table.sandbox.html
@@ -101,35 +101,15 @@
         </template>
     </m-table>
 
-    <h2>With title</h2>
-    <m-table :columns="columns"
-             :rows="rows"
-             title="Title">
-    </m-table>
-
-    <h2>Search slot</h2>
-    <m-table :columns="columns"
-             :rows="rows">
-        <m-textfield slot="search"></m-textfield>
-    </m-table>
-
-    <h2>Add button</h2>
-    <m-table :columns="columns"
-             :rows="rows"
-             add-btn-label="Add label">
-    </m-table>
-
-    <h2>Full header</h2>
-    <m-table :columns="columns"
-             :rows="rows"
-             title="Title"
-             add-btn-label="Add label">
-        <m-textfield slot="search"></m-textfield>
-    </m-table>
-
     <h2>Loading</h2>
     <m-table :columns="columns"
              :rows="rows"
              :loading="true">
+    </m-table>
+
+    <h2>Content wrapping</h2>
+    <m-table :columns="columnsOverflow"
+             :rows="rowsOverflow"
+             style="max-width: 320px;">
     </m-table>
 </div>

--- a/src/components/table/table.sandbox.ts
+++ b/src/components/table/table.sandbox.ts
@@ -89,6 +89,52 @@ export class MTableSandbox extends Vue {
         }
     ];
 
+    columnsOverflow: MColumnTable[] = [
+        {
+            id: 'name',
+            title: 'Name',
+            dataProp: 'name'
+        },
+        {
+            id: 'email',
+            title: 'Email',
+            dataProp: 'email'
+        },
+        {
+            id: 'address',
+            title: 'Address',
+            dataProp: 'address'
+        }
+    ];
+
+    rowsOverflow: any[] = [
+        {
+            name: 'Jonathan',
+            email: 'gasdghfhagsdlhfagldshf@ashdhgflasdf.com',
+            address: '1234 fasjdfje iawueriajsdfahsdfahsdfhfhasjdhf'
+        },
+        {
+            name: 'Carl',
+            email: 'asghfksda@asdfasdf.com',
+            address: '23874 da sdkajsd kjashd'
+        },
+        {
+            name: 'Jacob',
+            email: 'weoirfksdbnsd@asdfjasbd.com',
+            address: '123 sad sdasdasd'
+        },
+        {
+            name: 'Vincent',
+            email: 'owiefkjsd893@asduahdwu.com',
+            address: '1 dsakjda'
+        },
+        {
+            name: 'Manon',
+            email: 'iewf@asda.com',
+            address: '120 ddqawdw'
+        }
+    ];
+
     emptyRows: any[] = [];
 
     editData(id: string): void {

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -1,6 +1,9 @@
 @import 'commons';
 
 .m-table {
+    table-layout: fixed;
+    width: 100%;
+
     thead {
         text-align: left;
 
@@ -31,6 +34,7 @@
     td {
         padding: $m-spacing;
         box-sizing: content-box;
+        word-wrap: break-word;
     }
 
     &__loading td {

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -31,7 +31,6 @@
     td {
         padding: $m-spacing;
         box-sizing: content-box;
-        word-break: break-word;
     }
 
     &__loading td {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Deleted word-break: break-word css propety since it is not supported on Firefox.
Added table-layout: fixed and width: 100% on table element and word-wrap: break-word on th/td elements.
Breaking change : Table now spans across all available space. Columns without explicit width will distribute remaining space evenly.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-665
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
