### PR TITLE
Feature/modul 838 input state readonly

### DIFF
--- a/src/components/datepicker/datepicker.html
+++ b/src/components/datepicker/datepicker.html
@@ -1,5 +1,6 @@
 <div class="m-datepicker"
      :class="{ 'm--is-disabled': isDisabled,
+               'm--is-readonly': isReadonly,
                'm--is-waiting': isWaiting,
                'm--has-error': calandarError,
                'm--is-valid': isValid,
@@ -7,6 +8,7 @@
     <m-input-style :label="label"
                    :label-for="id"
                    :disabled="isDisabled"
+                   :readonly="isReadonly"
                    :waiting="isWaiting"
                    :focus="open"
                    :empty="isEmpty"
@@ -19,7 +21,8 @@
                aria-haspopup="true"
                :aria-controls="ariaControls1 + ' ' + ariaControls2"
                :aria-expanded="open"
-               :disabled="!active"
+               :disabled="isDisabled || isWaiting"
+               :readonly="isReadonly"
                :placeholder="placeholder"
                @keydown.delete="inputOnKeydownDelete"
                @keydown.enter="inputOnKeydownEnter"
@@ -31,7 +34,7 @@
                @focus="inputOnFocus"
                @blur="onBlur"
                @click.stop
-               :value="formattedDate">
+               :value="formattedDate" />
         <m-icon-button slot="right-content"
                        class="m-datepicker__icon"
                        icon-name="m-svg__calendar"

--- a/src/components/datepicker/datepicker.sandbox.html
+++ b/src/components/datepicker/datepicker.sandbox.html
@@ -25,4 +25,9 @@
         <m-button slot="trigger">Open the modal</m-button>
         <m-datepicker class="m-u--margint-top"></m-datepicker>
     </m-modal>
+
+    <h2>Readonly</h2>
+    <m-datepicker :readonly="true">
+    </m-datepicker>
+
 </div>

--- a/src/components/input-group/__snapshots__/input-group.spec.ts.snap
+++ b/src/components/input-group/__snapshots__/input-group.spec.ts.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MInputGroup with all props defined when removing legend will render correctly 1`] = `
-<fieldset class="m-input-group m--is-readonly m--is-disabled">
-  <div>true false false true false</div>
-  <m-validation-message disabled="disabled" error-message="Some error message" valid-message="Some valid message" helper-message="Some helper message" class="m-input-group__validation__message"></m-validation-message>
+<fieldset class="m-input-group m--is-readonly">
+  <div>false false false true false</div>
+  <m-validation-message error-message="Some error message" valid-message="Some valid message" helper-message="Some helper message" class="m-input-group__validation__message"></m-validation-message>
 </fieldset>
 `;
 
 exports[`MInputGroup with all props defined when setting visiblity to false will render correctly 1`] = `
-<fieldset class="m-input-group m--is-readonly m--is-disabled m--border-hidden">
-  <div>true false false true false</div>
+<fieldset class="m-input-group m--is-readonly m--border-hidden">
+  <div>false false false true false</div>
 </fieldset>
 `;
 
 exports[`MInputGroup with all props defined will render correctly 1`] = `
-<fieldset class="m-input-group m--is-readonly m--is-disabled">
+<fieldset class="m-input-group m--is-readonly">
   <legend class="m-input-group__legend">Some legend</legend>
-  <div>true false false true false</div>
-  <m-validation-message disabled="disabled" error-message="Some error message" valid-message="Some valid message" helper-message="Some helper message" class="m-input-group__validation__message"></m-validation-message>
+  <div>false false false true false</div>
+  <m-validation-message error-message="Some error message" valid-message="Some valid message" helper-message="Some helper message" class="m-input-group__validation__message"></m-validation-message>
 </fieldset>
 `;
 

--- a/src/components/input-style/input-style.html
+++ b/src/components/input-style/input-style.html
@@ -1,6 +1,6 @@
 <div class="m-input-style"
      :class="[{ 'm--is-focus' : isFocus,
-              'm--is-readonly': readonly,
+              'm--is-readonly': isReadonly,
               'm--is-label-up': isLabelUp,
               'm--is-disabled' : isDisabled,
               'm--is-waiting' : isWaiting,

--- a/src/components/input-style/input-style.scss
+++ b/src/components/input-style/input-style.scss
@@ -89,9 +89,18 @@ $m-input-style-base-height: $m-line-height + em;
     }
 
     &.m--is-disabled,
-    &.m--is-waiting {
+    &.m--is-waiting,
+    &.m--is-readonly {
         border-style: dashed;
 
+        input,
+        textarea {
+            user-select: none;
+        }
+    }
+
+    &.m--is-disabled,
+    &.m--is-waiting {
         .m-input-style__label,
         .m-input-style__body,
         .m-icon-button.m-icon-button,
@@ -99,11 +108,6 @@ $m-input-style-base-height: $m-line-height + em;
         input,
         textarea {
             color: $m-input-style--color-disabled;
-        }
-
-        input,
-        textarea {
-            user-select: none;
         }
     }
 
@@ -119,7 +123,9 @@ $m-input-style-base-height: $m-line-height + em;
     }
 
     &.m--is-readonly {
-        @include input-style-cursor();
+        @include input-style-cursor() {
+            user-select: none;
+        }
     }
 
     &.m--is-anim-ready {

--- a/src/components/integerfield/integerfield.html
+++ b/src/components/integerfield/integerfield.html
@@ -1,6 +1,7 @@
 <div class="m-integerfield"
      :class="[{ 'm--is-disabled': isDisabled,
                 'm--is-waiting': isWaiting,
+                'm--is-readonly': isReadonly,
                 'm--has-error': hasIntegerfieldError,
                 'm--is-valid': isIntegerfieldValid,
                 'm--has-label': hasLabel,
@@ -15,15 +16,15 @@
                    :label-for="id"
                    :focus="isFocus"
                    :empty="isEmpty"
-                   :readonly="readonly"
+                   :readonly="isReadonly"
                    :required-marker="requiredMarker"
                    :tag-style="tagStyle">
         <input class="m-integerfield__input"
                v-model="model"
                :id="id"
-               :disabled="!active"
+               :disabled="isDisabled || isWaiting"
                :placeholder="placeholder"
-               :readonly="readonly"
+               :readonly="isReadonly"
                :maxlength="maxLengthNumber"
                :pattern="inputPattern"
                :inputmode="inputMode"

--- a/src/components/integerfield/integerfield.sandbox.html
+++ b/src/components/integerfield/integerfield.sandbox.html
@@ -28,4 +28,14 @@
                     value="10"
                     v-model="model4"
                     valid-message="Valid textfield"></m-integerfield>
+
+    <h2>Readonly</h2>
+    <h3 class="m-u--h6">Placehoder</h3>
+    <m-integerfield label="label"
+                    placeholder="Put a number"
+                    :readonly="true"></m-integerfield>
+    <h3 class="m-u--h6">Value</h3>
+    <m-integerfield label="label"
+                    value="10"
+                    :readonly="true"></m-integerfield>
 </div>

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -1,6 +1,7 @@
 <div class="m-textarea"
      :class="{ 'm--is-disabled' : isDisabled,
                'm--is-waiting' : isWaiting,
+               'm--is-readonly' : isReadonly,
                'm--has-error' : hasTextareaError,
                'm--is-valid' : isTextareaValid,
                'm--is-focus' : isFocus,
@@ -16,15 +17,15 @@
                    :label-for="id"
                    :focus="isFocus"
                    :empty="isEmpty"
-                   :readonly="readonly"
+                   :readonly="isReadonly"
                    :required-marker="requiredMarker"
                    :tag-style="tagStyle">
         <textarea ref="input"
                   :id="id"
                   class="m-textarea__input"
-                  :disabled="!active"
+                  :disabled="isDisabled || isWaiting"
+                  :readonly="isReadonly"
                   :placeholder="placeholder"
-                  :readonly="readonly"
                   :maxlength="maxLengthNumber"
                   :autocomplete="autocomplete"
                   rows="1"

--- a/src/components/textarea/textarea.sandbox.html
+++ b/src/components/textarea/textarea.sandbox.html
@@ -130,6 +130,18 @@
                     character-counter-threshold="20">
         </m-textarea>
     </p>
+    <!-- Sandbox template -->
+    <h3>Readonly</h3>
+    <p class="m-u--margin-bottom">
+        With Placeholder
+        <m-textarea placeholder="Placeholder"
+                    :readonly="true"></m-textarea>
+    </p>
+    <p class="m-u--margin-bottom">
+        With value
+        <m-textarea value="Valeur"
+                    :readonly="true"></m-textarea>
+    </p>
 
     <!-- Sandbox template -->
     <h3>Test # : Title</h3>

--- a/src/components/textfield/textfield.html
+++ b/src/components/textfield/textfield.html
@@ -1,5 +1,6 @@
 <div class="m-textfield"
      :class="[{ 'm--is-disabled': isDisabled,
+                'm--is-readonly': isReadonly,
                 'm--is-waiting': isWaiting,
                 'm--has-error': hasTextfieldError,
                 'm--is-valid': isTextfieldValid,
@@ -17,7 +18,7 @@
                    :label-for="id"
                    :focus="isFocus"
                    :empty="isEmpty"
-                   :readonly="readonly"
+                   :readonly="isReadonly"
                    :required-marker="requiredMarker"
                    :tag-style="tagStyle">
         <input class="m-textfield__input"
@@ -25,9 +26,9 @@
                v-model="model"
                :id="id"
                :autocomplete="autocomplete"
-               :disabled="!active"
+               :disabled="isDisabled || isWaiting"
                :placeholder="placeholder"
-               :readonly="readonly"
+               :readonly="isReadonly"
                :maxlength="maxLengthNumber"
                :type="inputType"
                @focus="onFocus"
@@ -70,9 +71,9 @@
         <textarea ref="input"
                   :id="id"
                   class="m-textfield__input"
-                  :disabled="!active"
+                  :disabled="isDisabled || isWaiting"
                   :placeholder="placeholder"
-                  :readonly="readonly"
+                  :readonly="isReadonly"
                   rows="1"
                   @focus="onFocus"
                   @blur="onBlur"

--- a/src/components/timepicker/timepicker.html
+++ b/src/components/timepicker/timepicker.html
@@ -1,9 +1,11 @@
 <div class="m-timepicker"
      :class="{ 'm--is-disabled': isDisabled,
+               'm--is-readonly': isReadonly,
                'm--has-validation-message': hasValidationMessage }">
     <m-input-style :label="label"
                    :label-for="id"
                    :disabled="isDisabled"
+                   :readonly="isReadonly"
                    :waiting="isWaiting"
                    :focus="open"
                    :empty="isEmpty"
@@ -17,7 +19,8 @@
                aria-haspopup="true"
                :aria-controls="ariaControls"
                :aria-expanded="open"
-               :disabled="!active"
+               :disabled="isDisabled || isWaiting"
+               :readonly="isReadonly"
                :placeholder="placeholder"
                @keydown.enter="inputOnKeydownEnter"
                @keydown.return="inputOnKeydownEnter"

--- a/src/components/timepicker/timepicker.sandbox.html
+++ b/src/components/timepicker/timepicker.sandbox.html
@@ -7,7 +7,12 @@
         </br>From <a href="https://github.com/ulaval/modul-components/pull/000" target="blank">PR description</a>
         -->
     </p>
+    <h3>Readonly</h3>
+    <m-timepicker :readonly="true">
+    </m-timepicker>
     <p>
-        <m-timepicker><!-- Test case --></m-timepicker>
+        <m-timepicker>
+            <!-- Test case -->
+        </m-timepicker>
     </p>
 </div>

--- a/src/components/timepicker/timepicker.sandbox.html
+++ b/src/components/timepicker/timepicker.sandbox.html
@@ -7,12 +7,12 @@
         </br>From <a href="https://github.com/ulaval/modul-components/pull/000" target="blank">PR description</a>
         -->
     </p>
-    <h3>Readonly</h3>
-    <m-timepicker :readonly="true">
-    </m-timepicker>
     <p>
         <m-timepicker>
             <!-- Test case -->
         </m-timepicker>
     </p>
+    <h3>Readonly</h3>
+    <m-timepicker :readonly="true">
+    </m-timepicker>
 </div>

--- a/src/components/timepicker/timepicker.sandbox.ts
+++ b/src/components/timepicker/timepicker.sandbox.ts
@@ -1,7 +1,7 @@
 import Vue, { PluginObject } from 'vue';
 import { Component } from 'vue-property-decorator';
-
 import { TIMEPICKER_NAME } from '../component-names';
+import TimepickerPlugin from './timepicker';
 import WithRender from './timepicker.sandbox.html';
 
 @WithRender
@@ -11,6 +11,7 @@ export class MTimepickerSandbox extends Vue {
 
 const TimepickerSandboxPlugin: PluginObject<any> = {
     install(v, options): void {
+        v.use(TimepickerPlugin);
         v.component(`${TIMEPICKER_NAME}-sandbox`, MTimepickerSandbox);
     }
 };

--- a/src/mixins/input-state/input-state.ts
+++ b/src/mixins/input-state/input-state.ts
@@ -5,6 +5,7 @@ import { ModulVue } from '../../utils/vue/vue';
 export enum InputStateValue {
     Default = 'default',
     Disabled = 'disabled',
+    Readonly = 'readonly',
     Waiting = 'waiting',
     Error = 'error',
     Valid = 'valid'
@@ -24,6 +25,7 @@ export enum InputStateTagStyle {
 export interface InputStateMixin {
     active: boolean;
     isDisabled: boolean;
+    isReadonly: boolean;
     isWaiting: boolean;
     hasError: boolean;
     isValid: boolean;
@@ -86,6 +88,10 @@ export class InputState extends ModulVue implements InputStateMixin {
         return this.state === InputStateValue.Disabled;
     }
 
+    public get isReadonly(): boolean {
+        return this.state === InputStateValue.Readonly;
+    }
+
     public get isWaiting(): boolean {
         return this.state === InputStateValue.Waiting;
     }
@@ -99,23 +105,27 @@ export class InputState extends ModulVue implements InputStateMixin {
     }
 
     public get state(): InputStateValue {
-        let state: InputStateValue;
-        if (!this.disabled) {
-            if (!this.waiting) {
-                if (this.hasErrorMessage || this.error) {
-                    state = InputStateValue.Error;
-                } else if (this.hasValidMessage || this.valid) {
-                    state = InputStateValue.Valid;
-                } else {
-                    state = InputStateValue.Default;
-                }
-            } else {
-                state = InputStateValue.Waiting;
-            }
-        } else {
-            state = InputStateValue.Disabled;
+        if (this.readonly) {
+            return InputStateValue.Readonly;
         }
-        return state;
+
+        if (this.disabled) {
+            return InputStateValue.Disabled;
+        }
+
+        if (this.waiting) {
+            return InputStateValue.Waiting;
+        }
+
+        if (this.hasErrorMessage || this.error) {
+            return InputStateValue.Error;
+        }
+
+        if (this.hasValidMessage || this.valid) {
+            return InputStateValue.Valid;
+        }
+
+        return InputStateValue.Default;
     }
 
     public get hasErrorMessage(): boolean {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [X] Provide a small description of the changes introduced by this PR
Appliquer sur les composants utilisant <m-input-style> et les <input> ou <textarea> suivant
-- datePicker
-- integerField
-- textArea
-- textField
-- timePicker
Ne s'applique pas au rich-text-editor et dropdown car ils ont une présentation différente. Aussi le dropdown utilise déjà la propriété "readonly" dans son code pour un autre besoin. Ils pourraient faire partie d'autres PR adressant chacune de leurs particularités.
- Changement du visuel du Readonly: Bordure pointillé, texte noir
- Ajout de Readonly au state de input-state
- Clarification de ma méthode pour calculer le state

<!-- Description here... -->
- [X] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-838
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
