### PR TITLE
MODUL-729 - formfield disparait si doit être focus

### DIFF
--- a/src/components/form/form-field.ts
+++ b/src/components/form/form-field.ts
@@ -22,14 +22,15 @@ export const FormFieldDirective: DirectiveOptions = {
         const formField: FormField<any> = binding.value;
 
         if (formField.shouldFocus) {
-            const selector: string = 'input, textarea, [contenteditable=true]';
-            let container: HTMLDivElement = document.createElement('div');
-            container.appendChild(el);
+            if (el instanceof HTMLInputElement) {
+                el.focus();
+            } else {
+                const selector: string = 'input, textarea, [contenteditable=true]';
+                const elements: NodeListOf<HTMLInputElement> = el.querySelectorAll(selector);
 
-            const elements: NodeListOf<HTMLInputElement> = container.querySelectorAll(selector);
-
-            if (elements.length > 0) {
-                elements[0].focus();
+                if (elements.length > 0) {
+                    elements[0].focus();
+                }
             }
 
             formField.shouldFocus = false;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [ ] Provide a small description of the changes introduced by this 
J'avais modifié un algo selon une suggestion en code revue et je n'avais pas retesté tout le flow. Apparament le champs disparaissait si il devait focusser après cette modif.
- [ ] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-729- 
[ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
