### PR TITLE
MODUL-819 - m-rich-text-editor : cursor behaviour fix

### DIFF
--- a/src/styles/mixins/_froala.scss
+++ b/src/styles/mixins/_froala.scss
@@ -26,6 +26,7 @@
         display: block;
         margin: auto;
         text-align: center;
+        position: relative;
 
         &.fr-fil {
             float: left;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
When cursor is positionned next to a centered image, cursor no longer takes full height of image. 
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-819
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
