### PR TITLE
MODUL-975: Ajuster le visuel de l'entête des tableaux en mode sortable

### DIFF
--- a/src/components/table/__snapshots__/table.spec.ts.snap
+++ b/src/components/table/__snapshots__/table.spec.ts.snap
@@ -4,8 +4,10 @@ exports[`MTable Given a table full of data When using a footer Then should rende
 <table cellspacing="0" class="m-table m--is-skin-regular">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable m--is-sorted" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable m--is-sorted" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button icon-name="m-svg__arrow-thin--down" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>
@@ -32,8 +34,10 @@ exports[`MTable Given a table full of data When using slot to replace a td Then 
 <table cellspacing="0" class="m-table m--is-skin-regular">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable m--is-sorted" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable m--is-sorted" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button icon-name="m-svg__arrow-thin--down" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>
@@ -96,8 +100,10 @@ exports[`MTable Given a table full of data When using slot to replace the tbody 
 <table cellspacing="0" class="m-table m--is-skin-regular">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable m--is-sorted" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable m--is-sorted" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button icon-name="m-svg__arrow-thin--down" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>
@@ -114,8 +120,10 @@ exports[`MTable Given a table full of data When we don't use slots Then should r
 <table cellspacing="0" class="m-table m--is-skin-regular">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>
@@ -137,8 +145,10 @@ exports[`MTable Given an empty table When a custom slot is given Then should ren
 <table cellspacing="0" class="m-table m--is-skin-regular">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>
@@ -155,8 +165,10 @@ exports[`MTable Given an empty table When loading Then should render correctly 1
 <table cellspacing="0" class="m-table m--is-skin-regular m--is-loading">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button disabled="disabled" icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button disabled="disabled" icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>
@@ -181,8 +193,10 @@ exports[`MTable Given an empty table When we use the default template Then shoul
 <table cellspacing="0" class="m-table m--is-skin-regular">
   <thead>
     <tr>
-      <th scope="col" class="m--is-sortable" style="width:10%;"><span class="m-table__header-name">A</span>
-        <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+      <th scope="col" class="m--is-sortable" style="width:10%;">
+        <div class="m-table__header-wrap"><span class="m-table__header-name">A</span>
+          <m-icon-button icon-name="m-svg__arrow-thin--up" skin="bold" button-size="12px" class="m-table__sortable-icon"></m-icon-button>
+        </div>
       </th>
       <th scope="col"><span class="m-table__header-name">B</span></th>
     </tr>

--- a/src/components/table/__snapshots__/table.stories.ts.snap
+++ b/src/components/table/__snapshots__/table.stories.ts.snap
@@ -1251,97 +1251,109 @@ exports[`Storyshots components|m-table Sortable 1`] = `
         class="m--is-sortable"
         scope="col"
       >
-        <span
-          class="m-table__header-name"
+        <div
+          class="m-table__header-wrap"
         >
-          Name
-        </span>
-         
-        <button
-          class="m-icon-button m-table__sortable-icon m--is-skin-bold m--has-ripple"
-          style="width: 12px; height: 12px;"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="m-icon m-icon-button__icon"
-            height="20px"
-            width="20px"
+          <span
+            class="m-table__header-name"
           >
-            <!---->
-             
-            <use
-              aria-hidden="true"
-              class=""
-            />
-          </svg>
+            Name
+          </span>
            
-          <!---->
-        </button>
+          <button
+            class="m-icon-button m-table__sortable-icon m--is-skin-bold m--has-ripple"
+            style="width: 12px; height: 12px;"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="m-icon m-icon-button__icon"
+              height="20px"
+              width="20px"
+            >
+              <!---->
+               
+              <use
+                aria-hidden="true"
+                class=""
+              />
+            </svg>
+             
+            <!---->
+          </button>
+        </div>
       </th>
       <th
         class="m--is-sortable"
         scope="col"
       >
-        <span
-          class="m-table__header-name"
+        <div
+          class="m-table__header-wrap"
         >
-          Age
-        </span>
-         
-        <button
-          class="m-icon-button m-table__sortable-icon m--is-skin-bold m--has-ripple"
-          style="width: 12px; height: 12px;"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="m-icon m-icon-button__icon"
-            height="20px"
-            width="20px"
+          <span
+            class="m-table__header-name"
           >
-            <!---->
-             
-            <use
-              aria-hidden="true"
-              class=""
-            />
-          </svg>
+            Age
+          </span>
            
-          <!---->
-        </button>
+          <button
+            class="m-icon-button m-table__sortable-icon m--is-skin-bold m--has-ripple"
+            style="width: 12px; height: 12px;"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="m-icon m-icon-button__icon"
+              height="20px"
+              width="20px"
+            >
+              <!---->
+               
+              <use
+                aria-hidden="true"
+                class=""
+              />
+            </svg>
+             
+            <!---->
+          </button>
+        </div>
       </th>
       <th
         class="m--is-sortable"
         scope="col"
       >
-        <span
-          class="m-table__header-name"
+        <div
+          class="m-table__header-wrap"
         >
-          Username
-        </span>
-         
-        <button
-          class="m-icon-button m-table__sortable-icon m--is-skin-bold m--has-ripple"
-          style="width: 12px; height: 12px;"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="m-icon m-icon-button__icon"
-            height="20px"
-            width="20px"
+          <span
+            class="m-table__header-name"
           >
-            <!---->
-             
-            <use
-              aria-hidden="true"
-              class=""
-            />
-          </svg>
+            Username
+          </span>
            
-          <!---->
-        </button>
+          <button
+            class="m-icon-button m-table__sortable-icon m--is-skin-bold m--has-ripple"
+            style="width: 12px; height: 12px;"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="m-icon m-icon-button__icon"
+              height="20px"
+              width="20px"
+            >
+              <!---->
+               
+              <use
+                aria-hidden="true"
+                class=""
+              />
+            </svg>
+             
+            <!---->
+          </button>
+        </div>
       </th>
     </tr>
   </thead>

--- a/src/components/table/table.html
+++ b/src/components/table/table.html
@@ -6,22 +6,23 @@
             <tr>
                 <th v-for="(column, index) in columns"
                     :style="columnWidth(column)"
-                    :class="{ 'm--is-sortable': column.sortable, 'm--is-sorted': isColumnSorted(column), 'm--is-centered': column.centered }"
+                    :class="[{ 'm--is-sortable': column.sortable, 'm--is-sorted': isColumnSorted(column), 'm--is-centered': column.centered }, column.class]"
                     :key="column.id"
+                    @click="sort(column)"
                     scope="col">
                     <slot :name="'header.' + column.dataProp"
                           :column="column">
-                        <template v-if="column.sortable">
-                            <span class="m-table__header-name"
-                                  @click="sort(column)">{{ column.title }}</span>
+                        <div v-if="column.sortable"
+                             class="m-table__header-wrap">
+                            <span class="m-table__header-name">{{ column.title }}</span>
                             <m-icon-button v-if="column.sortable"
                                            class="m-table__sortable-icon"
                                            :disabled="loading"
                                            :icon-name="getIconName(column)"
-                                           @click="sort(column)"
                                            skin="bold"
-                                           button-size="12px"></m-icon-button>
-                        </template>
+                                           button-size="12px"
+                                           @click="sort(column)"></m-icon-button>
+                        </div>
                         <template v-else>
                             <span class="m-table__header-name">{{ column.title }}</span>
                         </template>

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -15,15 +15,7 @@ $m-table--icon-vertical-offset: -5px !default;
             font-weight: $m-font-weight--bold;
 
             &.m--is-sortable {
-                .m-table__header-name {
-                    cursor: pointer;
-                }
-
-                .m-table__sortable-icon {
-                    position: relative;
-                    top: $m-table--icon-vertical-offset;
-                    opacity: 0;
-                }
+                cursor: pointer;
 
                 &:hover {
                     color: $m-color--grey-darker;
@@ -31,6 +23,7 @@ $m-table--icon-vertical-offset: -5px !default;
                     .m-table__sortable-icon {
                         color: $m-color--grey;
                         opacity: 0.6;
+                        transform: translate3d(0, 0, 0);
                     }
                 }
 
@@ -40,6 +33,7 @@ $m-table--icon-vertical-offset: -5px !default;
                     .m-table__sortable-icon {
                         color: $m-color--grey-darker;
                         opacity: 1;
+                        transform: translate3d(0, 0, 0);
                     }
                 }
             }
@@ -88,6 +82,20 @@ $m-table--icon-vertical-offset: -5px !default;
                 text-align: center;
             }
         }
+    }
+
+    &__header-wrap {
+        display: flex;
+        align-items: center;
+    }
+
+    .m-table__sortable-icon {
+        transition: transform $m-transition-duration ease, opacity $m-transition-duration ease;
+        position: relative;
+        top: $m-table--icon-vertical-offset;
+        opacity: 0;
+        margin-left: $m-spacing--xs;
+        transform: translate3d(0, 4px, 0);
     }
 
     &__loading td {

--- a/src/components/table/table.ts
+++ b/src/components/table/table.ts
@@ -24,6 +24,7 @@ export interface MColumnTable {
     width?: string;
     sortable?: boolean;
     centered?: boolean;
+    class?: string;
     sortDirection?: MColumnSortDirection;
 }
 
@@ -63,7 +64,7 @@ export class MTable extends ModulVue {
     }
 
     public sort(columnTable: MColumnTable): void {
-        if (this.loading) {
+        if (this.loading || !columnTable.sortable) {
             return;
         }
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Les flèches dans l'entête, qui servent à trier le contenu du tableau, se positionnent à la mauvaise place lorsqu'un titre est long.
Voir la capture d'écran du billet [MODUL-975](https://jira.dti.ulaval.ca/browse/MODUL-975)
- Ajout de la propriété `class` à MCloumnTable permettant d'ajouter une classe sur la balise `<th>`
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-975
<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
Le visuel de la flèche de trie de l'entête de tableau a été modifié.

