### PR TITLE
MODUL-857 - Remettre la propriété touched au formulaire 

### DIFF
--- a/src/components/form/form-field.spec.ts
+++ b/src/components/form/form-field.spec.ts
@@ -87,14 +87,20 @@ describe('form-field', () => {
         it(`it should init and end edition on focus and blur`, () => {
             const spy1: jest.SpyInstance = jest.spyOn(mockFormField, 'initEdition');
             const spy2: jest.SpyInstance = jest.spyOn(mockFormField, 'endEdition');
-            const spy3: jest.SpyInstance = jest.spyOn(mockFormField, 'touch');
 
             wrapper.find({ ref: 'field' }).element.focus();
             wrapper.find({ ref: 'field' }).element.blur();
 
             expect(spy1).toHaveBeenCalled();
             expect(spy2).toHaveBeenCalled();
-            expect(spy3).toHaveBeenCalled();
+        });
+
+        it(`it should touch the field on blur`, () => {
+            const spy: jest.SpyInstance = jest.spyOn(mockFormField, 'touch');
+
+            wrapper.find({ ref: 'field' }).element.blur();
+
+            expect(spy).toHaveBeenCalled();
         });
     });
 });

--- a/src/components/form/form-field.spec.ts
+++ b/src/components/form/form-field.spec.ts
@@ -87,12 +87,14 @@ describe('form-field', () => {
         it(`it should init and end edition on focus and blur`, () => {
             const spy1: jest.SpyInstance = jest.spyOn(mockFormField, 'initEdition');
             const spy2: jest.SpyInstance = jest.spyOn(mockFormField, 'endEdition');
+            const spy3: jest.SpyInstance = jest.spyOn(mockFormField, 'touch');
 
             wrapper.find({ ref: 'field' }).element.focus();
             wrapper.find({ ref: 'field' }).element.blur();
 
             expect(spy1).toHaveBeenCalled();
             expect(spy2).toHaveBeenCalled();
+            expect(spy3).toHaveBeenCalled();
         });
     });
 });

--- a/src/components/form/form-field.ts
+++ b/src/components/form/form-field.ts
@@ -16,7 +16,10 @@ export const FormFieldDirective: DirectiveOptions = {
         Object.defineProperty(el, 'formFieldDirectiveListeners', {
             value: {
                 focusListener: () => formField.initEdition(),
-                blurListener: () => formField.endEdition()
+                blurListener: () => {
+                    formField.endEdition();
+                    formField.touch();
+                }
             }
         });
 

--- a/src/utils/form/form-field/form-field.ts
+++ b/src/utils/form/form-field/form-field.ts
@@ -35,6 +35,7 @@ export class FormField<T> {
     private editionContext: FormFieldEditionContext = FormFieldEditionContext.None;
     private shouldFocusInternal: boolean = false;
     private externalError: string = '';
+    private touched: boolean = false;
 
     /**
      *
@@ -130,6 +131,10 @@ export class FormField<T> {
         return this.internalState.errorMessagesSummary;
     }
 
+    get isTouched(): boolean {
+        return this.touched;
+    }
+
     /**
      * execute validations
      */
@@ -164,6 +169,7 @@ export class FormField<T> {
         this.oldValue = this.internalValue;
         this.internalState = new FormFieldState();
         this.externalError = '';
+        this.touched = false;
         this.editionContext = FormFieldEditionContext.None;
     }
 
@@ -180,6 +186,10 @@ export class FormField<T> {
     endEdition(): void {
         this.editionContext = FormFieldEditionContext.None;
         this.validate();
+    }
+
+    touch(): void {
+        this.touched = true;
     }
 
     /**


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
<!-- Description here... -->
C'est finalement utile dans certain cas. Comme par exemple les validation de cohérence entre les champs. On peut vouloir valider un champs seulement lorsqu'un autre est touché.
- [x] Include links to issues
<!-- Links here... -->
https://jira.dti.ulaval.ca/browse/MODUL-857
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
