### PR TITLE
MODUL-934 - Add recount for timeout in toaster when mouse leave

### DIFF
--- a/src/components/toast/toast.spec.ts
+++ b/src/components/toast/toast.spec.ts
@@ -176,14 +176,14 @@ describe(`MToast`, () => {
                     expect(((wrapper.vm as any) as Portal).portalMounted).toBe(true);
                     expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), MToastDuration.DesktopShort);
 
-                    let customWatingTime: number = 500;
-                    global.Date.now = jest.fn(() => now + customWatingTime); // Fast-forward dates in 500ms
+                    let customWaitingTime: number = 500;
+                    global.Date.now = jest.fn(() => now + customWaitingTime); // Fast-forward dates in 500ms
 
                     wrapper.vm.mouseEnterToast();
                     expect(((wrapper.vm as any) as PortalMixin).propOpen).toBe(true);
 
                     wrapper.vm.mouseLeaveToast();
-                    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), MToastDuration.DesktopShort - customWatingTime);
+                    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), MToastDuration.DesktopShort - customWaitingTime);
 
                     await jest.runOnlyPendingTimers(); // wait for the timeout to be over
                     expect(((wrapper.vm as any) as PortalMixin).propOpen).toBeFalsy();

--- a/src/components/toast/toast.spec.ts
+++ b/src/components/toast/toast.spec.ts
@@ -163,6 +163,9 @@ describe(`MToast`, () => {
 
             describe(`Then the mouse is over and leave the toast`, () => {
                 it(`Should appear and then not disappear`, async () => {
+                    const now: number = Date.now();
+                    global.Date.now = jest.fn(() => now);
+
                     initializeWrapper();
                     wrapper.setProps({
                         timeout: 'short'
@@ -171,12 +174,17 @@ describe(`MToast`, () => {
                     expect(((wrapper.vm as any) as PortalMixin).propOpen).toBe(true);
                     expect(((wrapper.vm as any) as Portal).portalCreated).toBe(true);
                     expect(((wrapper.vm as any) as Portal).portalMounted).toBe(true);
+                    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), MToastDuration.DesktopShort);
+
+                    let customWatingTime: number = 500;
+                    global.Date.now = jest.fn(() => now + customWatingTime); // Fast-forward dates in 500ms
 
                     wrapper.vm.mouseEnterToast();
-                    await jest.runOnlyPendingTimers(); // wait for the timeout to be over
                     expect(((wrapper.vm as any) as PortalMixin).propOpen).toBe(true);
 
                     wrapper.vm.mouseLeaveToast();
+                    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), MToastDuration.DesktopShort - customWatingTime);
+
                     await jest.runOnlyPendingTimers(); // wait for the timeout to be over
                     expect(((wrapper.vm as any) as PortalMixin).propOpen).toBeFalsy();
                 });

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -101,6 +101,8 @@ export class MToast extends ModulVue implements PortalMixinImpl {
 
     private buttonMode: MLinkMode = MLinkMode.Button;
     private timerCloseToast: any;
+    private internalTimeout: number;
+    private instantTimeoutStart: number;
 
     public doCustomPropOpen(value: boolean, el: HTMLElement): boolean {
         el.style.position = 'absolute';
@@ -109,19 +111,20 @@ export class MToast extends ModulVue implements PortalMixinImpl {
                 this.getPortalElement().style.transform = `translateY(${this.offset})`;
             }
 
+            this.internalTimeout = this.convertTimeout(this.timeout);
             this.startCloseToast();
         }
         return true;
     }
 
     private startCloseToast(): void {
-        let internalTimeout: number = this.convertTimeout(this.timeout);
+        this.instantTimeoutStart = Date.now();
 
-        if (internalTimeout > 0) {
+        if (this.internalTimeout > 0) {
             this.timerCloseToast
                 = setTimeout(() => {
                     this.onClose();
-                }, internalTimeout);
+                }, this.internalTimeout);
         }
     }
 
@@ -227,9 +230,16 @@ export class MToast extends ModulVue implements PortalMixinImpl {
     }
 
     public mouseEnterToast(): void {
-        if (!this.isMobile) {
+        if (!this.isMobile && this.timerCloseToast !== undefined) {
+            this.recountInternalTimeout();
             clearTimeout(this.timerCloseToast);
+            this.timerCloseToast = undefined;
         }
+    }
+
+    private recountInternalTimeout(): void {
+        let instantTimeoutStop: number = Date.now();
+        this.internalTimeout -= (instantTimeoutStop - this.instantTimeoutStart);
     }
 
     public mouseLeaveToast(): void {

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -231,13 +231,13 @@ export class MToast extends ModulVue implements PortalMixinImpl {
 
     public mouseEnterToast(): void {
         if (!this.isMobile && this.timerCloseToast !== undefined) {
-            this.recountInternalTimeout();
+            this.restoreTimeout();
             clearTimeout(this.timerCloseToast);
             this.timerCloseToast = undefined;
         }
     }
 
-    private recountInternalTimeout(): void {
+    private restoreTimeout(): void {
         let instantTimeoutStop: number = Date.now();
         this.internalTimeout -= (instantTimeoutStop - this.instantTimeoutStart);
     }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Ainsi que le curseur « sort de la boite », le décompte du Toast doit être reprend.
- [x] https://jira.dti.ulaval.ca/browse/MODUL-934

<!-- END_REQUIRED -->
<!-- Thanks for contributing! -->
