### PR TITLE
Integerfield now use cleavejs

### DIFF
--- a/src/components/decimalfield/__snapshots__/decimalfield.stories.ts.snap
+++ b/src/components/decimalfield/__snapshots__/decimalfield.stories.ts.snap
@@ -37,7 +37,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
               />
                 
               <!---->
@@ -107,7 +107,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
               />
                 
               <!---->
@@ -181,7 +181,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
               />
                 
               <!---->
@@ -247,7 +247,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
               />
                 
               <!---->
@@ -336,7 +336,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
               />
                 
               <!---->
@@ -406,7 +406,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
               />
                 
               <!---->
@@ -499,7 +499,7 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
                 placeholder="Enter a decimal number"
               />
                 
@@ -568,7 +568,7 @@ exports[`Storyshots components|m-decimalfield Custom precision 1`] = `
           <input
             class="m-decimalfield__input"
             id="mDecimalfield-uuid"
-            inputmode="numeric"
+            inputmode="decimal"
           />
             
           <!---->
@@ -634,7 +634,7 @@ exports[`Storyshots components|m-decimalfield Default precision 1`] = `
           <input
             class="m-decimalfield__input"
             id="mDecimalfield-uuid"
-            inputmode="numeric"
+            inputmode="decimal"
           />
             
           <!---->
@@ -700,7 +700,7 @@ exports[`Storyshots components|m-decimalfield Localization 1`] = `
           <input
             class="m-decimalfield__input"
             id="mDecimalfield-uuid"
-            inputmode="numeric"
+            inputmode="decimal"
           />
             
           <!---->
@@ -769,7 +769,7 @@ exports[`Storyshots components|m-decimalfield States 1`] = `
                 class="m-decimalfield__input"
                 disabled="disabled"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
                 placeholder="Disabled"
               />
                 
@@ -836,7 +836,7 @@ exports[`Storyshots components|m-decimalfield States 1`] = `
               <input
                 class="m-decimalfield__input"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
                 placeholder="Read-only"
                 readonly="readonly"
               />
@@ -905,7 +905,7 @@ exports[`Storyshots components|m-decimalfield States 1`] = `
                 class="m-decimalfield__input"
                 disabled="disabled"
                 id="mDecimalfield-uuid"
-                inputmode="numeric"
+                inputmode="decimal"
                 placeholder="Waiting"
               />
                 
@@ -980,7 +980,7 @@ exports[`Storyshots components|m-decimalfield With initial value (0) 1`] = `
           <input
             class="m-decimalfield__input"
             id="mDecimalfield-uuid"
-            inputmode="numeric"
+            inputmode="decimal"
           />
             
           <!---->
@@ -1046,7 +1046,7 @@ exports[`Storyshots components|m-decimalfield With initial value 1`] = `
           <input
             class="m-decimalfield__input"
             id="mDecimalfield-uuid"
-            inputmode="numeric"
+            inputmode="decimal"
           />
             
           <!---->

--- a/src/components/decimalfield/decimalfield.html
+++ b/src/components/decimalfield/decimalfield.html
@@ -33,11 +33,9 @@
                       @blur="onBlur"
                       @keyup="onKeyup"
                       @change="onChange"
-                      @drop="onDropDecimalfield"
                       ref="inputMask"
                       :options="inputMaskOptions"
-                      inputmode="numeric"></m-input-mask>
-
+                      inputmode="decimal"></m-input-mask>
         <template slot="right-content">
             <slot name="suffix"></slot>
         </template>

--- a/src/components/decimalfield/decimalfield.ts
+++ b/src/components/decimalfield/decimalfield.ts
@@ -43,11 +43,7 @@ export class MDecimalfield extends ModulVue {
     @Prop({ default: false })
     public forceRoundingFormat: boolean;
 
-    private id: string = `mDecimalfield-${uuid.generate()}`;
-
-    private onDropDecimalfield(event: DragEvent): void {
-        event.preventDefault();
-    }
+    protected id: string = `mDecimalfield-${uuid.generate()}`;
 
     private get hasDecimalfieldError(): boolean {
         return this.as<InputState>().hasError;
@@ -91,7 +87,7 @@ export class MDecimalfield extends ModulVue {
 }
 
 const DecimalfieldPlugin: PluginObject<any> = {
-    install(v, options): void {
+    install(v): void {
         v.use(L10nPlugin);
         v.use(InputStyle);
         v.use(ValidationMesagePlugin);

--- a/src/components/input-mask/input-mask.html
+++ b/src/components/input-mask/input-mask.html
@@ -6,4 +6,5 @@
        @keydown.enter="onEnter"
        @change="onChange"
        @paste="onPasteTextfield"
-       @drop="onDropTextfield" />
+       @drop="onDropTextfield"
+       @textInput="onTextInput" />

--- a/src/components/input-mask/input-mask.ts
+++ b/src/components/input-mask/input-mask.ts
@@ -104,9 +104,7 @@ export class MInputMask extends ModulVue {
 
         this.internalModel = this.value || '';
         this.updateRawValue(inputValue);
-
     }
-
 
     onFocus($event: any): void {
         this.$emit('focus', $event);
@@ -117,11 +115,27 @@ export class MInputMask extends ModulVue {
         this.$emit('blur', $event);
     }
 
-    onKeyup($event: any): void {
+    onKeyup($event: KeyboardEvent): void {
         this.$emit('keyup', $event);
     }
 
-    onKeydownTextfield($event: any): void {
+    onKeydownTextfield($event: KeyboardEvent): void {
+        const rawValue: string = this.cleave.getRawValue();
+        if (($event.key === '.' || $event.key === ',') && !rawValue.endsWith('.')) {
+            this.cleave.setRawValue(`${rawValue}.`);
+        }
+
+        this.$emit('keydown', $event);
+    }
+
+    // Hack pour android qui lève toujours le key code 229.
+    onTextInput($event: KeyboardEvent): void {
+        const key: string = ($event as any).data;
+        const rawValue: string = this.cleave.getRawValue();
+        if (key === '.' && !rawValue.endsWith('.')) {
+            this.cleave.setRawValue(`${rawValue}.`);
+        }
+
         this.$emit('keydown', $event);
     }
 

--- a/src/components/integerfield/__snapshots__/integerfield.spec.ts.snap
+++ b/src/components/integerfield/__snapshots__/integerfield.spec.ts.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MTextfield should render correctly 1`] = `
-<div class="m-integerfield" style="width:100%;max-width:288px;">
+<div class="m-decimalfield" style="width:100%;max-width:288px;">
   <div class="m-input-style m--is-tag-default">
     <div class="m-input-style__content" style="margin-top:10px;"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
       <div class="m-input-style__body">
         <div class="m-input-style__prefix"></div>
-        <div class="m-input-style__left-content"><input id="mIntegerfield-uuid" maxlength="16" pattern="[0-9]*" inputmode="numeric" type="number" value="" class="m-integerfield__input"> </div>
+        <div class="m-input-style__left-content"> <input id="mIntegerfield-uuid" inputmode="decimal" class="m-decimalfield__input"> </div>
         <div class="m-input-style__right-content"></div>
       </div>
     </div>
   </div>
-  <div class="m-integerfield__validation">
-    <div class="m-validation-message m-integerfield__validation__message"> </div>
+  <div class="m-decimalfield__validation">
+    <div class="m-validation-message m-decimalfield__validation__message"> </div>
   </div>
 </div>
 `;

--- a/src/components/integerfield/integerfield.html
+++ b/src/components/integerfield/integerfield.html
@@ -1,17 +1,17 @@
-<div class="m-integerfield"
+<div class="m-decimalfield"
      :class="[{ 'm--is-disabled': isDisabled,
                 'm--is-waiting': isWaiting,
                 'm--is-readonly': isReadonly,
-                'm--has-error': hasIntegerfieldError,
-                'm--is-valid': isIntegerfieldValid,
+                'm--has-error': hasDecimalfieldError,
+                'm--is-valid': isDecimalfieldValid,
                 'm--has-label': hasLabel,
                 'm--has-validation-message': hasValidationMessage } ]"
      @click="onClick"
      :style="{ width: inputWidth, maxWidth: inputMaxWidth }">
     <m-input-style :disabled="isDisabled"
                    :waiting="isWaiting"
-                   :error="hasIntegerfieldError"
-                   :valid="isIntegerfieldValid"
+                   :error="hasDecimalfieldError"
+                   :valid="isDecimalfieldValid"
                    :label="label"
                    :label-for="id"
                    :focus="isFocus"
@@ -20,31 +20,33 @@
                    :readonly="isReadonly"
                    :required-marker="requiredMarker"
                    :tag-style="tagStyle">
-        <input class="m-integerfield__input"
-               v-model="model"
-               :id="id"
-               :disabled="isDisabled || isWaiting"
-               :placeholder="placeholder"
-               :readonly="isReadonly"
-               :maxlength="maxLengthNumber"
-               :pattern="inputPattern"
-               :inputmode="inputMode"
-               type="number"
-               @focus="onFocus"
-               @blur="onBlur"
-               @keyup="onKeyup"
-               @keydown="onKeydownIntegerfield"
-               @change="onChange"
-               @paste="onPasteIntegerfield"
-               @drop="onDropIntegerfield" />
+        <template slot="prefix">
+            <slot name="prefix"></slot>
+        </template>
+        <m-input-mask class="m-decimalfield__input"
+                      v-model="model"
+                      :id="id"
+                      :disabled="isDisabled || isWaiting"
+                      :placeholder="placeholder"
+                      :readonly="isReadonly"
+                      @focus="onFocus"
+                      @blur="onBlur"
+                      @keyup="onKeyup"
+                      @change="onChange"
+                      ref="inputMask"
+                      :options="inputMaskOptions"
+                      inputmode="decimal"></m-input-mask>
+        <template slot="right-content">
+            <slot name="suffix"></slot>
+        </template>
     </m-input-style>
-    <div class="m-integerfield__validation">
-        <m-validation-message class="m-integerfield__validation__message"
+    <div class="m-decimalfield__validation">
+        <m-validation-message class="m-decimalfield__validation__message"
                               :disabled="isDisabled"
                               :waiting="isWaiting"
-                              :error="hasIntegerfieldError"
+                              :error="hasDecimalfieldError"
                               :error-message="errorMessage"
-                              :valid="isIntegerfieldValid"
+                              :valid="isDecimalfieldValid"
                               :valid-message="validMessage"
                               :helper-message="helperMessage"></m-validation-message>
     </div>

--- a/src/components/integerfield/integerfield.sandbox.html
+++ b/src/components/integerfield/integerfield.sandbox.html
@@ -15,7 +15,7 @@
     <h3 class="m-u--h6">2 numbers limit</h3>
     <m-integerfield label="number"
                     v-model="model2"
-                    max-length="2"
+                    :max-length="2"
                     :length-overflow="false"
                     placeholder="Put a number"></m-integerfield>
     <p> model = {{ model2 }} </p>

--- a/src/components/moneyfield/__snapshots__/moneyfield.spec.ts.snap
+++ b/src/components/moneyfield/__snapshots__/moneyfield.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`MTextfield should render correctly 1`] = `
       <div class="m-input-style__content" style="margin-top:10px;"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
         <div class="m-input-style__body">
           <div class="m-input-style__prefix">CA$</div>
-          <div class="m-input-style__left-content"> <input id="mDecimalfield-uuid" inputmode="numeric" class="m-decimalfield__input"> </div>
+          <div class="m-input-style__left-content"> <input id="mDecimalfield-uuid" inputmode="decimal" class="m-decimalfield__input"> </div>
           <div class="m-input-style__right-content"></div>
         </div>
       </div>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Integerfield now use cleavejs
Integerfield and decimalfield use inputmode decimal
Integerfield you can now type in 0 as first caracter
. and , will work to input the decimal-mark
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1014
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
max-length on integerfield now has to be a number (max-length="1" becomes :max-length="1")
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
