### PR TITLE
MODUL-1013 - Enlever le placeholder icon sur Firefox et Edge

### DIFF
--- a/src/components/dropdown/__snapshots__/dropdown.stories.ts.snap
+++ b/src/components/dropdown/__snapshots__/dropdown.stories.ts.snap
@@ -106,7 +106,7 @@ exports[`Storyshots components|m-dropdown default 1`] = `
 
 exports[`Storyshots components|m-dropdown filterable 1`] = `
 <div
-  class="m-dropdown m--is-filterable"
+  class="m-dropdown m--has-placeholder-icon"
   placeholder-icon-name="m-svg__search"
   style="width: 100%; max-width: 288px;"
 >
@@ -222,7 +222,7 @@ exports[`Storyshots components|m-dropdown filterable 1`] = `
 
 exports[`Storyshots components|m-dropdown filterable and placeholder 1`] = `
 <div
-  class="m-dropdown m--is-filterable"
+  class="m-dropdown"
   placeholder-icon-name="m-svg__search"
   style="width: 100%; max-width: 288px;"
 >
@@ -257,19 +257,7 @@ exports[`Storyshots components|m-dropdown filterable and placeholder 1`] = `
         <div
           class="m-input-style__left-content"
         >
-          <svg
-            aria-hidden="true"
-            class="m-icon m-dropdown__placeholder-icon"
-            height="16px"
-            width="16px"
-          >
-            <!---->
-             
-            <use
-              aria-hidden="true"
-              class=""
-            />
-          </svg>
+          <!---->
            
           <input
             aria-controls="mDropdown-uuid-controls"

--- a/src/components/dropdown/dropdown.html
+++ b/src/components/dropdown/dropdown.html
@@ -2,7 +2,7 @@
      :class="{ 'm--is-open': open,
                'm--is-disabled': isDisabled,
                'm--is-waiting': isWaiting,
-               'm--is-filterable': filterable,
+               'm--has-placeholder-icon': hasPlaceholderIcon,
                'm--has-validation-message': hasValidationMessage }"
      :style="{ width: inputWidth, maxWidth: inputMaxWidth }"
      ref="mDropdown">

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -22,7 +22,7 @@ $m-dropdown--margin: $m-padding--xs !default;
         }
     }
 
-    &.m--is-filterable {
+    &.m--has-placeholder-icon {
         .m-dropdown__input {
             &::placeholder {
                 padding-left: calc(#{$m-spacing} + #{$m-spacing--xs});

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -536,7 +536,21 @@ export class MDropdown extends BaseDropdown implements MDropdownInterface {
     }
 
     private get hasPlaceholderIcon(): boolean {
-        return this.filterable && this.selectedText === '';
+        if (UserAgentUtil.isEdge() && !UserAgentUtil.isBlink()) {
+            return this.filterable && this.selectedText === '' && this.isEdgeSupport;
+        } else if (UserAgentUtil.isGecko() && !UserAgentUtil.isBlink()) {
+            return this.filterable && this.selectedText === '' && this.isFirefoxSupport;
+        } else {
+            return this.filterable && this.selectedText === '';
+        }
+    }
+
+    private get isEdgeSupport(): boolean {
+        return UserAgentUtil.isEdge() && this.placeholder === '' || this.placeholder === undefined;
+    }
+
+    private get isFirefoxSupport(): boolean {
+        return UserAgentUtil.isGecko() && this.placeholder === '' || this.placeholder === undefined;
     }
 
 }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Impossible de mettre un padding sur le pseudo élément ::placeholder, onn doit donc cacher l'icône sur ses navigateurs
- [x] Include links to issues
[MODUL-1013](https://jira.dti.ulaval.ca/browse/MODUL-1013)
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->
