### PR TITLE
MODUL-814 - Changed underline on tooltip__link

### DIFF
--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -131,7 +131,7 @@ $m-tooltip--max-height: 280px !default;
         }
     }
 
-    &__link {
-        border-bottom: 2px dotted currentColor;
+    &__link /deep/ .m-link__text span {
+        border-bottom: 1px dotted currentColor;
     }
 }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

- [x] Provide a small description of the changes introduced by this PR
Changement d'épaisseur et de position du underline sur le tooltip__link
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-814
- [ ] Openshift deployment requested
