### PR TITLE
fix can't access length of undefined error on textfield

### DIFF
--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -153,7 +153,7 @@ export class MTextfield extends ModulVue implements InputManagementData {
     }
 
     public get valueLength(): number {
-        return this.internalValue.length;
+        return (this.internalValue || '').length;
     }
 
     private get maxLengthNumber(): number {


### PR DESCRIPTION
on textfield reinitialization

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Fix error occuring when reinitializing textfield value to undefined
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-901
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
