### PR TITLE
MODUL-798 - Ajuster l'espacement du message de validation du m-radio-group

### DIFF
--- a/src/components/radio-group/__snapshots__/radio-group.spec.ts.snap
+++ b/src/components/radio-group/__snapshots__/radio-group.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MRadioGroup should render correctly 1`] = `
 <div class="m-radio-group">
-  <div class="m-validation-message m-radio-group__message m-u--margin-bottom"></div>
+  <div class="m-validation-message m-radio-group__message"></div>
   <ul role="radiogroup" class="m-radio-group__body">
     <li class="m-radio"><input type="radio" id="uuid" name="uuid" value="rdo1" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
     <li class="m-radio"><input type="radio" id="uuid" name="uuid" value="rdo2" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
@@ -12,7 +12,7 @@ exports[`MRadioGroup should render correctly 1`] = `
 
 exports[`MRadioGroup should render correctly when disabled 1`] = `
 <div class="m-radio-group m--is-disabled">
-  <div class="m-validation-message m-radio-group__message m-u--margin-bottom"></div>
+  <div class="m-validation-message m-radio-group__message"></div>
   <ul role="radiogroup" class="m-radio-group__body">
     <li class="m-radio m--is-disabled"><input type="radio" id="uuid" name="uuid" disabled="disabled" aria-hidden="true" value="rdo1" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
     <li class="m-radio m--is-disabled"><input type="radio" id="uuid" name="uuid" disabled="disabled" aria-hidden="true" value="rdo2" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
@@ -22,7 +22,7 @@ exports[`MRadioGroup should render correctly when disabled 1`] = `
 
 exports[`MRadioGroup should render correctly when inline 1`] = `
 <div class="m-radio-group m--is-inline">
-  <div class="m-validation-message m-radio-group__message m-u--margin-bottom"></div>
+  <div class="m-validation-message m-radio-group__message"></div>
   <ul role="radiogroup" class="m-radio-group__body">
     <li class="m-radio m--is-inline"><input type="radio" id="uuid" name="uuid" value="rdo1" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
     <li class="m-radio m--is-inline"><input type="radio" id="uuid" name="uuid" value="rdo2" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
@@ -32,7 +32,7 @@ exports[`MRadioGroup should render correctly when inline 1`] = `
 
 exports[`MRadioGroup should render correctly when radiosMarginTop is  10px 1`] = `
 <div class="m-radio-group">
-  <div class="m-validation-message m-radio-group__message m-u--margin-bottom"></div>
+  <div class="m-validation-message m-radio-group__message"></div>
   <ul role="radiogroup" class="m-radio-group__body">
     <li class="m-radio"><input type="radio" id="uuid" name="uuid" value="rdo1" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:10px;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
     <li class="m-radio"><input type="radio" id="uuid" name="uuid" value="rdo2" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:10px;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
@@ -42,7 +42,7 @@ exports[`MRadioGroup should render correctly when radiosMarginTop is  10px 1`] =
 
 exports[`MRadioGroup should render correctly when radiosPosition is right 1`] = `
 <div class="m-radio-group">
-  <div class="m-validation-message m-radio-group__message m-u--margin-bottom"></div>
+  <div class="m-validation-message m-radio-group__message"></div>
   <ul role="radiogroup" class="m-radio-group__body">
     <li class="m-radio m--is-input-right"><input type="radio" id="uuid" name="uuid" value="rdo1" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
     <li class="m-radio m--is-input-right"><input type="radio" id="uuid" name="uuid" value="rdo2" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
@@ -52,7 +52,7 @@ exports[`MRadioGroup should render correctly when radiosPosition is right 1`] = 
 
 exports[`MRadioGroup should render correctly when radiosVerticalAlign is center 1`] = `
 <div class="m-radio-group">
-  <div class="m-validation-message m-radio-group__message m-u--margin-bottom"></div>
+  <div class="m-validation-message m-radio-group__message"></div>
   <ul role="radiogroup" class="m-radio-group__body">
     <li class="m-radio m--is-align-center"><input type="radio" id="uuid" name="uuid" value="rdo1" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>
     <li class="m-radio m--is-align-center"><input type="radio" id="uuid" name="uuid" value="rdo2" class="m-radio__hidden"> <label for="uuid" class="m-radio__wrap"><span aria-hidden="true" class="m-radio__input" style="margin-top:undefined;"></span> <span class="m-radio__label"> <span class="m-radio__label__content"></span> </span></label></li>

--- a/src/components/radio-group/radio-group.html
+++ b/src/components/radio-group/radio-group.html
@@ -4,12 +4,6 @@
               'm--has-error': hasError,
               'm--is-valid': isValid,
               'm--has-validation-message': hasValidationMessage }">
-    <m-validation-message :id="idValidationMessage"
-                          class="m-radio-group__message"
-                          :disabled="stateIsDisabled"
-                          :error-message="errorMessage"
-                          :valid-message="validMessage"
-                          :helper-message="helperMessage"></m-validation-message>
     <p :id="idLabel"
        class="m-radio-group__label"
        v-if="hasLabel">
@@ -18,6 +12,12 @@
             <slot name="icon"></slot>
         </span>
     </p>
+    <m-validation-message :id="idValidationMessage"
+                          class="m-radio-group__message"
+                          :disabled="stateIsDisabled"
+                          :error-message="errorMessage"
+                          :valid-message="validMessage"
+                          :helper-message="helperMessage"></m-validation-message>
     <ul class="m-radio-group__body"
         role="radiogroup"
         :aria-labelledby="idLabel"

--- a/src/components/radio-group/radio-group.html
+++ b/src/components/radio-group/radio-group.html
@@ -2,9 +2,10 @@
      :class="{ 'm--is-inline': inline,
               'm--is-disabled': stateIsDisabled,
               'm--has-error': hasError,
-              'm--is-valid': isValid }">
+              'm--is-valid': isValid,
+              'm--has-validation-message': hasValidationMessage }">
     <m-validation-message :id="idValidationMessage"
-                          class="m-radio-group__message m-u--margin-bottom"
+                          class="m-radio-group__message"
                           :disabled="stateIsDisabled"
                           :error-message="errorMessage"
                           :valid-message="validMessage"

--- a/src/components/radio-group/radio-group.sandbox.html
+++ b/src/components/radio-group/radio-group.sandbox.html
@@ -1,6 +1,8 @@
 <div>
     <h3>Add a margin below the radio button group</h3>
-    <p>From <a href="https://jira.dti.ulaval.ca/browse/MODUL-135">MODUL-135</a></p>
+    <p>From <a href="https://jira.dti.ulaval.ca/browse/MODUL-135"
+           target="_blank">MODUL-135</a> et <a href="https://jira.dti.ulaval.ca/browse/MODUL-798"
+           target="_blank">MODUL-798</a></p>
     <m-radio-group error-message="Enim ipsum qui consectetur ea in non.">
         <m-radio value="1">1</m-radio>
         <m-radio value="2">2</m-radio>

--- a/src/components/radio-group/radio-group.sandbox.html
+++ b/src/components/radio-group/radio-group.sandbox.html
@@ -1,9 +1,15 @@
 <div>
-    <h3>Add a margin below the radio button group</h3>
-    <p>From <a href="https://jira.dti.ulaval.ca/browse/MODUL-135"
-           target="_blank">MODUL-135</a> et <a href="https://jira.dti.ulaval.ca/browse/MODUL-798"
-           target="_blank">MODUL-798</a></p>
-    <m-radio-group error-message="Enim ipsum qui consectetur ea in non.">
+    <h3>Margin management between element in radio-group</h3>
+    <m-radio-group class="m-u--margin-top"
+                   error-message="Error message: Enim ipsum qui consectetur ea in non."
+                   label="Radio-group with label and error">
+        <m-radio value="1">1</m-radio>
+        <m-radio value="2">2</m-radio>
+        <m-radio value="3">3</m-radio>
+    </m-radio-group>
+
+    <m-radio-group class="m-u--margin-top"
+                   label="Radio-group with label">
         <m-radio value="1">1</m-radio>
         <m-radio value="2">2</m-radio>
         <m-radio value="3">3</m-radio>

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -2,12 +2,19 @@
 
 .m-radio-group {
     &__label {
-        margin-top: 0;
-        margin-bottom: $m-margin--s;
+        margin: 0;
         font-size: $m-font-size;
         font-weight: $m-font-weight--bold;
         display: flex;
         align-items: center;
+
+        ~ .m-radio-group__body {
+            margin-top: $m-spacing--s;
+        }
+    }
+
+    &__message {
+        transition: margin $m-transition-duration ease;
     }
 
     &__body {
@@ -22,13 +29,15 @@
         margin-left: $m-margin--xs;
     }
 
-    &__message {
-        transition: margin $m-transition-duration ease;
-    }
-
     &.m--has-validation-message {
-        .m-radio-group__message {
-            margin-bottom: $m-spacing--s;
+        .m-radio-group__label {
+            ~ .m-radio-group__message {
+                margin-top: $m-spacing--xs;
+            }
+        }
+
+        .m-radio-group__body {
+            margin-top: $m-spacing--s;
         }
     }
 
@@ -37,7 +46,7 @@
             display: inline;
 
             + .m-radio {
-                margin-left: $m-padding--s;
+                margin-left: $m-spacing--s;
             }
         }
     }
@@ -45,7 +54,7 @@
     &:not(.m--is-inline) {
         .m-radio {
             + .m-radio {
-                margin-top: $m-margin--s;
+                margin-top: $m-spacing--s;
             }
 
             &-group__body {

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -23,7 +23,13 @@
     }
 
     &__message {
-        margin-top: $m-margin--xs;
+        transition: margin $m-transition-duration ease;
+    }
+
+    &.m--has-validation-message {
+        .m-radio-group__message {
+            margin-bottom: $m-spacing--s;
+        }
     }
 
     &.m--is-inline {


### PR DESCRIPTION
…dio-goup

## `@ulaval/modul-components`
# PR Checklist
<!-- REQUIRED -->
- [X] Provide a small description of the changes introduced by this PR
Ajuster l'espacement du message de validation du m-radio-group
- [X] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-798 
https://jira.dti.ulaval.ca/browse/MODUL-798


- [x] Include this section in the release notes
<!-- Release notes here... -->
Revoir l'alignement du composant m-radio-group, car il ne possède plus de margin-top par défaut.
