### PR TITLE
MODUL-996 - Correction affichage RTE

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -107,7 +107,7 @@ $m-dropdown--margin: $m-padding--xs !default;
     &__placeholder-icon.m-icon.m-icon {
         position: absolute;
         left: 0;
-        top: 50%;
+        top: calc(50% + 2px); // magic number
         transform: translateY(-50%);
         color: $m-color--disabled !important;
     }

--- a/src/components/icon/__snapshots__/icon.stories.ts.snap
+++ b/src/components/icon/__snapshots__/icon.stories.ts.snap
@@ -151,6 +151,7 @@ exports[`Storyshots components|m-icon/badge offsetX 1`] = `
   aria-hidden="true"
   class="m-icon"
   height="30px"
+  style="overflow: visible;"
   width="30px"
 >
   <!---->
@@ -167,6 +168,7 @@ exports[`Storyshots components|m-icon/badge offsetY 1`] = `
   aria-hidden="true"
   class="m-icon"
   height="30px"
+  style="overflow: visible;"
   width="30px"
 >
   <!---->
@@ -183,6 +185,7 @@ exports[`Storyshots components|m-icon/badge state 1`] = `
   aria-hidden="true"
   class="m-icon"
   height="30"
+  style="overflow: visible;"
   width="30"
 >
   <!---->
@@ -199,6 +202,7 @@ exports[`Storyshots components|m-icon/badge state, offsetY, offsetX 1`] = `
   aria-hidden="true"
   class="m-icon"
   height="30"
+  style="overflow: visible;"
   width="30"
 >
   <!---->

--- a/src/components/input-style/__snapshots__/input-style.stories.ts.snap
+++ b/src/components/input-style/__snapshots__/input-style.stories.ts.snap
@@ -543,6 +543,8 @@ exports[`Storyshots components|m-input-style requiredMarker 1`] = `
 </div>
 `;
 
+exports[`Storyshots components|m-input-style rich text editor 1`] = `<!---->`;
+
 exports[`Storyshots components|m-input-style tagStyle 1`] = `
 <div
   class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-h1"

--- a/src/components/input-style/input-style.scss
+++ b/src/components/input-style/input-style.scss
@@ -218,8 +218,6 @@ $m-input-style-base-height: $m-line-height + em;
         position: relative;
         flex: 1 1 auto;
         max-width: 100%;
-        display: flex;
-        align-items: center;
     }
 
     &__right-content {

--- a/src/components/input-style/input-style.stories.ts
+++ b/src/components/input-style/input-style.stories.ts
@@ -4,8 +4,10 @@ import { storiesOf } from '@storybook/vue';
 import Vue from 'vue';
 import { componentsHierarchyRootSeparator } from '../../../conf/storybook/utils';
 import { INPUT_STYLE_NAME } from '../component-names';
+import RichTextEditorPlugin from '../rich-text-editor/rich-text-editor';
 import InputStylePlugin from './input-style';
 Vue.use(InputStylePlugin);
+Vue.use(RichTextEditorPlugin);
 
 
 declare module '@storybook/addon-knobs' {
@@ -189,4 +191,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${INPUT_STYLE_NAME}`, module)
             }
         },
         template: '<m-input-style label="label" :empty="false" :tag-style="tagStyle">Title ({{tagStyle}})</m-input-style>'
+    }))
+    .add('rich text editor', () => ({
+        template: '<m-rich-text-editor max-width="large" label="RTE - test for regressions"></m-rich-text-editor>'
     }));


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Dans le input-style, le display-flex permettait d'aligner verticalement l'icône dans un dropdown mais créait un problème dans le RTE (voir billet). Comme le input-style est utilisé dans le RTE et que le RTE est "fragile", j'ai préféré ajouter un cas dans le storybook du input-style.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-996
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
