### PR TITLE
MODUL-925 - Prevent adding images into RTE without using m-file-upload

### DIFF
--- a/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -250,6 +250,7 @@ export enum FroalaStatus {
     }
 
     protected filesAdded(files: MFile[]): void {
+        this.froalaEditor.opts.modulImageUploaded = true;
         this.$emit('image-added', files[0], (file: MFile, id: string) => {
             if (this.selectedImage) {
                 this.froalaEditor.image.insert(file.url, false, { id }, $(this.selectedImage));
@@ -412,7 +413,7 @@ export enum FroalaStatus {
                 [froalaEvents.PasteAfterCleanup]: (_e, _editor, data: string) => {
                     if (data.replace) {
                         data = replaceTags(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div'], 'p', data);
-                        return _editor.clean.html(data, ['table', 'video', 'u', 's', 'blockquote', 'button', 'input']);
+                        return _editor.clean.html(data, ['table', 'video', 'u', 's', 'blockquote', 'button', 'input', 'img']);
                     }
                 },
                 [froalaEvents.CommandBefore]: (_e, _editor, cmd) => {
@@ -441,8 +442,16 @@ export enum FroalaStatus {
                     this.updateModel();
                 },
                 [froalaEvents.ImageInserted]: (_e, _editor, img) => {
-                    img[0].alt = '';
-                    this.updateModel();
+                    if (_editor.opts.modulImageUploaded) {
+                        img[0].alt = '';
+                        this.updateModel();
+                    } else {
+                        setTimeout(() => {
+                            _editor.image.remove(img);
+                        });
+                    }
+
+                    _editor.opts.modulImageUploaded = false;
                 }
             }
         });

--- a/src/components/rich-text-editor/rich-text-editor.sandbox.html
+++ b/src/components/rich-text-editor/rich-text-editor.sandbox.html
@@ -68,7 +68,7 @@
     </div>
     <div class="m-u--margin-bottom">
         <m-rich-text-editor v-model="mediaModel2"
-                            :mode="mode"
+                            :options="options"
                             label="rich text"
                             max-width="large"
                             @image-ready="imageReady"


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Pasting image into RTE is no longer possible. This is to enforce use of m-file-upload for adding images.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-925
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
