### PR TITLE
MODUL-898 - Add min-width: 100% on m-dialog_hint–body

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -133,6 +133,7 @@ $m-dialog--max-width--l: 500px !default;
                 position: relative;
 
                 &--body {
+                    min-width: 100%;
                     border: 1px solid $m-color--hint;
                     padding: 10px $m-spacing--s;
                     text-align: left;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Add min-width: 100%; on the m-dialog_hint-body CSS Class so in order to correct a visual problem when the text contained in the element m-dialog_hint-text is not long enough.
- [ ] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-898
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
