### PR TITLE
MODUL-904:  Retirer les validateurs de la prop autocomplete du input-management

### DIFF
--- a/src/components/textfield/textfield.html
+++ b/src/components/textfield/textfield.html
@@ -22,42 +22,42 @@
                    :required-marker="requiredMarker"
                    :tag-style="tagStyle">
         <input v-if="!hasWordWrap"
-               v-model="model"
                :id="id"
                class="m-textfield__input"
-               ref="input"
+               v-model="model"
                :autocomplete="autocomplete"
                :disabled="isDisabled || isWaiting"
                :placeholder="placeholder"
                :readonly="isReadonly"
                :maxlength="maxLengthNumber"
                :type="inputType"
-               @focus="onFocus"
                @blur="onBlur"
+               @change="onChange"
+               @focus="onFocus"
                @keyup="onKeyup"
                @keydown="onKeydown"
                @keydown.enter="onEnter"
-               @change="onChange"
-               @paste="onPaste" />
-        <template slot="right-content"
-                  v-if="!hasWordWrap">
+               @paste="onPaste"
+               ref="input" />
+        <template v-if="!hasWordWrap"
+                  slot="right-content">
             <transition-group name="m--is">
                 <m-icon-button v-if="passwordIcon && hasValue"
                                class="m-textfield__icon-password"
-                               key="passwordIcon"
-                               button-size="22px"
                                :aria-controls="id"
                                :title="passwordIconDescription"
-                               @click="togglePasswordVisibility"
-                               :icon-name="passwordIconName"></m-icon-button>
+                               :icon-name="passwordIconName"
+                               key="passwordIcon"
+                               button-size="22px"
+                               @click="togglePasswordVisibility"></m-icon-button>
                 <m-icon-button v-if="isTypeSearch && hasValue"
                                class="m-textfield__reset"
                                key="resetIcon"
                                button-size="1em"
-                               icon-size="11px"
                                :aria-controls="id"
-                               @click="reset"
-                               icon-name="m-svg__close-clear"></m-icon-button>
+                               icon-size="11px"
+                               icon-name="m-svg__close-clear"
+                               @click="reset"></m-icon-button>
                 <m-icon-button v-if="isTypeSearch && searchIcon"
                                class="m-textfield__search-icon"
                                key="searchIcon"
@@ -70,10 +70,10 @@
             </transition-group>
         </template>
         <textarea v-if="hasWordWrap"
-                  v-model="model"
                   :id="id"
                   class="m-textfield__input"
-                  ref="input"
+                  v-model="model"
+                  :autocomplete="autocomplete"
                   :disabled="isDisabled || isWaiting"
                   :placeholder="placeholder"
                   :readonly="isReadonly"
@@ -85,8 +85,8 @@
                   @keyup="onKeyup"
                   @keydown="onKeydown"
                   @paste="onPaste"
-                  :autocomplete="autocomplete"
-                  v-m-textarea-auto-height>
+                  v-m-textarea-auto-height
+                  ref="input">
         </textarea>
     </m-input-style>
     <div class="m-textfield__validation">

--- a/src/components/textfield/textfield.html
+++ b/src/components/textfield/textfield.html
@@ -21,10 +21,11 @@
                    :readonly="isReadonly"
                    :required-marker="requiredMarker"
                    :tag-style="tagStyle">
-        <input class="m-textfield__input"
-               v-if="!hasWordWrap"
+        <input v-if="!hasWordWrap"
                v-model="model"
                :id="id"
+               class="m-textfield__input"
+               ref="input"
                :autocomplete="autocomplete"
                :disabled="isDisabled || isWaiting"
                :placeholder="placeholder"
@@ -41,36 +42,38 @@
         <template slot="right-content"
                   v-if="!hasWordWrap">
             <transition-group name="m--is">
-                <m-icon-button class="m-textfield__icon-password"
+                <m-icon-button v-if="passwordIcon && hasValue"
+                               class="m-textfield__icon-password"
                                key="passwordIcon"
                                button-size="22px"
                                :aria-controls="id"
                                :title="passwordIconDescription"
                                @click="togglePasswordVisibility"
-                               :icon-name="passwordIconName"
-                               v-if="passwordIcon && hasValue"></m-icon-button>
-                <m-icon-button class="m-textfield__reset"
+                               :icon-name="passwordIconName"></m-icon-button>
+                <m-icon-button v-if="isTypeSearch && hasValue"
+                               class="m-textfield__reset"
                                key="resetIcon"
                                button-size="1em"
                                icon-size="11px"
                                :aria-controls="id"
                                @click="reset"
-                               icon-name="m-svg__close-clear"
-                               v-if="isTypeSearch && hasValue"></m-icon-button>
-                <m-icon-button class="m-textfield__search-icon"
+                               icon-name="m-svg__close-clear"></m-icon-button>
+                <m-icon-button v-if="isTypeSearch && searchIcon"
+                               class="m-textfield__search-icon"
                                key="searchIcon"
                                button-size="22px"
                                :aria-controls="id"
                                :title="searchIconDescription"
                                :disabled="!hasValue"
                                icon-name="m-svg__search"
-                               @click="search"
-                               v-if="isTypeSearch && searchIcon"></m-icon-button>
+                               @click="search"></m-icon-button>
             </transition-group>
         </template>
-        <textarea ref="input"
+        <textarea v-if="hasWordWrap"
+                  v-model="model"
                   :id="id"
                   class="m-textfield__input"
+                  ref="input"
                   :disabled="isDisabled || isWaiting"
                   :placeholder="placeholder"
                   :readonly="isReadonly"
@@ -83,9 +86,7 @@
                   @keydown="onKeydown"
                   @paste="onPaste"
                   :autocomplete="autocomplete"
-                  v-model="model"
-                  v-m-textarea-auto-height
-                  v-if="hasWordWrap">
+                  v-m-textarea-auto-height>
         </textarea>
     </m-input-style>
     <div class="m-textfield__validation">
@@ -97,8 +98,8 @@
                               :valid="isTextfieldValid"
                               :valid-message="validMessage"
                               :helper-message="helperMessage"></m-validation-message>
-        <m-character-count class="m-textfield__validation__character-count"
-                           v-if="characterCount"
+        <m-character-count v-if="characterCount"
+                           class="m-textfield__validation__character-count"
                            :value-length="valueLength"
                            :max-length="maxLength"
                            :threshold="characterCountThreshold"

--- a/src/mixins/input-management/input-management.ts
+++ b/src/mixins/input-management/input-management.ts
@@ -19,10 +19,6 @@ export interface InputManagementFocusable {
     focusInput(): void;
 }
 
-export enum InputManagementAutocomplete {
-    Off = 'off',
-    On = 'on'
-}
 @Component
 export class InputManagement extends ModulVue
     implements InputManagementProps, InputManagementData, InputManagementFocusable {
@@ -34,13 +30,7 @@ export class InputManagement extends ModulVue
     public placeholder: string;
     @Prop()
     public readonly: boolean;
-    @Prop({
-        default: undefined,
-        validator: value =>
-            value === InputManagementAutocomplete.Off ||
-            value === InputManagementAutocomplete.On ||
-            value === undefined
-    })
+    @Prop()
     public autocomplete: string;
     @Prop()
     public focus: boolean;


### PR DESCRIPTION
…nagement

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Retirer les validateurs de la prop autocomplete du input-management, car l'attribut HTML autocomplete accepte beaucoup plus de valeurs que celles du validateur actuel.

Exemple de valeurs acceptées dans l'autocomplete: https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#recommended_input_name_and_autocomplete_attribute_values

-[x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-904

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
L'enum InputManagementAutocomplete a été supprimé.

