### PR TITLE
MODUL-1019 : Supprimer le padding-bottom du m-accordion avec le skin="light"

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -170,7 +170,7 @@ $m-accordion--color-default: $m-color--interactive !default;
         }
 
         &.m--is-left {
-            margin-right: $m-margin;
+            margin-right: $m-spacing;
         }
 
         .m-accordion.m--is-dark.m--has-icon-left &,
@@ -198,7 +198,7 @@ $m-accordion--color-default: $m-color--interactive !default;
             &.m-accordion-enter,
             &.m-accordion-leave-to {
                 .m-accordion__body {
-                    transform: translate3d(0, $m-margin--l, 0);
+                    transform: translate3d(0, $m-spacing--l, 0);
                     opacity: 0;
                 }
             }
@@ -244,16 +244,15 @@ $m-accordion--color-default: $m-color--interactive !default;
             }
 
             .m-accordion.m--is-light > .m-accordion__body-wrap > & {
-                padding-top: $m-margin--s;
-                padding-bottom: $m-margin;
+                padding-top: $m-spacing--s;
             }
 
             .m-accordion.m--is-light.m--has-icon-left > .m-accordion__body-wrap > & {
-                padding-left: 32px; // Magic number
+                padding-left: 36px; // Magic number
             }
 
             .m-accordion.m--is-light.m--has-icon-left.m--has-icon-large > .m-accordion__body-wrap > & {
-                padding-left: 36px; // Magic number
+                padding-left: 40px; // Magic number
             }
 
             .m-error-technical-difficulty & {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
* Supprimer le padding-bottom du corps du m-accordion avec le skin="light"
* Aligner le contenu du corps de l'accordéon avec le titre (contenu de l'entête) de l'accordéon
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1019

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
The padding-bottom of m-accordion body is remove when skin="light".
- [ ] Other info

