### PR TITLE
MODUL-851: Ajuster la largeur des icones dans les composants modul

### DIFF
--- a/src/components/datepicker/__snapshots__/datepicker.spec.ts.snap
+++ b/src/components/datepicker/__snapshots__/datepicker.spec.ts.snap
@@ -63,7 +63,7 @@ exports[`MDatepicker should render correctly when error is set 1`] = `
   </div>
   <div class="m-validation-message m-datepicker__validation-message">
     <div class="m-validation-message__wrap">
-      <p class="m-validation-message__error"><svg width="20px" height="20px" class="m-icon m-validation-message__error__icon">
+      <p class="m-validation-message__error"><svg width="1em" height="1em" class="m-icon m-validation-message__error__icon">
           <title>m-validation-message:title-error-icon</title>
           <use aria-hidden="true"></use>
         </svg> <span class="m-validation-message__text">Nostrud laboris quis velit voluptate aute elit elit non.</span></p>
@@ -87,7 +87,7 @@ exports[`MDatepicker should render correctly when valid is set 1`] = `
   </div>
   <div class="m-validation-message m-datepicker__validation-message">
     <div class="m-validation-message__wrap">
-      <p class="m-validation-message__valid"><svg width="20px" height="20px" class="m-icon m-validation-message__valid__icon">
+      <p class="m-validation-message__valid"><svg width="1em" height="1em" class="m-icon m-validation-message__valid__icon">
           <title>m-validation-message:title-valid-icon</title>
           <use aria-hidden="true"></use>
         </svg> <span class="m-validation-message__text">Nostrud laboris quis velit voluptate aute elit elit non.</span></p>

--- a/src/components/error-message/__snapshots__/error-message.spec.ts.snap
+++ b/src/components/error-message/__snapshots__/error-message.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`MErrorMessage given error should render correctly expanded 1`] = `
 <div class="m-error-message">
   <div class="m-message m--is-state-error m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -26,7 +26,7 @@ exports[`MErrorMessage given error should render correctly expanded with stack t
 <div class="m-error-message">
   <div class="m-message m--is-state-error m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -50,7 +50,7 @@ exports[`MErrorMessage given error with stack trace should render correctly expa
 <div class="m-error-message">
   <div class="m-message m--is-state-error m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -72,7 +72,7 @@ exports[`MErrorMessage given error with stack trace should render correctly expa
 <div class="m-error-message">
   <div class="m-message m--is-state-error m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -96,7 +96,7 @@ exports[`MErrorMessage should render correctly collapsed 1`] = `
 <div class="m-error-message">
   <div class="m-message m--is-state-error m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -118,7 +118,7 @@ exports[`MErrorMessage should render correctly expanded 1`] = `
 <div class="m-error-message">
   <div class="m-message m--is-state-error m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">

--- a/src/components/menu/menu-item/menu-item.html
+++ b/src/components/menu/menu-item/menu-item.html
@@ -13,7 +13,11 @@
                  :aria-selected="selected"
                  role="menuitem"
                  v-if="isUrl">
-        <m-icon class="m-menu-item__icon" ref="icon" v-if="iconName" :name="iconName"></m-icon>
+        <m-icon class="m-menu-item__icon"
+                v-if="iconName"
+                :name="iconName"
+                size="1em"
+                ref="icon"></m-icon>
         <span class="m-menu-item__label">{{ label }}</span>
     </router-link>
     <span class="m-menu-item__link"
@@ -25,12 +29,25 @@
           :aria-controls="group ? ariaControls : undefined"
           :aria-expanded="group ? propOpen : undefined"
           v-else>
-        <m-icon class="m-menu-item__icon" ref="icon" v-if="iconName" :name="iconName"></m-icon>
+        <m-icon class="m-menu-item__icon"
+                v-if="iconName"
+                :name="iconName"
+                ref="icon"
+                size="1em"></m-icon>
         <span class="m-menu-item__label">{{ label }}</span>
-        <m-plus class="m-menu-item__plus" skin="current-color" :open="propOpen" :large="groupSelected" ref="plus" v-if="group"></m-plus>
+        <m-plus class="m-menu-item__plus"
+                skin="current-color"
+                :open="propOpen"
+                :large="groupSelected"
+                ref="plus"
+                v-if="group"></m-plus>
     </span>
     <m-accordion-transition :transition="isAnimReady">
-        <ul :id="ariaControls" class="m-menu-item__group" ref="group" :aria-hidden="!propOpen" v-show="propOpen">
+        <ul :id="ariaControls"
+            class="m-menu-item__group"
+            ref="group"
+            :aria-hidden="!propOpen"
+            v-show="propOpen">
             <slot></slot>
         </ul>
     </m-accordion-transition>

--- a/src/components/message/__snapshots__/message.spec.ts.snap
+++ b/src/components/message/__snapshots__/message.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`MMessage should render correctly 1`] = `
 <div class="m-message m--is-state-confirmation m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body"> </div>
@@ -14,7 +14,7 @@ exports[`MMessage should render correctly 1`] = `
 exports[`MMessage should render correctly all possible states: Confirmation 1`] = `
 <div class="m-message m--is-state-confirmation m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body"> </div>
@@ -25,7 +25,7 @@ exports[`MMessage should render correctly all possible states: Confirmation 1`] 
 exports[`MMessage should render correctly all possible states: Error 1`] = `
 <div class="m-message m--is-state-error m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body"> </div>
@@ -36,7 +36,7 @@ exports[`MMessage should render correctly all possible states: Error 1`] = `
 exports[`MMessage should render correctly all possible states: Information 1`] = `
 <div class="m-message m--is-state-information m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body"> </div>
@@ -47,7 +47,7 @@ exports[`MMessage should render correctly all possible states: Information 1`] =
 exports[`MMessage should render correctly all possible states: Warning 1`] = `
 <div class="m-message m--is-state-warning m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body"> </div>
@@ -58,7 +58,7 @@ exports[`MMessage should render correctly all possible states: Warning 1`] = `
 exports[`MMessage should render correctly close button when prop is set 1`] = `
 <div class="m-message m--is-state-confirmation m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body m--has-close-button"> </div> <button type="button" class="m-icon-button m-message__body__close-button m--is-skin-light m--has-ripple" style="width:44px;height:44px;"><svg aria-hidden="true" width="10px" height="10px" class="m-icon m-icon-button__icon">
@@ -71,7 +71,7 @@ exports[`MMessage should render correctly close button when prop is set 1`] = `
 exports[`MMessage should render correctly content 1`] = `
 <div class="m-message m--is-state-confirmation m--is-skin-default">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body">
@@ -84,7 +84,7 @@ exports[`MMessage should render correctly content 1`] = `
 exports[`MMessage should render correctly light skin 1`] = `
 <div class="m-message m--is-state-confirmation m--is-skin-light">
   <div class="m-message__wrap">
-    <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+    <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
         <use aria-hidden="true"></use>
       </svg></div>
     <div class="m-message__body"> </div>

--- a/src/components/message/message.html
+++ b/src/components/message/message.html
@@ -1,5 +1,5 @@
 <div class="m-message"
-    :class="{'m--is-state-confirmation': isStateConfirmation,
+     :class="{'m--is-state-confirmation': isStateConfirmation,
             'm--is-state-information': isStateInformation,
             'm--is-state-warning': isStateWarning,
             'm--is-state-error': isStateError,
@@ -7,26 +7,28 @@
             'm--is-skin-light': isSkinLight,
             'm--is-skin-page': isSkinPage,
             'm--is-skin-page-light': isSkinPageLight}"
-    v-if="propVisible">
+     v-if="propVisible">
     <div class="m-message__wrap"
-        v-if="isNotSkinPage">
-        <div class="m-message__icon" v-if="icon">
-            <m-icon :name="getIcon()"></m-icon>
+         v-if="isNotSkinPage">
+        <div class="m-message__icon"
+             v-if="icon">
+            <m-icon :name="getIcon()"
+                    size="1em"></m-icon>
         </div>
         <div class="m-message__body"
-            :class="{'m--has-close-button': closeButton}">
+             :class="{'m--has-close-button': closeButton}">
             <h2 class="m-message__title"
                 v-if="title">{{title}}</h2>
             <div class="m-message__text"
-                    v-if="$slots.default">
+                 v-if="$slots.default">
                 <slot></slot>
             </div>
         </div>
         <m-icon-button class="m-message__body__close-button"
-                    v-if="showCloseButton"
-                    icon-name="m-svg__close-clear"
-                    icon-size="10px"
-                    @click="onClose" >
+                       v-if="showCloseButton"
+                       icon-name="m-svg__close-clear"
+                       icon-size="10px"
+                       @click="onClose">
             {{'m-message:close' | f-m-i18n}}
         </m-icon-button>
     </div>

--- a/src/components/message/message.scss
+++ b/src/components/message/message.scss
@@ -40,7 +40,7 @@ $m-message-size: 32px;
     .m-message {
         &__wrap {
             display: flex;
-            padding: $m-margin;
+            padding: $m-spacing;
             background: $m-color--grey-lightest;
         }
 
@@ -56,7 +56,7 @@ $m-message-size: 32px;
             display: flex;
             justify-content: center;
             flex-direction: column;
-            padding-left: $m-margin;
+            padding-left: $m-spacing;
             width: calc(100% - #{$m-message-size});
 
             &.m--has-close-button {
@@ -126,9 +126,10 @@ $m-message-size: 32px;
         }
 
         &__body {
-            margin-left: $m-margin--s;
+            margin-top: 1px; // Magic number: align text with icon
+            margin-left: $m-spacing--s;
             align-self: flex-start;
-            width: calc(100% - #{$m-font-size--l + $m-margin--s});
+            width: calc(100% - #{$m-font-size--l + $m-spacing--s});
         }
 
         &__title {

--- a/src/components/page-not-found/__snapshots__/page-not-found.spec.ts.snap
+++ b/src/components/page-not-found/__snapshots__/page-not-found.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`MPageNotFound should render correctly 1`] = `
 <div>
   <div class="m-message m--is-state-warning m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -24,7 +24,7 @@ exports[`MPageNotFound should render correctly with back-to-label override 1`] =
 <div>
   <div class="m-message m--is-state-warning m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">

--- a/src/components/session-expired/__snapshots__/session-expired.spec.ts.snap
+++ b/src/components/session-expired/__snapshots__/session-expired.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`MSessionExpired should render correctly 1`] = `
 <div>
   <div class="m-message m--is-state-information m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">
@@ -23,7 +23,7 @@ exports[`MSessionExpired should render correctly with back-to-label override 1`]
 <div>
   <div class="m-message m--is-state-information m--is-skin-default">
     <div class="m-message__wrap">
-      <div class="m-message__icon"><svg aria-hidden="true" width="20px" height="20px" class="m-icon">
+      <div class="m-message__icon"><svg aria-hidden="true" width="1em" height="1em" class="m-icon">
           <use aria-hidden="true"></use>
         </svg></div>
       <div class="m-message__body">

--- a/src/components/timepicker/__snapshots__/timepicker.spec.ts.snap
+++ b/src/components/timepicker/__snapshots__/timepicker.spec.ts.snap
@@ -63,7 +63,7 @@ exports[`MTimepicker should render correctly when error is set 1`] = `
   </div>
   <div class="m-validation-message m-timepicker__validation-message">
     <div class="m-validation-message__wrap">
-      <p class="m-validation-message__error"><svg width="20px" height="20px" class="m-icon m-validation-message__error__icon">
+      <p class="m-validation-message__error"><svg width="1em" height="1em" class="m-icon m-validation-message__error__icon">
           <title>m-validation-message:title-error-icon</title>
           <use aria-hidden="true"></use>
         </svg> <span class="m-validation-message__text">Nostrud laboris quis velit voluptate aute elit elit non.</span></p>
@@ -87,7 +87,7 @@ exports[`MTimepicker should render correctly when valid is set 1`] = `
   </div>
   <div class="m-validation-message m-timepicker__validation-message">
     <div class="m-validation-message__wrap">
-      <p class="m-validation-message__valid"><svg width="20px" height="20px" class="m-icon m-validation-message__valid__icon">
+      <p class="m-validation-message__valid"><svg width="1em" height="1em" class="m-icon m-validation-message__valid__icon">
           <title>m-validation-message:title-valid-icon</title>
           <use aria-hidden="true"></use>
         </svg> <span class="m-validation-message__text">Nostrud laboris quis velit voluptate aute elit elit non.</span></p>

--- a/src/components/toast/toast.html
+++ b/src/components/toast/toast.html
@@ -19,7 +19,8 @@
             <div class="m-toast__wrap">
                 <div v-if="icon"
                      class="m-toast__icon">
-                    <m-icon :name="getIcon()"></m-icon>
+                    <m-icon :name="getIcon()"
+                            size="1em"></m-icon>
                 </div>
                 <div class="m-toast__body">
                     <div class="m-toast__text">

--- a/src/components/validation-message/__snapshots__/validation-message.spec.ts.snap
+++ b/src/components/validation-message/__snapshots__/validation-message.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`MValidationMessage should render correctly when it is in error 1`] = `
 <div class="m-validation-message">
   <div class="m-validation-message__wrap">
-    <p class="m-validation-message__error"><svg width="20px" height="20px" class="m-icon m-validation-message__error__icon">
+    <p class="m-validation-message__error"><svg width="1em" height="1em" class="m-icon m-validation-message__error__icon">
         <title>Error</title>
         <use aria-hidden="true"></use>
       </svg> <span class="m-validation-message__text">error</span></p>
@@ -14,7 +14,7 @@ exports[`MValidationMessage should render correctly when it is in error 1`] = `
 exports[`MValidationMessage should render correctly when it is in error 2`] = `
 <div class="m-validation-message">
   <div class="m-validation-message__wrap">
-    <p class="m-validation-message__error"><svg width="20px" height="20px" class="m-icon m-validation-message__error__icon">
+    <p class="m-validation-message__error"><svg width="1em" height="1em" class="m-icon m-validation-message__error__icon">
         <title>Error</title>
         <use aria-hidden="true"></use>
       </svg> <span class="m-validation-message__text">error</span></p>
@@ -25,7 +25,7 @@ exports[`MValidationMessage should render correctly when it is in error 2`] = `
 exports[`MValidationMessage should render correctly when it is valid 1`] = `
 <div class="m-validation-message">
   <div class="m-validation-message__wrap">
-    <p class="m-validation-message__valid"><svg width="20px" height="20px" class="m-icon m-validation-message__valid__icon">
+    <p class="m-validation-message__valid"><svg width="1em" height="1em" class="m-icon m-validation-message__valid__icon">
         <title>Valid</title>
         <use aria-hidden="true"></use>
       </svg> <span class="m-validation-message__text">valid</span></p>
@@ -36,7 +36,7 @@ exports[`MValidationMessage should render correctly when it is valid 1`] = `
 exports[`MValidationMessage should render error message even if there is a valid message 1`] = `
 <div class="m-validation-message">
   <div class="m-validation-message__wrap">
-    <p class="m-validation-message__error"><svg width="20px" height="20px" class="m-icon m-validation-message__error__icon">
+    <p class="m-validation-message__error"><svg width="1em" height="1em" class="m-icon m-validation-message__error__icon">
         <title>Error</title>
         <use aria-hidden="true"></use>
       </svg> <span class="m-validation-message__text">error</span></p>

--- a/src/components/validation-message/validation-message.html
+++ b/src/components/validation-message/validation-message.html
@@ -5,18 +5,20 @@
              @click="onClick">
             <p class="m-validation-message__error"
                v-if="hasErrorMessage && hasError">
-                <m-icon name="m-svg__error"
+                <m-icon class="m-validation-message__error__icon"
+                        name="m-svg__error"
                         :svg-title="titleErrorIcon"
-                        class="m-validation-message__error__icon">
+                        size="1em">
                 </m-icon>
                 <span class="m-validation-message__text"
                       v-html="errorMessage"></span>
             </p>
             <p class="m-validation-message__valid"
                v-if="hasValidMessage && isValid">
-                <m-icon name="m-svg__confirmation"
+                <m-icon class="m-validation-message__valid__icon"
+                        name="m-svg__confirmation"
                         :svg-title="titleValidIcon"
-                        class="m-validation-message__valid__icon"></m-icon>
+                        size="1em"></m-icon>
                 <span class="m-validation-message__text"
                       v-html="validMessage"></span>
             </p>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

- [x] Provide a small description of the changes introduced by this PR
Suite aux modifications de ce billet MODUL-812, certaine icones s'affichent avec la mauvaise taille.
Pour tester les modification aller voir les sandbox des composants suivant:
- m-message
- m-validation-message
- m-toast
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-851