### PR TITLE
MODUL-723 - Added polyfill to allow Object.assign to be supported in …

### DIFF
--- a/src/utils/polyfills.ts
+++ b/src/utils/polyfills.ts
@@ -115,3 +115,38 @@ if (!String.prototype['startsWith']) {
         return this.substr(position || 0, searchString.length) === searchString;
     };
 }
+
+// Polyfill to allow IE 11 to support Object.assign
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+if (typeof Object.assign !== 'function') {
+    // Must be writable: true, enumerable: false, configurable: true
+    Object.defineProperty(Object, 'assign', {
+        value: function assign(target: any, _varArgs: any): any { // .length of function is 2
+            // == allow for null and undefined check
+            // tslint:disable-next-line:triple-equals no-null-keyword
+            if (target == null) { // TypeError if undefined or null
+                throw new TypeError('Cannot convert undefined or null to object');
+            }
+
+            const to: any = Object(target);
+
+            for (let index: number = 1; index < arguments.length; index++) {
+                let nextSource: any = arguments[index];
+                // != allow for null and undefined check
+                // tslint:disable-next-line:triple-equals no-null-keyword
+                if (nextSource != null) { // Skip over if undefined or null
+                    for (let nextKey in nextSource) {
+                        // Avoid bugs when hasOwnProperty is shadowed
+                        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                            to[nextKey] = nextSource[nextKey];
+                        }
+                    }
+                }
+            }
+            return to;
+        },
+        writable: true,
+        configurable: true
+    });
+}
+


### PR DESCRIPTION
…IE 11

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR

Ajout d'un polyfill pour supporter `Object.assign` dans IE11 - Régréssion dans Brio.
Le même polyfill a été ajouté dans Brio.

Cas d'utilisation :

```
    a: any = { a: 1, b: 2 };
    b: any = { a: 'a', c: 3 };
    c: any = {};

    c = Object.assign(c, a, b); // {"a": "a","b": 2,"c": 3 }
```

<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-723
<!-- Links here... -->
- [ ] Openshift deployment requested
