### PR TITLE
Change name/value of Z_INDEX_DEFAULT const to organize absolute elements properly

### DIFF
--- a/src/utils/modul/modul.ts
+++ b/src/utils/modul/modul.ts
@@ -25,7 +25,7 @@ const BACKDROP_STYLE_OPACITY: string = '0';
 const BACKDROP_STYLE_OPACITY_VISIBLE: string = '0.7';
 const BACKDROP_STYLE_OPACITY_NOT_VISIBLE: string = '0';
 
-const Z_INDEZ_DEFAULT: number = 100;
+const Z_INDEX_DEFAULT: number = 999;
 const DONE_EVENT_DURATION: number = 100;
 
 interface StackElement {
@@ -49,7 +49,7 @@ export class Modul {
     public scrollUp: boolean = true;
 
     public backdropElement: HTMLElement | undefined;
-    public windowZIndex: number = Z_INDEZ_DEFAULT;
+    public windowZIndex: number = Z_INDEX_DEFAULT;
 
     private windowStack: (string | undefined)[] = [];
     private windowStackMap: StackMap = {};
@@ -118,9 +118,9 @@ export class Modul {
             this.removeBackdrop(!stackElement.backdropIsFast);
         }
 
-        if (this.windowZIndex < Z_INDEZ_DEFAULT) {
+        if (this.windowZIndex < Z_INDEX_DEFAULT) {
             Vue.prototype.$log.warn('$modul: Invalid window ref count');
-            this.windowZIndex = Z_INDEZ_DEFAULT;
+            this.windowZIndex = Z_INDEX_DEFAULT;
         }
 
         delete this.windowStackMap[stackId];


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR

Since the storybook content is injected into an iframe, z-index isn't always working as intended and it is possible to click the RTE through the modal's backdrop (storybook only).

However, while it works correctly in the sandboxes, the z-index of the RTE elements shouldn't be higher than the Z_INDEX_DEFAULT const declared in the modul.ts file.

Z_INDEZ_DEFAULT is being renamed to Z_INDEX_DEFAULT since it had a typo and its value is being increased from 100 to 999 in order for the portal element to always be the top layer when multiple elements are positioned in absolute.

This fix will allow the backdrop to remain the top layer in both cases when it is either being injected in an iframe or used in regular fashion. It will also make it less likely for other components to come out on top.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-991
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
