### PR TITLE
MODUL-707 - Afficher message d'erreur d'un champs de formulaire si 'touched'

### DIFF
--- a/src/components/form/form.sandbox.html
+++ b/src/components/form/form.sandbox.html
@@ -11,7 +11,6 @@
                      :max-length="maxTitleLength"
                      :character-count-threshold="thresholdTitle"
                      @blur="titleField.touch()"
-                     v-m-form-field=titleField
                      ref="title"></m-textfield>
 
         <m-textarea v-model.trim="descriptionField.value"

--- a/src/components/form/form.sandbox.html
+++ b/src/components/form/form.sandbox.html
@@ -6,21 +6,21 @@
                      label="Title"
                      :max-width="inputMaxWidthSmall"
                      :required-marker="true"
-                     :error="titleField.hasError"
                      :error-message="titleField.errorMessage"
                      :character-count="true"
                      :max-length="maxTitleLength"
                      :character-count-threshold="thresholdTitle"
+                     @blur="titleField.markAsTouched()"
                      ref="title"></m-textfield>
 
         <m-textarea v-model.trim="descriptionField.value"
                     label="Description"
                     :max-width="inputMaxWidthLarge"
-                    :error="descriptionField.hasError"
                     :error-message="descriptionField.errorMessage"
                     :character-count="true"
                     :max-length="maxDescriptionLength"
                     :character-count-threshold="thresholdDescription"
+                    @blur="descriptionField.markAsTouched()"
                     ref="description">
         </m-textarea>
 
@@ -28,11 +28,11 @@
                     label="Location"
                     :max-width="inputMaxWidthLarge"
                     :required-marker="true"
-                    :error="locationField.hasError"
                     :error-message="locationField.errorMessage"
                     :character-count="true"
                     :max-length="maxLocationLength"
                     :character-count-threshold="thresholdLocation"
+                    @blur="locationField.markAsTouched()"
                     ref="location">
         </m-textarea>
     </m-form>

--- a/src/components/form/form.sandbox.html
+++ b/src/components/form/form.sandbox.html
@@ -10,7 +10,8 @@
                      :character-count="true"
                      :max-length="maxTitleLength"
                      :character-count-threshold="thresholdTitle"
-                     @blur="titleField.markAsTouched()"
+                     @blur="titleField.touch()"
+                     v-m-form-field=titleField
                      ref="title"></m-textfield>
 
         <m-textarea v-model.trim="descriptionField.value"
@@ -20,7 +21,7 @@
                     :character-count="true"
                     :max-length="maxDescriptionLength"
                     :character-count-threshold="thresholdDescription"
-                    @blur="descriptionField.markAsTouched()"
+                    @blur="descriptionField.touch()"
                     ref="description">
         </m-textarea>
 
@@ -32,7 +33,7 @@
                     :character-count="true"
                     :max-length="maxLocationLength"
                     :character-count-threshold="thresholdLocation"
-                    @blur="locationField.markAsTouched()"
+                    @blur="locationField.touch()"
                     ref="location">
         </m-textarea>
     </m-form>

--- a/src/components/form/form.sandbox.ts
+++ b/src/components/form/form.sandbox.ts
@@ -17,7 +17,7 @@ export class MFormSandbox extends Vue {
     formSent: any = '';
 
     titleField: FormField<string> = new FormField((): string => this.title, ValidationSandbox.validateTitle);
-    descriptionField: FormField<string> = new FormField((): string => this.description, ValidationSandbox.validateDescription);
+    descriptionField: FormField<string> = new FormField((): string => this.description, ValidationSandbox.validateDescription, { messageAfterTouched: false });
     locationField: FormField<string> = new FormField((): string => this.location, ValidationSandbox.validateLocation);
     form: Form = new Form([this.titleField, this.descriptionField, this.locationField]);
 

--- a/src/components/form/form.sandbox.ts
+++ b/src/components/form/form.sandbox.ts
@@ -5,6 +5,7 @@ import { Form } from '../../utils/form/form';
 import { FormFieldState } from '../../utils/form/form-field-state/form-field-state';
 import { FormField } from '../../utils/form/form-field/form-field';
 import { FORM } from '../component-names';
+import FormPlugin from './form';
 import WithRender from './form.sandbox.html';
 
 @WithRender
@@ -85,6 +86,7 @@ class ValidationSandbox {
 
 const MFormSandboxPlugin: PluginObject<any> = {
     install(v, options): void {
+        v.use(FormPlugin);
         v.component(`${FORM}-sandbox`, MFormSandbox);
     }
 };

--- a/src/utils/form/form-field/form-field.spec.ts
+++ b/src/utils/form/form-field/form-field.spec.ts
@@ -12,7 +12,7 @@ const FONCTION_VALIDATION: () => FormFieldState = (): FormFieldState => validati
 describe(`FormField`, () => {
     describe(`When we create a new instance with a value and a validating function`, () => {
         beforeEach(() => {
-            formField = new FormField((): string => FIELD_VALUE, FONCTION_VALIDATION);
+            formField = new FormField((): string => FIELD_VALUE, FONCTION_VALIDATION, { messageAfterTouched: false });
         });
 
         it(`Then the value is the field is the one passed`, () => {
@@ -53,6 +53,27 @@ describe(`FormField`, () => {
             });
 
             it(`Then the state of the field contains errors`, () => {
+                expect(formField.hasError).toBeTruthy();
+                expect(formField.errorMessageSummary).toBe(ERROR_MESSAGE_SUMMARY);
+                expect(formField.errorMessage).toBe(ERROR_MESSAGE);
+            });
+        });
+
+        describe(`When we validate an invalid field with messageAfterTouched = true`, () => {
+            beforeEach(() => {
+                formField = new FormField((): string => FIELD_VALUE, FONCTION_VALIDATION, { messageAfterTouched: true });
+                validationState = new FormFieldState(true, ERROR_MESSAGE_SUMMARY, ERROR_MESSAGE);
+            });
+
+            it(`Then the state of the field contains no errors if not touched`, () => {
+                formField.validate();
+                expect(formField.hasError).toBeTruthy();
+                expect(formField.errorMessageSummary).toBe(ERROR_MESSAGE_SUMMARY);
+                expect(formField.errorMessage).toBe('');
+            });
+
+            it(`Then the state of the field contains errors if touched`, () => {
+                formField.touch();
                 expect(formField.hasError).toBeTruthy();
                 expect(formField.errorMessageSummary).toBe(ERROR_MESSAGE_SUMMARY);
                 expect(formField.errorMessage).toBe(ERROR_MESSAGE);

--- a/src/utils/form/form-field/form-field.spec.ts
+++ b/src/utils/form/form-field/form-field.spec.ts
@@ -67,14 +67,14 @@ describe(`FormField`, () => {
 
             it(`Then the state of the field contains no errors if not touched`, () => {
                 formField.validate();
-                expect(formField.hasError).toBeTruthy();
+                expect(formField.hasError).toBe(true);
                 expect(formField.errorMessageSummary).toBe(ERROR_MESSAGE_SUMMARY);
                 expect(formField.errorMessage).toBe('');
             });
 
             it(`Then the state of the field contains errors if touched`, () => {
                 formField.touch();
-                expect(formField.hasError).toBeTruthy();
+                expect(formField.hasError).toBe(true);
                 expect(formField.errorMessageSummary).toBe(ERROR_MESSAGE_SUMMARY);
                 expect(formField.errorMessage).toBe(ERROR_MESSAGE);
             });

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -63,8 +63,7 @@ export class FormField<T> {
     get errorMessage(): string {
         let errorMessage: string = '';
 
-        if (this.hasError && ((this.messageAfterTouched && this.touched) || !this.messageAfterTouched)
-        ) {
+        if (this.hasError && ((this.messageAfterTouched && this.touched) || !this.messageAfterTouched)) {
             errorMessage = this.internalState.errorMessage;
         }
 

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -1,5 +1,9 @@
 import { FormFieldState } from '../form-field-state/form-field-state';
 
+export interface FormFieldOptions {
+    messageAfterTouched?: boolean;
+}
+
 /**
  * Form Field Class
  */
@@ -15,9 +19,14 @@ export class FormField<T> {
      * @param value function called to initialize the value of a field
      * @param validationCallback function called to validate
      */
-    constructor(public accessCallback: () => T, public validationCallback?: (value: T) => FormFieldState) {
+    constructor(public accessCallback: () => T, public validationCallback?: (value: T) => FormFieldState, options?: FormFieldOptions) {
         this.internalValue = accessCallback();
         this.internalState = new FormFieldState();
+
+        if (options) {
+            this.messageAfterTouched = typeof options.messageAfterTouched === undefined ?
+                this.messageAfterTouched : !!options.messageAfterTouched;
+        }
     }
 
     /**
@@ -32,13 +41,6 @@ export class FormField<T> {
      */
     set value(newValue: T) {
         this.change(newValue);
-    }
-
-    /**
-     * determine if the message should be available only when field has been touched
-     */
-    set isMessageAfterTouched(value: boolean) {
-        this.messageAfterTouched = value;
     }
 
     /**
@@ -59,7 +61,15 @@ export class FormField<T> {
      * message to show under the form field
      */
     get errorMessage(): string {
-        if (this.messageAfterTouched && this.touched && this.hasError) {
+        if (
+            this.hasError
+            &&
+            (
+                (this.messageAfterTouched && this.touched)
+                ||
+                !this.messageAfterTouched
+            )
+        ) {
             return this.internalState.errorMessage;
         }
 

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -93,6 +93,14 @@ export class FormField<T> {
     }
 
     /**
+     * Mark the field as touched and trigger validation
+     */
+    touch(): void {
+        this.touched = true;
+        this.validate();
+    }
+
+    /**
      * reset the field without validating
      */
     reset(): void {
@@ -100,14 +108,6 @@ export class FormField<T> {
         this.oldValue = this.internalValue;
         this.internalState = new FormFieldState();
         this.touched = false;
-    }
-
-    /**
-     * Mark the field as touched and trigger validation
-     */
-    touch(): void {
-        this.touched = true;
-        this.validate();
     }
 
     /**

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -25,7 +25,7 @@ export class FormField<T> {
 
         if (options) {
             this.messageAfterTouched = typeof options.messageAfterTouched === undefined ?
-                this.messageAfterTouched : !!options.messageAfterTouched;
+                this.messageAfterTouched : options.messageAfterTouched!;
         }
     }
 

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -61,19 +61,14 @@ export class FormField<T> {
      * message to show under the form field
      */
     get errorMessage(): string {
-        if (
-            this.hasError
-            &&
-            (
-                (this.messageAfterTouched && this.touched)
-                ||
-                !this.messageAfterTouched
-            )
+        let errorMessage: string = '';
+
+        if (this.hasError && ((this.messageAfterTouched && this.touched) || !this.messageAfterTouched)
         ) {
-            return this.internalState.errorMessage;
+            errorMessage = this.internalState.errorMessage;
         }
 
-        return '';
+        return errorMessage;
     }
 
     /**

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -103,9 +103,9 @@ export class FormField<T> {
     }
 
     /**
-     * Mark the field as touched
+     * Mark the field as touched and trigger validation
      */
-    markAsTouched(): void {
+    touch(): void {
         this.touched = true;
         this.validate();
     }

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -93,7 +93,7 @@ export class FormField<T> {
     }
 
     /**
-     * Mark the field as touched and trigger validation
+     * mark the field as touched and trigger validation
      */
     touch(): void {
         this.touched = true;

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -7,6 +7,8 @@ export class FormField<T> {
     private internalValue: T;
     private oldValue: T;
     private internalState: FormFieldState;
+    private messageAfterTouched: boolean = true;
+    private touched: boolean = false;
 
     /**
      *
@@ -25,8 +27,18 @@ export class FormField<T> {
         return this.internalValue;
     }
 
+    /**
+     * set the value of the field
+     */
     set value(newValue: T) {
         this.change(newValue);
+    }
+
+    /**
+     * determine if the message should be available only when field has been touched
+     */
+    set isMessageAfterTouched(value: boolean) {
+        this.messageAfterTouched = value;
     }
 
     /**
@@ -37,10 +49,21 @@ export class FormField<T> {
     }
 
     /**
+     * indicates if the field is touched
+     */
+    get isTouched(): boolean {
+        return this.touched;
+    }
+
+    /**
      * message to show under the form field
      */
     get errorMessage(): string {
-        return this.internalState.errorMessage;
+        if (this.messageAfterTouched && this.touched && this.hasError) {
+            return this.internalState.errorMessage;
+        }
+
+        return '';
     }
 
     /**
@@ -66,6 +89,15 @@ export class FormField<T> {
         this.internalValue = this.accessCallback();
         this.oldValue = this.internalValue;
         this.internalState = new FormFieldState();
+        this.touched = false;
+    }
+
+    /**
+     * Mark the field as touched
+     */
+    markAsTouched(): void {
+        this.touched = true;
+        this.validate();
     }
 
     /**


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Pour être conforme aux règles de formulaire établies, le message d'erreur ne s'affichera que lorsque le champs sera touché au moins une fois. 
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-707
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
