### PR TITLE
Make periodpicker works with iso dates

### DIFF
--- a/src/components/datepicker/datepicker.html
+++ b/src/components/datepicker/datepicker.html
@@ -61,7 +61,7 @@
              placement="bottom"
              @open="onOpen"
              @close="onClose">
-        <m-calendar :value="value"
+        <m-calendar :value="formattedDate"
                     @input="selectDate"
                     :min-date="minDateString"
                     :max-date="maxDateString"

--- a/src/components/datepicker/datepicker.ts
+++ b/src/components/datepicker/datepicker.ts
@@ -8,6 +8,7 @@ import { InputPopup } from '../../mixins/input-popup/input-popup';
 import { InputState } from '../../mixins/input-state/input-state';
 import { MediaQueries } from '../../mixins/media-queries/media-queries';
 import MediaQueriesPlugin from '../../utils/media-queries/media-queries';
+import ModulDate from '../../utils/modul-date/modul-date';
 import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
 import ButtonPlugin from '../button/button';
@@ -21,7 +22,7 @@ import { InputManagement } from './../../mixins/input-management/input-managemen
 import WithRender from './datepicker.html?style=./datepicker.scss';
 
 
-export type DatePickerSupportedTypes = moment.Moment | Date | string | undefined;
+export type DatePickerSupportedTypes = Date | string | undefined;
 
 @WithRender
 @Component({
@@ -46,9 +47,9 @@ export class MDatepicker extends ModulVue {
     public required: boolean;
     @Prop({ default: 'YYYY/MM/DD' })
     public format: string;
-    @Prop({ default: () => { return moment().subtract(10, 'year'); } })
+    @Prop({ default: () => { return new ModulDate().subtract(10, 'year'); } })
     public min: DatePickerSupportedTypes;
-    @Prop({ default: () => { return moment().add(10, 'year'); } })
+    @Prop({ default: () => { return new ModulDate().add(10, 'year'); } })
     public max: DatePickerSupportedTypes;
     @Prop({ default: () => Vue.prototype.$i18n.translate('m-datepicker:placeholder') })
     public placeholder: string;
@@ -157,8 +158,6 @@ export class MDatepicker extends ModulVue {
     private createModelUpdateValue(newValue: DatePickerSupportedTypes): DatePickerSupportedTypes {
         if (this.value instanceof Date) {
             return new Date(this.value);
-        } else if (this.value instanceof moment) {
-            return moment({ year: this.selectedYear, month: this.selectedMonth, day: this.selectedDay });
         } else {
             return newValue;
         }
@@ -171,10 +170,6 @@ export class MDatepicker extends ModulVue {
             this.selectedYear = value.getFullYear();
             this.selectedMonth = value.getMonth();
             this.selectedDay = value.getDate();
-        } else if (value instanceof moment) {
-            this.selectedYear = moment(value).get('year');
-            this.selectedMonth = moment(value).get('month');
-            this.selectedDay = moment(value).get('day');
         } else {
             const dateValue: Date = new Date(value as string);
             this.selectedYear = dateValue.getFullYear();

--- a/src/components/datepicker/datepicker.ts
+++ b/src/components/datepicker/datepicker.ts
@@ -156,8 +156,8 @@ export class MDatepicker extends ModulVue {
     }
 
     private createModelUpdateValue(newValue: DatePickerSupportedTypes): DatePickerSupportedTypes {
-        if (this.value instanceof Date) {
-            return new Date(this.value);
+        if (newValue && newValue instanceof Date) {
+            return new Date(newValue);
         } else {
             return newValue;
         }

--- a/src/components/daterangepicker/daterangepicker.html
+++ b/src/components/daterangepicker/daterangepicker.html
@@ -1,6 +1,14 @@
 <m-periodpicker v-bind="periodPickerProps"
                 @input="updateValue"
-                ref="periodpicker">
+                ref="periodpicker"
+                :disabled="disabled"
+                :waiting="waiting"
+                :error="error"
+                :valid="valid"
+                :readonly="readonly"
+                :error-message="errorMessage"
+                :valid-message="validMessage"
+                :helper-message="helperMessage">
     <m-datepicker :label="labelFrom"
                   slot="first"
                   slot-scope="{ props, handlers }"

--- a/src/components/periodpicker/periodpicker.sandbox.html
+++ b/src/components/periodpicker/periodpicker.sandbox.html
@@ -20,6 +20,43 @@
         </m-periodpicker>
     </p>
     <p>Selected value: {{ model }}</p>
+    <h3>Should work when model is not empty by default</h3>
+    <p class="m-u--margin-bottom">
+        When the model is filled by default with string values, it should be possible to select the same values withouth chaging the model.
+    </p>
+    <p>
+        <m-periodpicker v-model="defaultStringValueModel">
+            <m-datepicker slot="first"
+                          slot-scope="{ props, handlers }"
+                          label="From"
+                          v-on="handlers"
+                          v-bind="props"></m-datepicker>
+            <m-datepicker slot="second"
+                          slot-scope="{ props, handlers }"
+                          label="To"
+                          v-on="handlers"
+                          v-bind="props"></m-datepicker>
+        </m-periodpicker>
+    </p>
+    <p>Selected value: {{ defaultStringValueModel }}</p>
+    <p class="m-u--margin-bottom">
+        When the model is filled by default with date values, it should be possible to select the same values withouth chaging the model.
+    </p>
+    <p>
+        <m-periodpicker v-model="defaultDateValueModel">
+            <m-datepicker slot="first"
+                          slot-scope="{ props, handlers }"
+                          label="From"
+                          v-on="handlers"
+                          v-bind="props"></m-datepicker>
+            <m-datepicker slot="second"
+                          slot-scope="{ props, handlers }"
+                          label="To"
+                          v-on="handlers"
+                          v-bind="props"></m-datepicker>
+        </m-periodpicker>
+    </p>
+    <p>Selected value: {{ defaultDateValueModel }}</p>
     <h3>Should limit input based on min and max props</h3>
     <p class="m-u--margin-bottom">
         It shouldn't be possible to select a date outside current month in the picker below.

--- a/src/components/periodpicker/periodpicker.sandbox.ts
+++ b/src/components/periodpicker/periodpicker.sandbox.ts
@@ -10,6 +10,13 @@ import WithRender from './periodpicker.sandbox.html';
 export class MPeriodpickerSandbox extends Vue {
     from: any = undefined;
     to: any = undefined;
+
+    fromDefaultStringValue: string = '2019-02-20T05:00:00.000Z';
+    toDefaultStringValue: string = '2019-03-01T04:59:59.999Z';
+
+    fromDefaultDateValue: Date = new Date('2019-02-20T05:00:00.000Z');
+    toDefaultDateValue: Date = new Date('2019-03-01T04:59:59.999Z');
+
     errorMessage: string = '';
     validMessage: string = '';
     helperMessage: string = '';
@@ -18,7 +25,9 @@ export class MPeriodpickerSandbox extends Vue {
     readonly: boolean = false;
     error: boolean = false;
 
-    model: MDateRange = { to: this.to, from: this.from };
+    model: MDateRange = { from: this.from, to: this.to };
+    defaultStringValueModel: MDateRange = { from: this.fromDefaultStringValue, to: this.toDefaultStringValue };
+    defaultDateValueModel: MDateRange = { from: this.fromDefaultDateValue, to: this.toDefaultDateValue };
 
     get min(): Date {
         const date: Date = new Date();

--- a/src/components/periodpicker/periodpicker.spec.ts
+++ b/src/components/periodpicker/periodpicker.spec.ts
@@ -1,6 +1,7 @@
 import { shallowMount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import { renderComponent } from '../../../tests/helpers/render';
+import ModulDate from '../../utils/modul-date/modul-date';
 import { DatePickerSupportedTypes } from './../datepicker/datepicker';
 import PeriodpickerPlugin, { MPeriodpicker, MPeriodpickerFromSlotProps, MPeriodpickerToSlotProps } from './periodpicker';
 
@@ -98,7 +99,7 @@ describe(`m-periodpicker`, () => {
 
             expect(wrapper.emitted('input')[0][0]).toEqual({
                 from: undefined,
-                to: newDateToValue
+                to: new ModulDate(newDateToValue).endOfDay()
             });
         });
     });
@@ -135,7 +136,7 @@ describe(`m-periodpicker`, () => {
 
             expect(wrapper.emitted('input')[0][0]).toEqual({
                 from: newDateFromValue,
-                to: toDateProp
+                to: new ModulDate(newDateFromValue).endOfDay()
             });
         });
 
@@ -147,7 +148,7 @@ describe(`m-periodpicker`, () => {
 
             expect(wrapper.emitted('input')[0][0]).toEqual({
                 from: fromDateProp,
-                to: newDateToValue
+                to: new ModulDate(newDateToValue).endOfDay()
             });
         });
     });

--- a/src/components/periodpicker/periodpicker.spec.ts
+++ b/src/components/periodpicker/periodpicker.spec.ts
@@ -41,21 +41,21 @@ const initializeWrapper: () => Wrapper<MPeriodpicker> = () => {
     return wrapper;
 };
 
-beforeEach(() => {
-    Vue.use(PeriodpickerPlugin);
-
-    wrapper = undefined as any;
-    fromDateProp = undefined as any;
-    toDateProp = undefined as any;
-    minDateProp = undefined as any;
-    maxDateProp = undefined as any;
-
-    isMqMinSValue = false;
-
-    currentFromScopeProps = undefined as any;
-});
-
 describe(`m-periodpicker`, () => {
+    beforeEach(() => {
+        Vue.use(PeriodpickerPlugin);
+
+        wrapper = undefined as any;
+        fromDateProp = undefined as any;
+        toDateProp = undefined as any;
+        minDateProp = undefined as any;
+        maxDateProp = undefined as any;
+
+        isMqMinSValue = false;
+
+        currentFromScopeProps = undefined as any;
+    });
+
     it(`should render correctly`, () => {
         initializeWrapper();
 
@@ -136,7 +136,7 @@ describe(`m-periodpicker`, () => {
 
             expect(wrapper.emitted('input')[0][0]).toEqual({
                 from: newDateFromValue,
-                to: new ModulDate(newDateFromValue).endOfDay()
+                to: new ModulDate(toDateProp).endOfDay()
             });
         });
 

--- a/src/components/periodpicker/periodpicker.ts
+++ b/src/components/periodpicker/periodpicker.ts
@@ -3,6 +3,7 @@ import Component from 'vue-class-component';
 import { Emit, Prop } from 'vue-property-decorator';
 import { InputState } from '../../mixins/input-state/input-state';
 import { MediaQueries, MediaQueriesMixin } from '../../mixins/media-queries/media-queries';
+import ModulDate from '../../utils/modul-date/modul-date';
 import { ModulVue } from '../../utils/vue/vue';
 import { PERIODPICKER_NAME } from '../component-names';
 import { DatePickerSupportedTypes } from '../datepicker/datepicker';
@@ -140,7 +141,7 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
 
             this.emitNewValue(Object.assign({}, this.internalValue, {
                 from: newValue,
-                to: newValue > (this.internalValue.to || '') ? undefined : this.internalValue.to
+                to: newValue > (this.internalValue.to || '') ? undefined : new ModulDate(newValue).endOfDay()
             }));
         } else {
             this.emitNewValue({ from: undefined, to: this.internalValue.to });
@@ -150,7 +151,7 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
     onDateToChange(newValue: DatePickerSupportedTypes): void {
         if (newValue) {
             this.unfocusDateToField();
-            this.emitNewValue(Object.assign({}, this.internalValue, { to: newValue }));
+            this.emitNewValue(Object.assign({}, this.internalValue, { to: new ModulDate(newValue).endOfDay() }));
         } else {
             this.emitNewValue({ from: this.internalValue.from, to: undefined });
         }

--- a/src/components/periodpicker/periodpicker.ts
+++ b/src/components/periodpicker/periodpicker.ts
@@ -140,7 +140,7 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
                 this.toIsFocused = true;
             }
 
-            this.emitNewValue({ from: this.getNewModelValue(newValue), to: newValue > (this.internalValue.to || '') ? undefined : dateToValue });
+            this.emitNewValue({ from: this.getNewModelValue(newValue), to: dateToValue });
         } else {
             this.emitNewValue({ from: undefined, to: dateToValue });
         }

--- a/src/components/periodpicker/periodpicker.ts
+++ b/src/components/periodpicker/periodpicker.ts
@@ -134,26 +134,25 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
     }
 
     onDateFromChange(newValue: DatePickerSupportedTypes): void {
+        const dateToValue: DatePickerSupportedTypes = this.getNewModelValue(this.internalValue.to, true);
         if (newValue) {
             if (this.as<MediaQueriesMixin>().isMqMinS) {
                 this.toIsFocused = true;
             }
 
-            this.emitNewValue(Object.assign({}, this.internalValue, {
-                from: newValue,
-                to: newValue > (this.internalValue.to || '') ? undefined : new ModulDate(newValue).endOfDay()
-            }));
+            this.emitNewValue({ from: this.getNewModelValue(newValue), to: newValue > (this.internalValue.to || '') ? undefined : dateToValue });
         } else {
-            this.emitNewValue({ from: undefined, to: this.internalValue.to });
+            this.emitNewValue({ from: undefined, to: dateToValue });
         }
     }
 
     onDateToChange(newValue: DatePickerSupportedTypes): void {
+        const dateFromValue: DatePickerSupportedTypes = this.getNewModelValue(this.internalValue.from);
         if (newValue) {
             this.unfocusDateToField();
-            this.emitNewValue(Object.assign({}, this.internalValue, { to: new ModulDate(newValue).endOfDay() }));
+            this.emitNewValue({ from: dateFromValue, to: this.getNewModelValue(newValue, true) });
         } else {
-            this.emitNewValue({ from: this.internalValue.from, to: undefined });
+            this.emitNewValue({ from: dateFromValue, to: undefined });
         }
     }
 
@@ -170,6 +169,15 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
 
     unfocusDateToField(): void {
         this.toIsFocused = false;
+    }
+
+    getNewModelValue(newValue: DatePickerSupportedTypes, endOfDay: boolean = false): DatePickerSupportedTypes {
+        if (!newValue) { return; }
+
+        const modulDate: ModulDate = new ModulDate(newValue);
+        const isoString: string = endOfDay ? modulDate.endOfDay().toISOString() : modulDate.toISOString();
+
+        return new Date(isoString);
     }
 }
 

--- a/src/utils/modul-date/modul-date.spec.ts
+++ b/src/utils/modul-date/modul-date.spec.ts
@@ -133,6 +133,7 @@ describe(`ModulDate`, () => {
             });
         });
     });
+
     describe(`serialization`, () => {
         it(`of a date to string, will match the string format`, () => {
             const modulDate: ModulDate = new ModulDate('2018-01-01');
@@ -140,6 +141,22 @@ describe(`ModulDate`, () => {
             const result: string = modulDate.toString();
 
             expect(result).toBe('2018-01-01');
+        });
+
+        it(`of a date to isoString, will match the string format`, () => {
+            const modulDate: ModulDate = new ModulDate('2018-01-01');
+
+            const result: string = modulDate.toISOString();
+
+            expect(result).toBe(new Date(2018, 0, 1).toISOString());
+        });
+
+        it(`of a date to locale string, will match the string format`, () => {
+            const modulDate: ModulDate = new ModulDate('2018-01-01');
+
+            const result: string = modulDate.toLocaleDateString();
+
+            expect(result).toBe(new Date(2018, 0, 1).toLocaleDateString());
         });
     });
 
@@ -584,6 +601,52 @@ describe(`ModulDate`, () => {
                     ]
                 }]
             }].forEach(testSuiteRunner);
+        });
+    });
+
+    describe(`operations`, () => {
+        describe(`add`, () => {
+            it(`should return a new date with added years with kind year`, () => {
+                const date: Date = new Date(1900, 1, 1);
+                const modulDate: ModulDate = new ModulDate(date);
+
+                const newDate: Date = modulDate.add(10, 'year');
+
+                expect(newDate.getFullYear()).toBe(date.getFullYear() + 10);
+            });
+
+            it(`should not change the current date`, () => {
+                const date: Date = new Date(1900, 1, 1);
+                const modulDate: ModulDate = new ModulDate(date);
+
+                modulDate.add(10, 'year');
+
+                expect(modulDate.fullYear()).toBe(1900);
+                expect(modulDate.month()).toBe(1);
+                expect(modulDate.day()).toBe(1);
+            });
+        });
+
+        describe(`subtract`, () => {
+            it(`should return a new date with added years with kind year`, () => {
+                const date: Date = new Date(1900, 1, 1);
+                const modulDate: ModulDate = new ModulDate(date);
+
+                const newDate: Date = modulDate.subtract(10, 'year');
+
+                expect(newDate.getFullYear()).toBe(date.getFullYear() - 10);
+            });
+
+            it(`should not change the current date`, () => {
+                const date: Date = new Date(1900, 1, 1);
+                const modulDate: ModulDate = new ModulDate(date);
+
+                modulDate.subtract(10, 'year');
+
+                expect(modulDate.fullYear()).toBe(1900);
+                expect(modulDate.month()).toBe(1);
+                expect(modulDate.day()).toBe(1);
+            });
         });
     });
 });

--- a/src/utils/modul-date/modul-date.spec.ts
+++ b/src/utils/modul-date/modul-date.spec.ts
@@ -648,5 +648,38 @@ describe(`ModulDate`, () => {
                 expect(modulDate.day()).toBe(1);
             });
         });
+
+        describe(`endOfDay`, () => {
+            it(`should return end of day of current date`, () => {
+                const date: Date = new Date(1990, 1, 1);
+                const modulDate: ModulDate = new ModulDate(date);
+
+                const endOfDay: Date = modulDate.endOfDay();
+
+                expect(endOfDay.getFullYear()).toBe(date.getFullYear());
+                expect(endOfDay.getMonth()).toBe(date.getMonth());
+                expect(endOfDay.getDate()).toBe(date.getDate());
+                expect(endOfDay.getHours()).toBe(23);
+                expect(endOfDay.getMinutes()).toBe(59);
+                expect(endOfDay.getSeconds()).toBe(59);
+                expect(endOfDay.getMilliseconds()).toBe(999);
+            });
+
+            it(`should return end of day even when date is already at end of day`, () => {
+                const date: Date = new Date(1990, 1, 1);
+                date.setHours(23, 59, 59, 999);
+                const modulDate: ModulDate = new ModulDate(date);
+
+                const endOfDay: Date = modulDate.endOfDay();
+
+                expect(endOfDay.getFullYear()).toBe(date.getFullYear());
+                expect(endOfDay.getMonth()).toBe(date.getMonth());
+                expect(endOfDay.getDate()).toBe(date.getDate());
+                expect(endOfDay.getHours()).toBe(23);
+                expect(endOfDay.getMinutes()).toBe(59);
+                expect(endOfDay.getSeconds()).toBe(59);
+                expect(endOfDay.getMilliseconds()).toBe(999);
+            });
+        });
     });
 });

--- a/src/utils/modul-date/modul-date.spec.ts
+++ b/src/utils/modul-date/modul-date.spec.ts
@@ -634,7 +634,7 @@ describe(`ModulDate`, () => {
 
                 const newDate: Date = modulDate.subtract(10, 'year');
 
-                expect(newDate.getFullYear()).toBe(date.getFullYear() - 10);
+                expect(newDate.getFullYear()).toBe(1890);
             });
 
             it(`should not change the current date`, () => {

--- a/src/utils/modul-date/modul-date.ts
+++ b/src/utils/modul-date/modul-date.ts
@@ -165,6 +165,20 @@ export default class ModulDate {
     }
 
     /**
+     * format date following the date part of the standard ISO-8601
+     */
+    public toISOString(): string {
+        return this.innerDate.toISOString();
+    }
+
+    /**
+     * format date following the locale representation of a date
+     */
+    public toLocaleDateString(): string {
+        return this.innerDate.toLocaleDateString();
+    }
+
+    /**
      * Getter for the year value
      */
     public fullYear(): number {
@@ -216,17 +230,57 @@ export default class ModulDate {
         return Math.round(Math.abs(other.innerDate.getTime() - this.innerDate.getTime()) / (1000 * 3600 * 24));
     }
 
+    /**
+     * Add an unit of time to a copy of the current date and return it.
+     *
+     * @param valueToAdd The value to add to the time unit.
+     * @param kind The kind of time unit to be added.
+     * @return A new Date
+     */
+    public add(valueToAdd: number, kind: 'year'): Date {
+        return this.subtract(-valueToAdd, kind);
+    }
+
+    /**
+     * subtract an unit of time to a copy of the current date and return it.
+     *
+     * @param valueToAdd The value to add to the time unit.
+     * @param kind The kind of time unit to be added.
+     * @return A new Date
+     */
+    public subtract(valueToSubstract: number, kind: 'year'): Date {
+        const newDate: Date = new Date(this.innerDate);
+        switch (kind) {
+            case 'year':
+                newDate.setFullYear(newDate.getFullYear() - valueToSubstract);
+                break;
+            default: throw new Error(`modul-date: Unknown substract kind: ${kind}`);
+        }
+
+        return newDate;
+    }
+
+    /**
+     * Return a date representing the end of the day of a given date (23:59:59).
+     *
+     * @return A new Date
+     */
+    public endOfDay(): Date {
+        return new Date(this.innerDate.getUTCFullYear(), this.innerDate.getUTCMonth(), this.innerDate.getUTCDate(), 23, 59, 59, 999);
+    }
+
     private dateFromString(value: string): void {
         if (value === '') {
             this.innerDate = new Date();
         } else {
             this.innerDate = this.convertDateString(value);
         }
-
     }
 
     private convertDateString(value: string): Date {
-        const dateFormat: RegExp = /(^(\d{1,4})[\.|\\/|-](\d{1,2})[\.|\\/|-](\d{1,4}))$/;
+        const dateFormat: RegExp = /(^(\d{1,4})[\.|\\/|-](\d{1,2})[\.|\\/|-](\d{1,4})).*$/;
+        const isoTime: string = value.split('T')[1];
+
         const parts: string[] = dateFormat.exec(value) as string[];
         if (!parts || parts.length < 4) {
             throw Error(`Impossible to find date parts in date`);
@@ -252,9 +306,13 @@ export default class ModulDate {
         }
         const month: string = this.padString(second);
         const day: string = this.padString(third);
-        const date: Date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+        let date: Date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
 
-        return new Date(`${year}-${month}-${day}`);
+        if (isoTime) {
+            date = new Date(`${date.toISOString().split('T')[0]}T${isoTime}`);
+        }
+
+        return date;
     }
 
     private padString(input: string): string {

--- a/src/utils/modul-date/modul-date.ts
+++ b/src/utils/modul-date/modul-date.ts
@@ -234,27 +234,27 @@ export default class ModulDate {
      * Add an unit of time to a copy of the current date and return it.
      *
      * @param valueToAdd The value to add to the time unit.
-     * @param kind The kind of time unit to be added.
+     * @param unitOfTime The kind of time unit to be added.
      * @return A new Date
      */
-    public add(valueToAdd: number, kind: 'year'): Date {
-        return this.subtract(-valueToAdd, kind);
+    public add(valueToAdd: number, unitOfTime: 'year'): Date {
+        return this.subtract(-valueToAdd, unitOfTime);
     }
 
     /**
      * subtract an unit of time to a copy of the current date and return it.
      *
-     * @param valueToAdd The value to add to the time unit.
-     * @param kind The kind of time unit to be added.
+     * @param valueToSubtract The value to add to the time unit.
+     * @param unitOfTime The kind of time unit to be added.
      * @return A new Date
      */
-    public subtract(valueToSubstract: number, kind: 'year'): Date {
+    public subtract(valueToSubtract: number, unitOfTime: 'year'): Date {
         const newDate: Date = new Date(this.innerDate);
-        switch (kind) {
+        switch (unitOfTime) {
             case 'year':
-                newDate.setFullYear(newDate.getFullYear() - valueToSubstract);
+                newDate.setFullYear(newDate.getFullYear() - valueToSubtract);
                 break;
-            default: throw new Error(`modul-date: Unknown substract kind: ${kind}`);
+            default: throw new Error(`modul-date: Unknown substract unitOfTime: ${unitOfTime}`);
         }
 
         return newDate;
@@ -273,16 +273,17 @@ export default class ModulDate {
         if (value === '') {
             this.innerDate = new Date();
         } else {
-            this.innerDate = this.convertDateString(value);
+            this.innerDate = this.convertStringToDate(value);
         }
     }
 
-    private convertDateString(value: string): Date {
+    private convertStringToDate(value: string): Date {
         // If the string is an iso string, we use it directly.
         if (value.split('T')[1]) {
             return new Date(value);
         }
 
+        // Otherwise we try to build the date from a partial date string (2010-12-01 or 2010/12/01)
         const dateFormat: RegExp = /(^(\d{1,4})[\.|\\/|-](\d{1,2})[\.|\\/|-](\d{1,4})).*$/;
 
         const parts: string[] = dateFormat.exec(value) as string[];

--- a/src/utils/modul-date/modul-date.ts
+++ b/src/utils/modul-date/modul-date.ts
@@ -266,7 +266,7 @@ export default class ModulDate {
      * @return A new Date
      */
     public endOfDay(): Date {
-        return new Date(this.innerDate.getUTCFullYear(), this.innerDate.getUTCMonth(), this.innerDate.getUTCDate(), 23, 59, 59, 999);
+        return new Date(this.innerDate.getFullYear(), this.innerDate.getMonth(), this.innerDate.getDate(), 23, 59, 59, 999);
     }
 
     private dateFromString(value: string): void {
@@ -278,8 +278,12 @@ export default class ModulDate {
     }
 
     private convertDateString(value: string): Date {
+        // If the string is an iso string, we use it directly.
+        if (value.split('T')[1]) {
+            return new Date(value);
+        }
+
         const dateFormat: RegExp = /(^(\d{1,4})[\.|\\/|-](\d{1,2})[\.|\\/|-](\d{1,4})).*$/;
-        const isoTime: string = value.split('T')[1];
 
         const parts: string[] = dateFormat.exec(value) as string[];
         if (!parts || parts.length < 4) {
@@ -306,12 +310,7 @@ export default class ModulDate {
         }
         const month: string = this.padString(second);
         const day: string = this.padString(third);
-        let date: Date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
-
-        if (isoTime) {
-            date = new Date(`${date.toISOString().split('T')[0]}T${isoTime}`);
-        }
-
+        const date: Date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
         return date;
     }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
period picker wasn't working with ISO date string
values returned by the "dateTo" model will now be set at end of the day by default
- [ ] Include links to issues
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
https://jira.dti.ulaval.ca/browse/MODUL-780
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
