### PR TITLE
Storybook to replace sandbox when running npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please refer to [this repository](https://github.com/ulaval/modul-typescript-tem
 
 ## Contributing
 
-### Deploy sandboxes
+### Deploy storybook
 
 1. Clone this project and install using npm install
 2. Run npm run install
@@ -34,7 +34,8 @@ Please refer to [this repository](https://github.com/ulaval/modul-typescript-tem
 
 ### Deployment for local usage in your project
 
-1. Run npm pack
-2. Add the dependency in your package.json ("@ulaval/modul-components": "file://&lt;path-to&gt;\\ulaval-modul-components-&lt;version&gt;.tgz")
+1. Run npm pack in the modUL project folder
+2. In you project Add the dependency in your package.json ("@ulaval/modul-components": "file://&lt;path-to&gt;\\ulaval-modul-components-&lt;version&gt;.tgz")
+3. Then update the modUL package using npm install @ulaval/modul-components
 
 > The `npm pack` command produces multiple .js files along with their definition files (.d.ts), html templates, scss files, etc.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "clean": "rimraf dist",
         "reset": "rmdir /S /Q node_modules",
-        "dev": "rimraf dist/**/* && webpack-dev-server --progress --config conf/webpack.config.js  --colors --port 8082 --open --history-api-fallback",
+        "dev": "start-storybook --config-dir ./conf/storybook --port 8082",
         "buildWebpack": "webpack --config conf/webpack.config.js --env.lib --colors",
         "build": "tsc --project tsconfig.lib.json && copyfiles -u 1 \"./src/**/*.json\" dist && copyfiles -u 1 \"./src/**/*.html\" dist && copyfiles -u 1 \"./src/**/*.scss\" dist && copyfiles -u 1 \"./src/**/*.css\" dist && npm run assetsToDist && npm run metagenv2",
         "buildlib": "webpack --config conf/webpack.config.js --colors --env.lib",
@@ -25,7 +25,7 @@
         "stats": "webpack --config conf/webpack.config.js --env.lib --env.silent --colors --profile --json > reports/stats.json && webpack-bundle-analyzer reports/stats.json",
         "print_version_win": "echo %npm_package_version%",
         "print_version_nx": "echo $npm_package_version",
-        "storybook": "start-storybook --config-dir ./conf/storybook",
+        "sandboxes": "rimraf dist/**/* && webpack-dev-server --progress --config conf/webpack.config.js  --colors --port 8082 --open --history-api-fallback",
         "storybook:openshift": "start-storybook --ci --port 8080 --config-dir ./conf/storybook",
         "storybook:unit": "jest --config ./conf/storybook/jest.config.storybook.js --verbose",
         "storybook:unit:update": "jest --config ./conf/storybook/jest.config.storybook.js --verbose --updateSnapshot"


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR

storybook will now replace snadboxes when running with npm run dev. Readme was updated

- [ ] Include links to issues
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
