### PR TITLE
MODUL-980 - Amélioration de l'entête du m-accordion-group

### DIFF
--- a/src/components/accordion-group/__snapshots__/accordion-group.stories.ts.snap
+++ b/src/components/accordion-group/__snapshots__/accordion-group.stories.ts.snap
@@ -389,152 +389,6 @@ exports[`Storyshots components|m-accordion-group header 1`] = `
 </article>
 `;
 
-exports[`Storyshots components|m-accordion-group reverse-header 1`] = `
-<article
-  class="m-accordion-group"
->
-  <div
-    class="m-accordion-group__header m--is-reserve-header"
-  >
-    <div
-      class="m-accordion-group__header-title"
-    >
-      <h2>
-        An Accordion Group Title
-      </h2>
-    </div>
-     
-    <div
-      class="m-accordion-group__secondary-content"
-    >
-       
-      <div
-        class="m-accordion-group__toggle-link"
-      >
-        <!---->
-         
-        <!---->
-         
-        <!---->
-      </div>
-    </div>
-  </div>
-   
-  <div
-    class="m-accordion-group__body"
-  >
-     
-    <article
-      class="m-accordion m--is-default m--is-closed m--has-icon-left m--has-icon-large"
-    >
-      <div
-        aria-controls="uuid-controls"
-        class="m-accordion__header m--has-padding"
-        id="uuid"
-        role="tab"
-        tabindex="0"
-      >
-        <div
-          class="m-accordion__header__content"
-        >
-          <h3>
-            An Accordion Title
-          </h3>
-           
-          <span
-            class="m-i18n m-accordion__hidden"
-          >
-            Cliquer pour afficher le contenu
-          </span>
-           
-          <!---->
-        </div>
-         
-        <span
-          aria-hidden="true"
-          class="m-plus m-accordion__header-icon m--is-skin-default m--is-large m--is-left"
-          title="Cliquer pour afficher le contenu"
-        />
-      </div>
-       
-      <!---->
-    </article>
-     
-    <article
-      class="m-accordion m--is-default m--is-closed m--has-icon-left m--has-icon-large"
-    >
-      <div
-        aria-controls="uuid-controls"
-        class="m-accordion__header m--has-padding"
-        id="uuid"
-        role="tab"
-        tabindex="0"
-      >
-        <div
-          class="m-accordion__header__content"
-        >
-          <h3>
-            An Accordion Title
-          </h3>
-           
-          <span
-            class="m-i18n m-accordion__hidden"
-          >
-            Cliquer pour afficher le contenu
-          </span>
-           
-          <!---->
-        </div>
-         
-        <span
-          aria-hidden="true"
-          class="m-plus m-accordion__header-icon m--is-skin-default m--is-large m--is-left"
-          title="Cliquer pour afficher le contenu"
-        />
-      </div>
-       
-      <!---->
-    </article>
-     
-    <article
-      class="m-accordion m--is-default m--is-closed m--has-icon-left m--has-icon-large"
-    >
-      <div
-        aria-controls="uuid-controls"
-        class="m-accordion__header m--has-padding"
-        id="uuid"
-        role="tab"
-        tabindex="0"
-      >
-        <div
-          class="m-accordion__header__content"
-        >
-          <h3>
-            An Accordion Title
-          </h3>
-           
-          <span
-            class="m-i18n m-accordion__hidden"
-          >
-            Cliquer pour afficher le contenu
-          </span>
-           
-          <!---->
-        </div>
-         
-        <span
-          aria-hidden="true"
-          class="m-plus m-accordion__header-icon m--is-skin-default m--is-large m--is-left"
-          title="Cliquer pour afficher le contenu"
-        />
-      </div>
-       
-      <!---->
-    </article>
-  </div>
-</article>
-`;
-
 exports[`Storyshots components|m-accordion-group secondary-content 1`] = `
 <article
   class="m-accordion-group"
@@ -690,6 +544,152 @@ exports[`Storyshots components|m-accordion-group title 1`] = `
 >
   <div
     class="m-accordion-group__header"
+  >
+    <div
+      class="m-accordion-group__header-title"
+    >
+      <h2>
+        An Accordion Group Title
+      </h2>
+    </div>
+     
+    <div
+      class="m-accordion-group__secondary-content"
+    >
+       
+      <div
+        class="m-accordion-group__toggle-link"
+      >
+        <!---->
+         
+        <!---->
+         
+        <!---->
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="m-accordion-group__body"
+  >
+     
+    <article
+      class="m-accordion m--is-default m--is-closed m--has-icon-left m--has-icon-large"
+    >
+      <div
+        aria-controls="uuid-controls"
+        class="m-accordion__header m--has-padding"
+        id="uuid"
+        role="tab"
+        tabindex="0"
+      >
+        <div
+          class="m-accordion__header__content"
+        >
+          <h3>
+            An Accordion Title
+          </h3>
+           
+          <span
+            class="m-i18n m-accordion__hidden"
+          >
+            Cliquer pour afficher le contenu
+          </span>
+           
+          <!---->
+        </div>
+         
+        <span
+          aria-hidden="true"
+          class="m-plus m-accordion__header-icon m--is-skin-default m--is-large m--is-left"
+          title="Cliquer pour afficher le contenu"
+        />
+      </div>
+       
+      <!---->
+    </article>
+     
+    <article
+      class="m-accordion m--is-default m--is-closed m--has-icon-left m--has-icon-large"
+    >
+      <div
+        aria-controls="uuid-controls"
+        class="m-accordion__header m--has-padding"
+        id="uuid"
+        role="tab"
+        tabindex="0"
+      >
+        <div
+          class="m-accordion__header__content"
+        >
+          <h3>
+            An Accordion Title
+          </h3>
+           
+          <span
+            class="m-i18n m-accordion__hidden"
+          >
+            Cliquer pour afficher le contenu
+          </span>
+           
+          <!---->
+        </div>
+         
+        <span
+          aria-hidden="true"
+          class="m-plus m-accordion__header-icon m--is-skin-default m--is-large m--is-left"
+          title="Cliquer pour afficher le contenu"
+        />
+      </div>
+       
+      <!---->
+    </article>
+     
+    <article
+      class="m-accordion m--is-default m--is-closed m--has-icon-left m--has-icon-large"
+    >
+      <div
+        aria-controls="uuid-controls"
+        class="m-accordion__header m--has-padding"
+        id="uuid"
+        role="tab"
+        tabindex="0"
+      >
+        <div
+          class="m-accordion__header__content"
+        >
+          <h3>
+            An Accordion Title
+          </h3>
+           
+          <span
+            class="m-i18n m-accordion__hidden"
+          >
+            Cliquer pour afficher le contenu
+          </span>
+           
+          <!---->
+        </div>
+         
+        <span
+          aria-hidden="true"
+          class="m-plus m-accordion__header-icon m--is-skin-default m--is-large m--is-left"
+          title="Cliquer pour afficher le contenu"
+        />
+      </div>
+       
+      <!---->
+    </article>
+  </div>
+</article>
+`;
+
+exports[`Storyshots components|m-accordion-group toggle-link-left 1`] = `
+<article
+  class="m-accordion-group"
+>
+  <div
+    class="m-accordion-group__header m--is-toggle-link-left"
   >
     <div
       class="m-accordion-group__header-title"
@@ -2271,7 +2271,7 @@ exports[`Storyshots components|m-accordion-group/secondary-content m-link 1`] = 
   class="m-accordion-group"
 >
   <div
-    class="m-accordion-group__header m--has-secondary-content m--is-reserve-header"
+    class="m-accordion-group__header m--has-secondary-content m--is-toggle-link-left"
   >
     <div
       class="m-accordion-group__header-title"
@@ -2582,12 +2582,12 @@ exports[`Storyshots components|m-accordion-group/secondary-content no-title 1`] 
 </article>
 `;
 
-exports[`Storyshots components|m-accordion-group/secondary-content no-title-reverse-header 1`] = `
+exports[`Storyshots components|m-accordion-group/secondary-content no-title-toggle-link-left 1`] = `
 <article
   class="m-accordion-group"
 >
   <div
-    class="m-accordion-group__header m--no-title m--has-secondary-content m--is-reserve-header"
+    class="m-accordion-group__header m--no-title m--has-secondary-content m--is-toggle-link-left"
   >
     <!---->
      
@@ -2725,12 +2725,12 @@ exports[`Storyshots components|m-accordion-group/secondary-content no-title-reve
 </article>
 `;
 
-exports[`Storyshots components|m-accordion-group/secondary-content reverse-header 1`] = `
+exports[`Storyshots components|m-accordion-group/secondary-content toggle-link-left 1`] = `
 <article
   class="m-accordion-group"
 >
   <div
-    class="m-accordion-group__header m--has-secondary-content m--is-reserve-header"
+    class="m-accordion-group__header m--has-secondary-content m--is-toggle-link-left"
   >
     <div
       class="m-accordion-group__header-title"

--- a/src/components/accordion-group/accordion-group.html
+++ b/src/components/accordion-group/accordion-group.html
@@ -2,7 +2,7 @@
     <div class="m-accordion-group__header"
          :class="{ 'm--no-title' : !hasTitleSlot,
                    'm--has-secondary-content' : hasSecondaryContentSlot,
-                   'm--is-reserve-header' : reverseHeader }"
+                   'm--is-toggle-link-left' : toggleLinkLeft }"
          v-if="hasTitleSlot || !concurrent">
         <div class="m-accordion-group__header-title"
              v-if="hasTitleSlot">

--- a/src/components/accordion-group/accordion-group.scss
+++ b/src/components/accordion-group/accordion-group.scss
@@ -9,19 +9,14 @@
             justify-content: flex-end;
         }
 
-        &:not(.m--has-secondary-content):not(.m--no-title) {
-            justify-content: space-between;
-            align-items: flex-end;
-
-            &.m--is-reserve-header {
-                flex-direction: row-reverse;
-            }
+        &:not(.m--has-secondary-content):not(.m--no-title).m--is-toggle-link-left {
+            flex-direction: column;
         }
 
         &.m--has-secondary-content {
             flex-direction: column;
 
-            &.m--is-reserve-header {
+            &.m--is-toggle-link-left {
                 .m-accordion-group__secondary-content {
                     flex-direction: row-reverse;
                 }
@@ -29,14 +24,19 @@
         }
     }
 
+    &__header-title {
+        flex: 1 1 auto;
+    }
+
     &__secondary-content {
         display: flex;
         justify-content: space-between;
         align-items: flex-end;
+        flex-shrink: 0;
     }
 
     &__toggle-link {
-        flex: none;
+        flex-shrink: 0;
     }
 
     &__body {

--- a/src/components/accordion-group/accordion-group.stories.ts
+++ b/src/components/accordion-group/accordion-group.stories.ts
@@ -51,8 +51,8 @@ storiesOf(`${componentsHierarchyRootSeparator}${ACCORDION_GROUP_NAME}`, module)
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
     </m-accordion-group>`
     }))
-    .add('reverse-header', () => ({
-        template: `<m-accordion-group :reverse-header="true">
+    .add('toggle-link-left', () => ({
+        template: `<m-accordion-group :toggle-link-left="true">
                         <h2 slot="title">An Accordion Group Title</h2>
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
@@ -175,8 +175,8 @@ storiesOf(`${componentsHierarchyRootSeparator}${ACCORDION_GROUP_NAME}/secondary-
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
     </m-accordion-group>`
     }))
-    .add('reverse-header', () => ({
-        template: `<m-accordion-group :reverse-header="true">
+    .add('toggle-link-left', () => ({
+        template: `<m-accordion-group :toggle-link-left="true">
                         <h2 slot="title">An Accordion Group Title</h2>
                         <h3 slot="secondary-content">An Accordion Group Title</h3>
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
@@ -185,7 +185,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${ACCORDION_GROUP_NAME}/secondary-
     </m-accordion-group>`
     }))
     .add('m-link', () => ({
-        template: `<m-accordion-group :reverse-header="true">
+        template: `<m-accordion-group :toggle-link-left="true">
                         <h2 slot="title">An Accordion Group Title</h2>
                         <m-link icon-name="m-svg__add-circle-filled" icon-size="22px" mode="button" slot="secondary-content">Add content</m-link>
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
@@ -201,8 +201,8 @@ storiesOf(`${componentsHierarchyRootSeparator}${ACCORDION_GROUP_NAME}/secondary-
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
     </m-accordion-group>`
     }))
-    .add('no-title-reverse-header', () => ({
-        template: `<m-accordion-group :reverse-header="true">
+    .add('no-title-toggle-link-left', () => ({
+        template: `<m-accordion-group :toggle-link-left="true">
                         <h3 slot="secondary-content">An Accordion Group Title</h3>
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>
                         <m-accordion><h3 slot="header">An Accordion Title</h3>Some Accordion Content</m-accordion>

--- a/src/components/accordion-group/accordion-group.ts
+++ b/src/components/accordion-group/accordion-group.ts
@@ -36,7 +36,7 @@ export class MAccordionGroup extends Vue implements AccordionGroupGateway {
     @Prop({
         default: false
     })
-    public reverseHeader: boolean;
+    public toggleLinkLeft: boolean;
 
     private accordions: { [id: string]: AccordionGateway } = {};
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Amélioration de l'entête du m-accordion-group
- [x] Include links to issues
[MODUL-980](https://jira.dti.ulaval.ca/browse/MODUL-980)
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

### BREAKING CHANGE
La prop **reverseHeader** change pour **toggleLinkLeft** pour être plus symbolique. Le comportement n'a pas changé, seulement à renommer la prop pour le nouveau nom