### PR TITLE
MODUL-1002 - fix async and external validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "popper.js": "^1.12.9",
         "portal-vue": "~1.1.1",
         "qs": "^6.5.1",
-        "rxjs": "^6.5.1",
         "sprintf-js": "^1.1.1",
         "vue-touch": "^2.0.0-beta.4",
         "zingtouch": "^1.0.6"

--- a/src/components/form/__snapshots__/form.stories.ts.snap
+++ b/src/components/form/__snapshots__/form.stories.ts.snap
@@ -6,6 +6,8 @@ exports[`Storyshots components|m-form default 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <div
     class="m-textfield m--is-type-text"
     style="width: 100%; max-width: 288px;"
@@ -128,6 +130,8 @@ exports[`Storyshots components|m-form/built-in action-fallouts default 1`] = `
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <div
@@ -254,6 +258,8 @@ exports[`Storyshots components|m-form/built-in action-fallouts focus first field
 >
   <!---->
    
+  <!---->
+   
   <div
     class="m-textfield m--is-type-text"
     style="width: 100%; max-width: 288px;"
@@ -378,6 +384,8 @@ exports[`Storyshots components|m-form/built-in action-fallouts message summary a
 >
   <!---->
    
+  <!---->
+   
   <div
     class="m-textfield m--is-type-text"
     style="width: 100%; max-width: 288px;"
@@ -500,6 +508,8 @@ exports[`Storyshots components|m-form/built-in action-fallouts toast and clear t
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <div
@@ -628,6 +638,8 @@ exports[`Storyshots components|m-form/built-in validators compare 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <m-input-group />
    
   <p
@@ -680,6 +692,8 @@ exports[`Storyshots components|m-form/built-in validators email 1`] = `
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <div
@@ -804,6 +818,8 @@ exports[`Storyshots components|m-form/built-in validators max 1`] = `
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <m-integerfield />
@@ -956,6 +972,8 @@ exports[`Storyshots components|m-form/built-in validators max-length 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <div
     class="m-textfield m--is-type-text"
     style="width: 100%; max-width: 288px;"
@@ -1078,6 +1096,8 @@ exports[`Storyshots components|m-form/built-in validators min 1`] = `
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <m-integerfield />
@@ -1230,6 +1250,8 @@ exports[`Storyshots components|m-form/built-in validators min-length 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <div
     class="m-textfield m--is-type-text"
     style="width: 100%; max-width: 288px;"
@@ -1354,6 +1376,8 @@ exports[`Storyshots components|m-form/built-in validators required 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <div
     class="m-textfield m--is-type-text"
     style="width: 100%; max-width: 288px;"
@@ -1472,10 +1496,166 @@ exports[`Storyshots components|m-form/built-in validators required 1`] = `
 </form>
 `;
 
+exports[`Storyshots components|m-form/fields datepicker 1`] = `
+<form
+  class="m-u--margin-top"
+>
+  <!---->
+   
+  <!---->
+   
+  <div
+    class="m-datepicker"
+    style="width: 100%; max-width: 136px;"
+  >
+    <div
+      class="m-input-style m--has-label m--is-tag-default"
+    >
+      <div
+        class="m-input-style__content"
+        style="margin-top: 10px;"
+      >
+        <label
+          class="m-input-style__label"
+          for="mDatepicker-uuid"
+        >
+          <span
+            class="m-input-style__text"
+          >
+            <span>
+              Birthdate
+            </span>
+             
+            <!---->
+          </span>
+        </label>
+         
+        <div
+          class="m-input-style__body"
+        >
+          <!---->
+           
+          <div
+            class="m-input-style__left-content"
+          >
+            <input
+              aria-haspopup="true"
+              autocomplete="off"
+              id="mDatepicker-uuid"
+              placeholder="AAAA-MM-JJ"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__right-content"
+          >
+            <button
+              aria-controls="mDatepicker-uuid"
+              class="m-icon-button m-datepicker__icon m--is-skin-light m--has-ripple"
+              style="width: 22px; height: 22px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="m-icon m-icon-button__icon"
+                height="20px"
+                width="20px"
+              >
+                <!---->
+                 
+                <use
+                  aria-hidden="true"
+                  class=""
+                />
+              </svg>
+               
+              <!---->
+            </button>
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+    </div>
+     
+    <div
+      class="m-validation-message m-datepicker__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="m-popup"
+    >
+      <div
+        class="m-popper"
+      >
+         
+        <!---->
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <p
+    class="m-u--margin-bottom--l"
+  >
+    <button
+      class="m-button m--is-skin-primary"
+      type="submit"
+    >
+      <!---->
+       
+      <!---->
+       
+      <span
+        class="m-button__text"
+      >
+        Submit 
+        <!---->
+      </span>
+       
+      <!---->
+       
+      <!---->
+    </button>
+     
+    <button
+      class="m-button m--is-skin-secondary"
+      type="reset"
+    >
+      <!---->
+       
+      <!---->
+       
+      <span
+        class="m-button__text"
+      >
+        Reset 
+        <!---->
+      </span>
+       
+      <!---->
+       
+      <!---->
+    </button>
+  </p>
+</form>
+`;
+
 exports[`Storyshots components|m-form/validation-type at-exit 1`] = `
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <p>
@@ -1606,6 +1786,8 @@ exports[`Storyshots components|m-form/validation-type correction 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <p>
     edition context: 
   </p>
@@ -1734,6 +1916,8 @@ exports[`Storyshots components|m-form/validation-type modification 1`] = `
 >
   <!---->
    
+  <!---->
+   
   <p>
     edition context: 
   </p>
@@ -1860,6 +2044,8 @@ exports[`Storyshots components|m-form/validation-type on-going 1`] = `
 <form
   class="m-u--margin-top"
 >
+  <!---->
+   
   <!---->
    
   <p>

--- a/src/components/form/control-directive.ts
+++ b/src/components/form/control-directive.ts
@@ -1,68 +1,53 @@
-import Vue, { DirectiveOptions, VNodeDirective } from 'vue';
+import Vue, { DirectiveOptions, VNode, VNodeDirective } from 'vue';
 import { AbstractControl } from '../../utils/form/abstract-control';
 import { FormControl } from '../../utils/form/form-control';
 
-const DISTANCE_FROM_TOP: number = -200;
+const INPUT_SELECTOR: string = 'input, textarea, [contenteditable=true]';
 
-const scrollToElement: Function = (element: HTMLElement): void => {
-    (Vue.prototype).$scrollTo.goTo(element, DISTANCE_FROM_TOP);
-};
+
+
 
 export const AbstractControlDirective: DirectiveOptions = {
     inserted(
         el: HTMLElement,
-        binding: VNodeDirective
+        binding: VNodeDirective,
+        vnode: VNode
     ): void {
         const control: AbstractControl = binding.value;
-        const selector: string = 'input, textarea, [contenteditable=true]';
-        const inputElement: Element = el.querySelectorAll(selector)[0];
 
-        control.focusGrantedObservable.subscribe(granted => {
-            if (!granted) {
-                return;
-            }
+        const inputElements: NodeListOf<Element> = el.querySelectorAll(INPUT_SELECTOR);
+        if (inputElements.length > 0) {
+            control.focusableElement = inputElements[0] as HTMLElement;
+        } else {
+            control.focusableElement = el;
+        }
 
-            if (el instanceof HTMLInputElement) {
-                scrollToElement(el);
-                el.focus();
-            } else if (inputElement) {
-                scrollToElement(inputElement);
-                (inputElement as HTMLInputElement).focus();
-            } else {
-                scrollToElement(el);
-            }
-
-            control.focusGrantedObservable.next(false);
-        });
-
-        Object.defineProperty(el, 'ControlDirectiveListeners', {
-            value: {
-                focusListener: () => {
-                    if (control instanceof FormControl) {
-                        control.initEdition();
-                    }
-                },
-                blurListener: (event: any) => {
-                    if (control instanceof FormControl) {
-                        control.endEdition();
-                    }
+        if (control instanceof FormControl) {
+            Object.defineProperty(el, 'ControlDirectiveListeners', {
+                value: {
+                    focusListener: () => control.initEdition(),
+                    blurListener: (event: any) => control.endEdition()
                 }
-            }
-        });
-
-        el.addEventListener('focus', el['ControlDirectiveListeners'].focusListener, true);
-        el.addEventListener('blur', el['ControlDirectiveListeners'].blurListener, true);
+            });
+            (vnode.componentInstance as Vue).$on('focus', el['ControlDirectiveListeners'].focusListener);
+            (vnode.componentInstance as Vue).$on('blur', el['ControlDirectiveListeners'].blurListener);
+        }
     },
     unbind(
         el: HTMLElement,
-        binding: VNodeDirective
+        binding: VNodeDirective,
+        vnode: VNode
     ): void {
         const control: AbstractControl = binding.value;
 
-        control.focusGrantedObservable.unsubscribe();
+        control.focusableElement = undefined;
 
-        el.removeEventListener('focus', el['ControlDirectiveListeners'].focusListener, true);
-        el.removeEventListener('blur', el['ControlDirectiveListeners'].blurListener, true);
+        if (control instanceof FormControl) {
+            (vnode.componentInstance as Vue).$off('focus', el['ControlDirectiveListeners'].focusListener);
+            (vnode.componentInstance as Vue).$off('blur', el['ControlDirectiveListeners'].blurListener);
+        }
+
+
     }
 };
 

--- a/src/components/form/form.html
+++ b/src/components/form/form.html
@@ -5,6 +5,7 @@
         <m-message class="m-form__message-summary"
                    v-if="displaySummary"
                    state="error"
+                   :close-button="true"
                    ref="summary">
             <ul>
                 <li v-for="(error, index) in summaryErrors"
@@ -14,5 +15,12 @@
             </ul>
         </m-message>
     </m-accordion-transition>
+
+
+    <m-toast :open.sync="displayToast"
+             position="top-center"
+             state="error">
+        <p v-html="toastMessage"></p>
+    </m-toast>
     <slot></slot>
 </form>

--- a/src/components/form/form.sandbox.html
+++ b/src/components/form/form.sandbox.html
@@ -96,11 +96,11 @@
 
     <hr />
 
-    <h2 class="m-u--no-margin">More than one validations (course code)</h2>
+    <h2 class="m-u--no-margin">More than one validations (external) </h2>
     <p>input mask is not ready for this (it should use inputs mixins)</p>
     <p>
         <m-form :form-group="formGroups[4]"
-                :ref="formGroups[4].name"
+                ref="form4"
                 v-m-control="formGroups[4]"
                 @reset="reset(4)"
                 @submit="submit(4)">
@@ -127,12 +127,14 @@
     <p>
         <m-form :form-group="formGroups[5]"
                 :ref="formGroups[5].name"
-                v-m-control="formGroups[5]"
                 @reset="reset(5)"
                 @submit="submit(5)">
 
             <m-textfield v-model.trim="formGroups[5].getControl('Username').value"
                          :label="formGroups[5].getControl('Username').name"
+                         :waiting="formGroups[5].getControl('Username').waiting"
+                         :valid-message="formGroups[5].getControl('Username').valid? 'Le nom d\'utilisateur est disponible' : ''"
+                         :valid="formGroups[5].getControl('Username').valid"
                          :error-message="formGroups[5].getControl('Username').errors.length > 0 ? formGroups[5].getControl('Username').errors[0].message : null"
                          v-m-control="formGroups[5].getControl('Username')">
             </m-textfield>

--- a/src/components/form/form.sandbox.html
+++ b/src/components/form/form.sandbox.html
@@ -133,7 +133,7 @@
             <m-textfield v-model.trim="formGroups[5].getControl('Username').value"
                          :label="formGroups[5].getControl('Username').name"
                          :waiting="formGroups[5].getControl('Username').waiting"
-                         :valid-message="formGroups[5].getControl('Username').valid? 'Le nom d\'utilisateur est disponible' : ''"
+                         :valid-message="formGroups[5].getControl('Username').valid ? 'Le nom d\'utilisateur est disponible' : ''"
                          :valid="formGroups[5].getControl('Username').valid"
                          :error-message="formGroups[5].getControl('Username').errors.length > 0 ? formGroups[5].getControl('Username').errors[0].message : null"
                          v-m-control="formGroups[5].getControl('Username')">

--- a/src/components/form/form.sandbox.ts
+++ b/src/components/form/form.sandbox.ts
@@ -50,10 +50,10 @@ export class MFormSandbox extends ModulVue {
                         RequiredValidator('Postal code'),
                         {
                             key: 'postal-code-format',
-                            validationFunction: (control: FormControl<string>): Promise<boolean> => {
+                            validationFunction: (control: FormControl<string>): boolean => {
                                 const regex: RegExp = /^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/;
 
-                                return Promise.resolve(regex.test(control.value || ''));
+                                return regex.test(control.value || '');
                             },
                             error: {
                                 message: 'Enter postal code.'
@@ -84,10 +84,10 @@ export class MFormSandbox extends ModulVue {
                         }),
                         {
                             key: 'course-code-format',
-                            validationFunction: (control: FormControl<string>): Promise<boolean> => {
+                            validationFunction: (control: FormControl<string>): boolean => {
                                 const regex: RegExp = /^[A-Za-z]{3}[-]?\d{4}$/;
 
-                                return Promise.resolve(regex.test(control.value || ''));
+                                return regex.test(control.value || '');
                             },
                             error: {
                                 message: 'Enter a valid course format (ex. : MAT-1000).'
@@ -110,22 +110,35 @@ export class MFormSandbox extends ModulVue {
             {
                 'Username': new FormControl<string>(
                     [
+                        RequiredValidator('Value', {
+                            error: {
+                                message: 'Username is required'
+                            },
+                            validationType: ControlValidatorValidationType.AtExit
+                        }),
                         {
                             key: '',
                             validationFunction: async (control: FormControl<string>): Promise<boolean> => {
                                 return new Promise(res => {
-                                    setTimeout(() => res(![
-                                        'John',
-                                        'Jane',
-                                        'Doe'
-                                    ].includes(control.value || '')), 1200);
+                                    if (control.value) {
+                                        setTimeout(() => res(![
+                                            'John',
+                                            'Jane',
+                                            'Doe'
+                                        ].includes(control.value || '')), 2000);
+                                    } else {
+                                        res(false);
+                                    }
+
                                 });
                             },
+                            async: true,
                             error: {
                                 message: 'Username is not available'
                             },
                             validationType: ControlValidatorValidationType.AtExit
                         }
+
                     ]
                 )
             }
@@ -151,11 +164,8 @@ export class MFormSandbox extends ModulVue {
                     [
                         {
                             key: 'selection-min-count',
-                            validationFunction: (group: FormGroup): Promise<boolean> => {
-                                let previousSelectionCount: number = group.controls.filter((c: FormControl<boolean>) => !!c['_oldValue']).length;
-                                let selectionCount: number = group.controls.filter((c: FormControl<boolean>) => !!c.value).length;
-
-                                return Promise.resolve((selectionCount > previousSelectionCount) || (selectionCount >= 2));
+                            validationFunction: (array: FormArray): boolean => {
+                                return array.value.filter(c => c).length >= 2;
                             },
                             error: {
                                 message: 'Select at least 2 roles'
@@ -164,10 +174,8 @@ export class MFormSandbox extends ModulVue {
                         },
                         {
                             key: 'selection-max-count',
-                            validationFunction: (group: FormGroup): Promise<boolean> => {
-                                let selectionCount: number = group.controls.filter((c: FormControl<boolean>) => !!c.value).length;
-
-                                return Promise.resolve(selectionCount <= 5);
+                            validationFunction: (array: FormArray): boolean => {
+                                return array.value.filter(c => c).length <= 5;
                             },
                             error: {
                                 message: 'Select 5 roles or less'
@@ -194,8 +202,8 @@ export class MFormSandbox extends ModulVue {
             [
                 {
                     key: 'compare-email',
-                    validationFunction: (control: FormGroup): Promise<boolean> => {
-                        return Promise.resolve(
+                    validationFunction: (control: FormGroup): boolean => {
+                        return (
                             !(control.getControl('Email') as FormControl<string>).value
                             ||
                             ['Email', 'Email confirmation']
@@ -212,6 +220,8 @@ export class MFormSandbox extends ModulVue {
         )
     ];
 
+
+
     submit(formGroupIndex: number): void {
         let me: any = this;
 
@@ -221,12 +231,12 @@ export class MFormSandbox extends ModulVue {
 
                 control.validators
                     .find(v => v.key === 'duplicate-course-code')!
-                    .validationFunction = (): Promise<boolean> => Promise.resolve(![
+                    .validationFunction = (): boolean => (![
                         'AAA-0000',
                         'AAA-0001'
                     ].includes(control.value || ''));
 
-                (me.$refs[me.formGroups[4].name] as MForm).submit(true);
+                (me.$refs['form4'] as MForm).submit(true);
             }, 1000);
         }
     }

--- a/src/components/form/form.stories.ts
+++ b/src/components/form/form.stories.ts
@@ -25,8 +25,6 @@ declare module '@storybook/addon-knobs' {
 }
 
 storiesOf(`${componentsHierarchyRootSeparator}${FORM_NAME}`, module)
-    .addDecorator(withA11y)
-    .addDecorator(withKnobs)
     .add('default', () => ({
         methods: {
             submit: () => {
@@ -55,6 +53,44 @@ storiesOf(`${componentsHierarchyRootSeparator}${FORM_NAME}`, module)
                         :label="formGroup.getControl('name').name"
                         v-m-control="formGroup.getControl('name')">
             </m-textfield>
+            <p class="m-u--margin-bottom--l">
+                <m-button type="submit"
+                        :form="formGroup.id">Submit</m-button>
+                <m-button type="reset"
+                        skin="secondary"
+                        :form="formGroup.id">Reset</m-button>
+            </p>
+        </m-form>
+        `
+    }));
+
+storiesOf(`${componentsHierarchyRootSeparator}${FORM_NAME}/fields`, module)
+    .add('datepicker', () => ({
+        data: () => ({
+            formGroup: new FormGroup(
+                {
+                    'date': new FormControl<string>(
+                        [
+                            RequiredValidator('date')
+                        ]
+                    )
+                }
+            )
+        }),
+        template: `
+        <m-form class="m-u--margin-top"
+                :form-group="formGroup">
+                <m-datepicker   v-m-control="formGroup.getControl('date')"
+                                v-model="formGroup.getControl('date').value"
+                                :required-marker="true"
+                                label="Birthdate"
+                                min="1900-01-01"
+                                max="2020-01-01"
+                                :error="formGroup.getControl('date').hasError()"
+                                :error-message="formGroup.getControl('date').errorMessage"
+                                :disabled="!formGroup.getControl('date').enabled"
+                                :readonly="formGroup.getControl('date').readonly"
+                                :waiting="formGroup.getControl('date').waiting"></m-datepicker>
             <p class="m-u--margin-bottom--l">
                 <m-button type="submit"
                         :form="formGroup.id">Submit</m-button>
@@ -437,8 +473,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${FORM_NAME}/built-in validators`,
         }),
         template: `
         <m-form class="m-u--margin-top"
-                :form-group="formGroup"
-                v-m-control="formGroup">
+                :form-group="formGroup">
             <m-input-group :legend="formGroup.name"
                 :error-message="formGroup.errors.length > 0 ? formGroup.errors[0].message : null">
                 <div slot-scope="{  }">
@@ -484,7 +519,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${FORM_NAME}/validation-type`, mod
         }),
         template: `
         <m-form class="m-u--margin-top"
-        :form-group="formGroup">
+                 :form-group="formGroup">
             <p>edition context: {{formGroup.getControl('email')['editionContext']}}</p>
             <m-textfield v-model.trim="formGroup.getControl('email').value"
                         :error-message="formGroup.getControl('email').errors.length > 0 ? formGroup.getControl('email').errors[0].message : null"

--- a/src/components/form/form.ts
+++ b/src/components/form/form.ts
@@ -2,6 +2,7 @@ import { Component, Emit, Prop } from 'vue-property-decorator';
 import { ControlError } from '../../utils/form/control-error';
 import { ControlValidatorValidationType } from '../../utils/form/control-validator-validation-type';
 import { FormGroup } from '../../utils/form/form-group';
+import { FormatMode } from '../../utils/i18n/i18n';
 import { ModulVue } from '../../utils/vue/vue';
 import { FormActionFallout } from './form-action-fallout';
 import { FormActions } from './form-action-type';
@@ -11,11 +12,15 @@ import WithRender from './form.html?style=./form.scss';
 @Component
 export class MForm extends ModulVue {
     @Prop()
-    public formGroup: FormGroup;
+    public readonly formGroup!: FormGroup;
     public displaySummary: boolean = false;
+    public displayToast: boolean = false;
 
     @Prop({ default: () => ModulVue.prototype.$form.formActionFallouts || [] })
     public actionFallouts: FormActionFallout[];
+
+    @Prop({ default: -200 })
+    public scrollToOffset: number;
 
     @Emit('submit')
     public emitSubmit(): void { }
@@ -29,6 +34,21 @@ export class MForm extends ModulVue {
                 .map(c => c.errors)
                 .reduce((acc, curr) => acc.concat(curr), [])
         );
+    }
+
+    public hasErrors(): boolean {
+        return this.summaryErrors.length > 0;
+    }
+
+    public get toastMessage(): string {
+        const formControlErrorsCount: number = this.formGroup.controls.filter(c => c.errors.length > 0).length;
+        const formGroupErrorsCount: number = this.formGroup.errors.length;
+        return (ModulVue.prototype).$i18n
+            .translate(
+                'm-form:multipleErrorsToCorrect',
+                { totalNbOfErrors: formControlErrorsCount + formGroupErrorsCount },
+                undefined, undefined, undefined, FormatMode.Sprintf
+            );
     }
 
     public async submit(external: boolean = false): Promise<void> {
@@ -86,4 +106,5 @@ export class MForm extends ModulVue {
             .filter(a => type & a.action)
             .forEach(a => a.fallout(this));
     }
+
 }

--- a/src/components/message/message.ts
+++ b/src/components/message/message.ts
@@ -1,3 +1,4 @@
+
 import Vue, { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Emit, Prop, Watch } from 'vue-property-decorator';

--- a/src/utils/form/abstract-control.ts
+++ b/src/utils/form/abstract-control.ts
@@ -122,7 +122,6 @@ export abstract class AbstractControl {
                 return;
             }
 
-            // type validationFunction = ReturnType<v.validationFunction>;
             const validationResult: Promise<boolean> | boolean | undefined = v.validationFunction(this);
 
             if (!(validationResult instanceof Promise)) {

--- a/src/utils/form/abstract-control.ts
+++ b/src/utils/form/abstract-control.ts
@@ -1,4 +1,3 @@
-import { BehaviorSubject } from 'rxjs';
 import { ControlEditionContext } from './control-edition-context';
 import { ControlError } from './control-error';
 import { ControlOptions, FormControlOptions } from './control-options';
@@ -13,7 +12,7 @@ import { ControlValidator } from './validators/control-validator';
  *
  */
 export abstract class AbstractControl {
-    public focusGrantedObservable: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+    public focusableElement: HTMLElement | undefined;
     protected readonly _validationGuard: ControlValidationGuard = DefaultValidationGuard;
     protected _editionContext: ControlEditionContext = ControlEditionContext.None;
     protected _errors: ControlError[] = [];

--- a/src/utils/form/abstract-control.ts
+++ b/src/utils/form/abstract-control.ts
@@ -76,6 +76,7 @@ export abstract class AbstractControl {
         this._editionContext = ControlEditionContext.None;
         this._resetExternalValidators();
         this.validate();
+        this.validateAsync();
         if (this.parent) {
 
             this.parent.endEdition();
@@ -109,7 +110,39 @@ export abstract class AbstractControl {
      * Run all validatiors
      * @param external
      */
-    public async validate(external: boolean = false): Promise<void> {
+    public validate(external: boolean = false): void {
+
+
+        this.validators.map((v) => {
+            if (this._validationGuard(this._editionContext, v.validationType, external)) {
+                return;
+            }
+
+            if (v.async) {
+                return;
+            }
+
+            // type validationFunction = ReturnType<v.validationFunction>;
+            const validationResult: Promise<boolean> | boolean | undefined = v.validationFunction(this);
+
+            if (!(validationResult instanceof Promise)) {
+                v.lastCheck = v.validationFunction(this) as boolean | undefined;
+            } else {
+                throw new Error('if you are using a async validation function  you must set the async flag to true');
+            }
+
+        });
+
+
+        this._updateErrors();
+    }
+
+    /**
+     *
+     * @param external
+     */
+    public async validateAsync(external: boolean = false): Promise<void> {
+
         await Promise.all(
             this.validators
                 .map(async (v) => {
@@ -117,8 +150,22 @@ export abstract class AbstractControl {
                         return;
                     }
 
-                    v.lastCheck = await v.validationFunction(this);
+                    if (!v.async) {
+                        return;
+                    }
+
+                    const validationResult: Promise<boolean> | boolean | undefined = v.validationFunction(this);
+                    if (validationResult instanceof Promise) {
+                        this._waiting = true;
+                        v.lastCheck = await v.validationFunction(this);
+                        this._waiting = false;
+                    } else {
+                        throw new Error('Async validation function should return a Promise<boolan>');
+                    }
+
                 })
+
+
         );
 
         this._updateErrors();
@@ -149,7 +196,7 @@ export abstract class AbstractControl {
 
     public validateAndNotifyParent(): void {
         this.validate();
-
+        this.validateAsync();
         if (this.parent) {
             this.parent.validateAndNotifyParent();
         }

--- a/src/utils/form/form-array.ts
+++ b/src/utils/form/form-array.ts
@@ -102,7 +102,8 @@ export class FormArray extends AbstractControl {
     }
 
     public async submit(external: boolean = false): Promise<void> {
-        await this.validate();
+        this.validate();
+        await this.validateAsync();
         await Promise.all(this.controls.map(c => {
             return c.submit(external);
         }));

--- a/src/utils/form/form-contols.spec.ts
+++ b/src/utils/form/form-contols.spec.ts
@@ -65,7 +65,7 @@ describe('FromControl', () => {
                 [{
                     key: 'always-false',
                     validationFunction: (control: FormControl<string>) => {
-                        return Promise.resolve(false);
+                        return false;
                     },
                     error: {
                         message: 'Always false'
@@ -75,10 +75,12 @@ describe('FromControl', () => {
             );
         });
 
-        it('should be invalid and no error', () => {
+        it('should be invalid and no error', async () => {
             expect(formControl.valid).toBe(false);
             expect(formControl.hasError()).toBe(false);
             expect(formControl.errorMessage).toBe('');
+            formControl.validate();
+            expect(formControl.hasError()).toBe(true);
         });
 
         describe('when edited', () => {

--- a/src/utils/form/form-control.ts
+++ b/src/utils/form/form-control.ts
@@ -91,7 +91,8 @@ export class FormControl<T> extends AbstractControl {
 
 
     public async submit(external: boolean = false): Promise<void> {
-        await this.validate(external);
+        this.validate(external);
+        await this.validateAsync(external);
     }
 
 }

--- a/src/utils/form/form-group.ts
+++ b/src/utils/form/form-group.ts
@@ -118,7 +118,8 @@ export class FormGroup extends AbstractControl {
     }
 
     public async submit(external: boolean = false): Promise<void> {
-        await this.validate();
+        this.validate();
+        await this.validateAsync();
         await Promise.all(this.controls.map(c => {
             return c.submit(external);
         }));

--- a/src/utils/form/validators/between/between.ts
+++ b/src/utils/form/validators/between/between.ts
@@ -12,7 +12,7 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const BetweenValidator: Function = (controlName: string, lowerBound: number | Date, upperBound: number | Date, options: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.Between,
-        validationFunction: (control: FormControl<any>): Promise<boolean> => {
+        validationFunction: (control: FormControl<any>): boolean => {
             if (control instanceof FormGroup) {
                 throw Error('the between validator should not be attached to a form group');
             }
@@ -31,7 +31,7 @@ export const BetweenValidator: Function = (controlName: string, lowerBound: numb
                 isBetween = value >= lowerBound && value <= upperBound;
             }
 
-            return Promise.resolve(isBetween);
+            return isBetween;
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/compare/compare.ts
+++ b/src/utils/form/validators/compare/compare.ts
@@ -9,14 +9,14 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const CompareValidator: Function = (controlNames: string[], options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.Compare,
-        validationFunction: (control: FormGroup): Promise<boolean> => {
+        validationFunction: (control: FormGroup): boolean => {
             if (control instanceof FormControl) {
                 throw Error('the compare controls validator should not be attached to a form control');
             }
 
-            return Promise.resolve(controlNames
+            return controlNames
                 .map(cn => (control.getControl(cn) as FormControl<any>))
-                .every(fc => fc.value === (control.controls[0] as FormControl<any>).value));
+                .every(fc => fc.value === (control.controls[0] as FormControl<any>).value);
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/control-validator.ts
+++ b/src/utils/form/validators/control-validator.ts
@@ -4,10 +4,11 @@ import { ControlValidatorValidationType } from '../control-validator-validation-
 
 export interface ControlValidator {
     key: string;
-    validationFunction: (self: AbstractControl) => Promise<boolean> | undefined;
+    validationFunction: (self: AbstractControl) => boolean | Promise<boolean> | undefined;
     error: ControlError;
     validationType: ControlValidatorValidationType;
     lastCheck?: boolean;
+    async?: boolean;
 }
 
 export interface ControlValidatorOptions {

--- a/src/utils/form/validators/email/email.ts
+++ b/src/utils/form/validators/email/email.ts
@@ -9,14 +9,14 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const EmailValidator: Function = (controlName: string, options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.Email,
-        validationFunction: (control: FormControl<any>): Promise<boolean> => {
+        validationFunction: (control: FormControl<any>): boolean => {
             if (control instanceof FormGroup) {
                 throw Error('the email validator should not be attached to a form group');
             }
 
             let re: RegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-            return Promise.resolve(re.test(String(control.value).toLowerCase()));
+            return re.test(String(control.value).toLowerCase());
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/max-length/max-length.ts
+++ b/src/utils/form/validators/max-length/max-length.ts
@@ -12,7 +12,7 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const MaxLengthValidator: Function = (controlName: string, maxLength: number, options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.MaxLength,
-        validationFunction: (control: FormControl<any>): Promise<boolean> => {
+        validationFunction: (control: FormControl<any>): boolean => {
             if (control instanceof FormGroup) {
                 throw Error('the max length validator should not be attached to a form group');
             }
@@ -27,7 +27,7 @@ export const MaxLengthValidator: Function = (controlName: string, maxLength: num
                 isMaxLength = control.value.length <= maxLength;
             }
 
-            return Promise.resolve(isMaxLength);
+            return isMaxLength;
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/max/max.ts
+++ b/src/utils/form/validators/max/max.ts
@@ -12,7 +12,7 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const MaxValidator: Function = (controlName: string, max: number | Date, options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.Max,
-        validationFunction: (control: FormControl<any>): Promise<boolean> => {
+        validationFunction: (control: FormControl<any>): boolean => {
             if (control instanceof FormGroup) {
                 throw Error('the max validator should not be attached to a form group');
             }
@@ -31,7 +31,7 @@ export const MaxValidator: Function = (controlName: string, max: number | Date, 
                 isMax = value <= max;
             }
 
-            return Promise.resolve(isMax);
+            return isMax;
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/min-length/min-length.ts
+++ b/src/utils/form/validators/min-length/min-length.ts
@@ -12,7 +12,7 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const MinLengthValidator: Function = (controlName: string, minLength: number, options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.MaxLength,
-        validationFunction: (control: FormControl<any>): Promise<boolean> => {
+        validationFunction: (control: FormControl<any>): boolean => {
             if (control instanceof FormGroup) {
                 throw Error('the min length validator should not be attached to a form group');
             }
@@ -27,7 +27,7 @@ export const MinLengthValidator: Function = (controlName: string, minLength: num
                 isMinLength = control.value.length >= minLength;
             }
 
-            return Promise.resolve(isMinLength);
+            return isMinLength;
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/min/min.ts
+++ b/src/utils/form/validators/min/min.ts
@@ -12,7 +12,7 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const MinValidator: Function = (controlName: string, min: number | Date, options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.Min,
-        validationFunction: (control: FormControl<any>): Promise<boolean> => {
+        validationFunction: (control: FormControl<any>): boolean => {
             if (control instanceof FormGroup) {
                 throw Error('the min validator should not be attached to a form group');
             }
@@ -32,7 +32,7 @@ export const MinValidator: Function = (controlName: string, min: number | Date, 
             }
 
 
-            return Promise.resolve(isMin);
+            return isMin;
         },
         error: options && options.error ?
             options.error : {

--- a/src/utils/form/validators/required/required.ts
+++ b/src/utils/form/validators/required/required.ts
@@ -10,7 +10,7 @@ import { ValidatorKeys } from '../validator-error-keys';
 export const RequiredValidator: Function = (controlName: string, options?: ControlValidatorOptions): ControlValidator => {
     return {
         key: ValidatorKeys.Required,
-        validationFunction: (control: AbstractControl): Promise<boolean> => {
+        validationFunction: (control: AbstractControl): boolean => {
             let isPopulate: boolean = false;
 
             let assertPopulate: Function = (value: any): boolean => {
@@ -33,7 +33,7 @@ export const RequiredValidator: Function = (controlName: string, options?: Contr
                 isPopulate = assertPopulate((control as FormControl<any>).value);
             }
 
-            return Promise.resolve(isPopulate);
+            return isPopulate;
         },
         error: options && options.error ?
             options.error : {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist


<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR

- Changement de la fonction de validation pour séparer la validation async de la validation sync. De cette facon les validation sync retourne directement ce qui evite d'avoir un delai entre la validation et la mise a jour des erreurs dans le visuel (dans le cas des validation sync)

- Les validateurs async doivent mainteannt mettre le flag async a true et retourner une Promise<boolean>

- Modification des sandboxes pour la validation async et external

- [ ] Include links to issues

- [ ] Openshift deployment requested

<!-- END_REQUIRED -->


