### PR TITLE
Bugfix/modul 695 empecher televersement fichier sans extension

### DIFF
--- a/src/components/file-upload/file-upload.spec.ts
+++ b/src/components/file-upload/file-upload.spec.ts
@@ -68,7 +68,7 @@ describe('MFileUpload', () => {
         });
 
         fupd.vm.$file.add(
-            createMockFileList([createMockFile('file')]),
+            createMockFileList([createMockFile('file.jpg')]),
             'unique-name'
         );
         await Vue.nextTick();
@@ -307,7 +307,7 @@ describe('MFileUpload', () => {
         it('should emit files-ready event when $file managed files change', async () => {
             const fupd: Wrapper<MFileUpload> = mount(MFileUpload);
 
-            fupd.vm.$file.add(createMockFileList([createMockFile('new-file')]));
+            fupd.vm.$file.add(createMockFileList([createMockFile('new-file.jpg')]));
             await Vue.nextTick();
 
             expect(fupd.emitted('files-ready')[0][0]).toEqual([

--- a/src/utils/file/file.spec.ts
+++ b/src/utils/file/file.spec.ts
@@ -1,16 +1,17 @@
 import axios, { AxiosRequestConfig, CancelTokenSource } from 'axios';
 import Vue from 'vue';
-
 import { createMockFile, createMockFileList } from '../../../tests/helpers/file';
 import { HttpService } from '../http/http';
 import { RequestConfig } from '../http/rest';
 import { ModulVue } from '../vue/vue';
 import { extractExtension, FileService, MFile, MFileRejectionCause, MFileStatus } from './file';
 
+
 jest.mock('../http/http');
 
 const FILENAME_POSITION_1: string = 'file.jpg';
 const FILENAME_POSITION_2: string = 'file.mov';
+const FILENAME_POSITION_3: string = 'file';
 
 describe('FileService', () => {
     let filesvc: FileService;
@@ -82,6 +83,23 @@ describe('FileService', () => {
     });
 
     describe('validations', () => {
+
+        describe(`No mather what`, () => {
+            it(`should not accept a file without an extension`, () => {
+
+                filesvc.add(
+                    createMockFileList([
+                        createMockFile(FILENAME_POSITION_3)
+                    ])
+                );
+
+                expect(readyFiles().length).toEqual(0);
+                expect(rejectedFiles().length).toEqual(1);
+                expect(rejectedFiles()[0].name).toEqual(FILENAME_POSITION_3);
+                expect(rejectedFiles()[0].status).toEqual(MFileStatus.REJECTED);
+                expect(rejectedFiles()[0].rejection).toEqual(MFileRejectionCause.FILE_TYPE);
+            });
+        });
 
         describe(`When there is only accepted extensions`, () => {
             it(`should accept the right file`, () => {
@@ -218,12 +236,12 @@ describe('FileService', () => {
             rejectionCause: MFileRejectionCause
         ) => {
 
-            expect(readyFiles().length).toEqual(expectedNbReadyFiles);
-            expect(rejectedFiles().length).toEqual(1);
-            expect(rejectedFiles()[0].name).toEqual('invalid.mov');
-            expect(rejectedFiles()[0].status).toEqual(MFileStatus.REJECTED);
-            expect(rejectedFiles()[0].rejection).toEqual(rejectionCause);
-        };
+                expect(readyFiles().length).toEqual(expectedNbReadyFiles);
+                expect(rejectedFiles().length).toEqual(1);
+                expect(rejectedFiles()[0].name).toEqual('invalid.mov');
+                expect(rejectedFiles()[0].status).toEqual(MFileStatus.REJECTED);
+                expect(rejectedFiles()[0].rejection).toEqual(rejectionCause);
+            };
 
         const readyFiles: () => MFile[] = () => {
             return filesvc.files().filter(f => f.status === MFileStatus.READY);

--- a/src/utils/file/file.spec.ts
+++ b/src/utils/file/file.spec.ts
@@ -236,12 +236,12 @@ describe('FileService', () => {
             rejectionCause: MFileRejectionCause
         ) => {
 
-                expect(readyFiles().length).toEqual(expectedNbReadyFiles);
-                expect(rejectedFiles().length).toEqual(1);
-                expect(rejectedFiles()[0].name).toEqual('invalid.mov');
-                expect(rejectedFiles()[0].status).toEqual(MFileStatus.REJECTED);
-                expect(rejectedFiles()[0].rejection).toEqual(rejectionCause);
-            };
+            expect(readyFiles().length).toEqual(expectedNbReadyFiles);
+            expect(rejectedFiles().length).toEqual(1);
+            expect(rejectedFiles()[0].name).toEqual('invalid.mov');
+            expect(rejectedFiles()[0].status).toEqual(MFileStatus.REJECTED);
+            expect(rejectedFiles()[0].rejection).toEqual(rejectionCause);
+        };
 
         const readyFiles: () => MFile[] = () => {
             return filesvc.files().filter(f => f.status === MFileStatus.READY);

--- a/src/utils/file/file.ts
+++ b/src/utils/file/file.ts
@@ -267,6 +267,7 @@ class FileStore {
     }
 
     /**
+     * If the extension is not specified, it'll be rejected.
      * If the extension is a part of acceptedExtensions or if acceptedExtensions is empty or undefined, we accept all extensions.
      * If the extension is a part of rejectedExtensions, it'll be rejected.
      * If the extension is a part of the accepted and rejected extensions, it'll be rejected.
@@ -274,7 +275,7 @@ class FileStore {
     private validateExtension(file: MFile): void {
         const ext: string = extractExtension(file.file.name);
 
-        if (this.extensionInRejectedExtensions(ext) || !this.extensionInAcceptedExtensions(ext)) {
+        if (ext === '' || this.extensionInRejectedExtensions(ext) || !this.extensionInAcceptedExtensions(ext)) {
             file.status = MFileStatus.REJECTED;
             file.rejection = MFileRejectionCause.FILE_TYPE;
         }

--- a/src/utils/file/file.ts
+++ b/src/utils/file/file.ts
@@ -249,12 +249,10 @@ class FileStore {
     }
 
     private validate(file: MFile): void {
+        this.validateExtension(file);
+
         if (!this.options) {
             return;
-        }
-
-        if (this.options.rejectedExtensions || this.options.allowedExtensions) {
-            this.validateExtension(file);
         }
 
         if (this.options.maxSizeKb) {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Reject files that do not specify an extension in the file upload.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-695
https://jira.dti.ulaval.ca/browse/ENA2-4416
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
