### PR TITLE
MODUL-916 - Separated toast service plugin from toast service:

### DIFF
--- a/src/components/form/form.plugin.ts
+++ b/src/components/form/form.plugin.ts
@@ -2,7 +2,7 @@ import { PluginObject } from 'vue';
 import { FORM_FIELD_NAME } from '../../directives/directive-names';
 import { FormClearToastBehavior, FormErrorFocusBehavior, FormErrorToastBehavior, MFormListener, MFormService } from '../../utils/form/form-service/form-service';
 import ScrollToPlugin from '../../utils/scroll-to/scroll-to';
-import ToastServicePlugin from '../../utils/toast/toast-service';
+import ToastServicePlugin from '../../utils/toast/toast-service.plugin';
 import { FORM } from '../component-names';
 import I18nPlugin from '../i18n/i18n';
 import MessagePlugin from '../message/message';

--- a/src/utils/toast/toast-service.plugin.ts
+++ b/src/utils/toast/toast-service.plugin.ts
@@ -10,7 +10,7 @@ declare module 'vue/types/vue' {
 const ToastServicePlugin: PluginObject<any> = {
     install(v): void {
         let toast: ToastService = new ToastService();
-        (v.prototype).$toast = toast;
+        v.prototype.$toast = toast;
     }
 };
 

--- a/src/utils/toast/toast-service.plugin.ts
+++ b/src/utils/toast/toast-service.plugin.ts
@@ -1,0 +1,17 @@
+import { PluginObject } from 'vue';
+import ToastService from './toast-service';
+
+declare module 'vue/types/vue' {
+    interface Vue {
+        $toast: ToastService;
+    }
+}
+
+const ToastServicePlugin: PluginObject<any> = {
+    install(v): void {
+        let toast: ToastService = new ToastService();
+        (v.prototype).$toast = toast;
+    }
+};
+
+export default ToastServicePlugin;

--- a/src/utils/toast/toast-service.sandbox.ts
+++ b/src/utils/toast/toast-service.sandbox.ts
@@ -2,9 +2,9 @@
 import { Component } from 'vue-property-decorator';
 import { PluginObject } from 'vue/types/plugin';
 import { MToastPosition, MToastState, MToastTimeout } from '../../components/toast/toast';
-import { TOAST } from '../utils-names';
 import { ModulVue } from '../vue/vue';
-import ToastServicePlugin, { ToastParams } from './toast-service';
+import { ToastParams } from './toast-service';
+import ToastServicePlugin from './toast-service.plugin';
 import WithRender from './toast-service.sandbox.html';
 
 @WithRender

--- a/src/utils/toast/toast-service.spec.ts
+++ b/src/utils/toast/toast-service.spec.ts
@@ -1,5 +1,5 @@
 import { MToast } from '../../components/toast/toast';
-import { ToastParams, ToastService } from './toast-service';
+import ToastService, { ToastParams } from './toast-service';
 
 let mockToast: any = {};
 jest.mock('../../components/toast/toast', () => {

--- a/src/utils/toast/toast-service.ts
+++ b/src/utils/toast/toast-service.ts
@@ -1,13 +1,5 @@
 import Vue from 'vue';
-import { PluginObject } from 'vue/types/plugin';
 import { MToast, MToastPosition, MToastState, MToastTimeout } from '../../components/toast/toast';
-
-
-declare module 'vue/types/vue' {
-    interface Vue {
-        $toast: ToastService;
-    }
-}
 
 export interface ToastParams {
     text: string; // Can be html, but must start with a root tag: <p> text of toast </p>
@@ -21,7 +13,7 @@ export interface ToastParams {
 
 const TIME_BEFORE_ANIMATION_IS_OVER: number = 300;
 
-export class ToastService {
+export default class ToastService {
     public activeToast?: MToast;
     public toasts: MToast[] = [];
     public baseTopPosition: string = '0';
@@ -81,12 +73,3 @@ export class ToastService {
         return toast;
     }
 }
-
-const ToastServicePlugin: PluginObject<any> = {
-    install(v): void {
-        let toast: ToastService = new ToastService();
-        (v.prototype).$toast = toast;
-    }
-};
-
-export default ToastServicePlugin;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Pour permettre plus de flexibilité aux projets utilisant modUL, la déclaration du plugin de service de toast a été séparée du service de toast

### Breaking change
The file required to register the toast plugin has changed. Instead of importing `@ulaval/modul-components/dist/utils/toast/toast-service` the file `@ulaval/modul-components/dist/utils/toast/toast-service.plugin` must be imported instead

The name of the plugin remains unchanged  `ToastServicePlugin`.

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-916

- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
