### PR TITLE
MODUL-704 - improve RTE blur management

### DIFF
--- a/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -22,6 +22,7 @@ enum froalaEvents {
     InitializationDelayed = 'froalaEditor.initializationDelayed',
     ContentChanged = 'froalaEditor.contentChanged',
     Focus = 'froalaEditor.focus',
+    Blur = 'froalaEditor.blur',
     KeyUp = 'froalaEditor.keyup',
     KeyDown = 'froalaEditor.keydown',
     PasteAfter = 'froalaEditor.paste.after',
@@ -197,17 +198,7 @@ export enum FroalaStatus {
 
     protected mouseupListener(event: MouseEvent): void {
         if (!this.mousedownInsideEditor && !this.$el.contains(event.target as HTMLElement)) {
-            this.status = FroalaStatus.Blurring;
-            window.addEventListener('resize', this.onResize);
-            this.$emit('blur');
-            this.hideToolbar();
-
-            this.isFocused = false;
-            this.status = FroalaStatus.Blurred;
-
-            this.isDirty = false;
-            this.internalReadonly = false;
-            this.isDisabled = this.disabled;
+            this.closeEditor();
         }
     }
 
@@ -322,6 +313,12 @@ export enum FroalaStatus {
                         this.internalReadonly = this.readonly;
                     }
                 },
+                [froalaEvents.Blur]: (_e, _editor) => {
+                    if (this.mousedownInsideEditor) {
+                        // iOS keyboard closed
+                        this.closeEditor();
+                    }
+                },
                 [froalaEvents.KeyUp]: (_e, _editor) => {
                     if (this.currentConfig.immediateVueModelUpdate) {
                         this.updateModel();
@@ -354,6 +351,20 @@ export enum FroalaStatus {
         if (this._$element.froalaEditor) {
             this._$editor = this._$element.froalaEditor(this.currentConfig).data('froala.editor').$el;
         }
+    }
+
+    private closeEditor(): void {
+        this.status = FroalaStatus.Blurring;
+        window.addEventListener('resize', this.onResize);
+        this.$emit('blur');
+        this.hideToolbar();
+
+        this.isFocused = false;
+        this.status = FroalaStatus.Blurred;
+
+        this.isDirty = false;
+        this.internalReadonly = false;
+        this.isDisabled = this.disabled;
     }
 
     @Watch('disabled')

--- a/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -85,6 +85,7 @@ export enum FroalaStatus {
     protected isDirty: boolean = false;
     protected status: FroalaStatus = FroalaStatus.Blurred;
 
+    private mousedownTriggered: boolean = false;
     private mousedownInsideEditor: boolean = false;
 
     @Watch('value')
@@ -189,6 +190,7 @@ export enum FroalaStatus {
     }
 
     protected mousedownListener(event: MouseEvent): void {
+        this.mousedownTriggered = true;
         if (this.$el.contains(event.target as HTMLElement) || $('.fr-modal.fr-active').length > 0) {
             this.mousedownInsideEditor = true;
         } else {
@@ -197,6 +199,7 @@ export enum FroalaStatus {
     }
 
     protected mouseupListener(event: MouseEvent): void {
+        this.mousedownTriggered = false;
         if (!this.mousedownInsideEditor && !this.$el.contains(event.target as HTMLElement)) {
             this.closeEditor();
         }
@@ -313,9 +316,8 @@ export enum FroalaStatus {
                         this.internalReadonly = this.readonly;
                     }
                 },
-                [froalaEvents.Blur]: (_e, _editor) => {
-                    if (this.mousedownInsideEditor) {
-                        // iOS keyboard closed
+                [froalaEvents.Blur]: () => {
+                    if (!this.mousedownTriggered || this.mousedownInsideEditor) {
                         this.closeEditor();
                     }
                 },


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
RTE now closes after mouseup event occured. This prevents bugs when clicking controls below an open RTE.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-704
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
