### PR TITLE
MODUL-791 - moved images styles into common mixin

### DIFF
--- a/src/components/rich-text-editor/adapter/vue-froala.scss
+++ b/src/components/rich-text-editor/adapter/vue-froala.scss
@@ -270,23 +270,6 @@
                 }
             }
         }
-
-        img {
-            max-width: 100%;
-            display: block;
-            margin: auto;
-            text-align: center;
-
-            &.fr-fil {
-                float: left;
-                margin-right: $m-spacing--s;
-            }
-
-            &.fr-fir {
-                float: right;
-                margin-left: $m-spacing--s;
-            }
-        }
     }
 
     &.m--is-mobile {

--- a/src/styles/mixins/_froala.scss
+++ b/src/styles/mixins/_froala.scss
@@ -20,4 +20,21 @@
     table {
         @include m-table();
     }
+
+    img {
+        max-width: 100%;
+        display: block;
+        margin: auto;
+        text-align: center;
+
+        &.fr-fil {
+            float: left;
+            margin-right: $m-spacing--s;
+        }
+
+        &.fr-fir {
+            float: right;
+            margin-left: $m-spacing--s;
+        }
+    }
 }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Moved images styles from vue-froala to mixin m-commons-froala-styles used by both m-rich-text-editor and m-rich-text.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-791
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
