### PR TITLE
periodpicker: Update model on blur only

### DIFF
--- a/src/components/periodpicker/periodpicker.ts
+++ b/src/components/periodpicker/periodpicker.ts
@@ -79,6 +79,9 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
     @Prop()
     max: DatePickerSupportedTypes;
 
+    @Emit('input')
+    emitNewValue(newValue: MDateRange): void { }
+
     dateFromInternalValue: DatePickerSupportedTypes = new Date();
     dateToInternalValue: DatePickerSupportedTypes = new Date();
     dateFromChanged: boolean = false;
@@ -167,9 +170,6 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
         this.dateToInternalValue = newValue ? this.getNewModelValue(newValue, true) : undefined;
         this.endSelection();
     }
-
-    @Emit('input')
-    emitNewValue(newValue: MDateRange): void { }
 
     onDateFromOpen(): void {
         this.fromIsFocused = true;

--- a/src/components/periodpicker/periodpicker.ts
+++ b/src/components/periodpicker/periodpicker.ts
@@ -2,7 +2,7 @@ import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Emit, Prop } from 'vue-property-decorator';
 import { InputState } from '../../mixins/input-state/input-state';
-import { MediaQueries, MediaQueriesMixin } from '../../mixins/media-queries/media-queries';
+import { MediaQueries } from '../../mixins/media-queries/media-queries';
 import ModulDate from '../../utils/modul-date/modul-date';
 import { ModulVue } from '../../utils/vue/vue';
 import { PERIODPICKER_NAME } from '../component-names';
@@ -16,6 +16,7 @@ export class MDateRange {
 }
 
 interface MPeriodpickerFromProps {
+    focus: boolean;
     value: DatePickerSupportedTypes;
     min: DatePickerSupportedTypes;
     max: DatePickerSupportedTypes;
@@ -29,6 +30,7 @@ interface MPeriodpickerFromProps {
 interface MPeriodpickerFromHandlers {
     change(newValue: DatePickerSupportedTypes): void;
     open(): void;
+    close(): void;
 }
 
 export interface MPeriodpickerFromComponentVue extends MPeriodpickerFromProps, MPeriodpickerFromHandlers { }
@@ -47,6 +49,7 @@ interface MPeriodpickerToProps {
 
 interface MPeriodpickerToHandlers {
     change(newValue: DatePickerSupportedTypes): void;
+    open(): void;
     close(): void;
 }
 
@@ -76,11 +79,18 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
     @Prop()
     max: DatePickerSupportedTypes;
 
+    dateFromInternalValue: DatePickerSupportedTypes = new Date();
+    dateToInternalValue: DatePickerSupportedTypes = new Date();
+    dateFromChanged: boolean = false;
+    dateToChanged: boolean = false;
+    selecting: boolean = false;
+    fromIsFocused: boolean = false;
     toIsFocused: boolean = false;
 
     get firstInputState(): MPeriodpickerFromSlotProps {
         return {
             props: {
+                focus: this.fromIsFocused,
                 value: this.internalValue.from,
                 min: this.min,
                 max: this.max,
@@ -92,7 +102,8 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
             },
             handlers: {
                 change: (newValue: DatePickerSupportedTypes) => this.onDateFromChange(newValue),
-                open: () => this.onDateFromOpen()
+                open: () => this.onDateFromOpen(),
+                close: () => this.onDateFromClose()
             }
         };
     }
@@ -112,13 +123,18 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
             },
             handlers: {
                 change: (newValue: DatePickerSupportedTypes) => this.onDateToChange(newValue),
+                open: () => this.onDateToOpen(),
                 close: () => this.onDateToClose()
             }
         };
     }
 
     get internalValue(): MDateRange {
-        return this.value || {};
+        if (!this.selecting) {
+            return this.value || {};
+        } else {
+            return { from: this.dateFromInternalValue, to: this.dateToInternalValue };
+        }
     }
 
     get minDateTo(): DatePickerSupportedTypes {
@@ -134,41 +150,47 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
     }
 
     onDateFromChange(newValue: DatePickerSupportedTypes): void {
-        const dateToValue: DatePickerSupportedTypes = this.getNewModelValue(this.internalValue.to, true);
-        if (newValue) {
-            if (this.as<MediaQueriesMixin>().isMqMinS) {
-                this.toIsFocused = true;
-            }
+        this.dateFromChanged = true;
 
-            this.emitNewValue({ from: this.getNewModelValue(newValue), to: dateToValue });
+        this.dateFromInternalValue = newValue ? this.getNewModelValue(newValue) : undefined;
+        if (!newValue) {
+            this.endSelection();
         } else {
-            this.emitNewValue({ from: undefined, to: dateToValue });
+            this.toIsFocused = true;
         }
+        this.fromIsFocused = false;
     }
 
     onDateToChange(newValue: DatePickerSupportedTypes): void {
-        const dateFromValue: DatePickerSupportedTypes = this.getNewModelValue(this.internalValue.from);
-        if (newValue) {
-            this.unfocusDateToField();
-            this.emitNewValue({ from: dateFromValue, to: this.getNewModelValue(newValue, true) });
-        } else {
-            this.emitNewValue({ from: dateFromValue, to: undefined });
-        }
+        this.dateToChanged = true;
+
+        this.dateToInternalValue = newValue ? this.getNewModelValue(newValue, true) : undefined;
+        this.endSelection();
     }
 
     @Emit('input')
     emitNewValue(newValue: MDateRange): void { }
 
     onDateFromOpen(): void {
-        this.unfocusDateToField();
+        this.fromIsFocused = true;
+        this.beginSelection();
+    }
+
+    onDateFromClose(): void {
+        if (!this.dateFromChanged) {
+            this.endSelection();
+        }
+    }
+
+    onDateToOpen(): void {
+        this.toIsFocused = true;
+        this.beginSelection();
     }
 
     onDateToClose(): void {
-        this.unfocusDateToField();
-    }
-
-    unfocusDateToField(): void {
-        this.toIsFocused = false;
+        if (!this.dateToChanged) {
+            this.endSelection();
+        }
     }
 
     getNewModelValue(newValue: DatePickerSupportedTypes, endOfDay: boolean = false): DatePickerSupportedTypes {
@@ -178,6 +200,23 @@ export class MPeriodpicker extends ModulVue implements MPeriodpickerProps {
         const isoString: string = endOfDay ? modulDate.endOfDay().toISOString() : modulDate.toISOString();
 
         return new Date(isoString);
+    }
+
+    beginSelection(): void {
+        if (!this.selecting) {
+            this.dateFromChanged = false;
+            this.dateToChanged = false;
+            this.dateFromInternalValue = (this.value || {}).from;
+            this.dateToInternalValue = (this.value || {}).to;
+            this.selecting = true;
+        }
+    }
+
+    endSelection(): void {
+        this.selecting = false;
+        this.fromIsFocused = false;
+        this.toIsFocused = false;
+        this.emitNewValue({ from: this.dateFromInternalValue, to: this.dateToInternalValue });
     }
 }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
period picker model is now updated only when blur / selection end occurs.  This allows easier validation (No validation breaking when picking from date when we have not had the chance to pick a date to yet)
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-823
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
