### PR TITLE
MODUL-1047 - Ajout des icônes m-svg__remove-circle et m-svg__remove-circle-filled

### DIFF
--- a/src/assets/icons/sprites-default.svg
+++ b/src/assets/icons/sprites-default.svg
@@ -765,6 +765,19 @@
             <polyline points="2.3,11.6 0.5,9.7 2.3,11.6 4.3,9.8"/>
         </g>
     </symbol>
+    <symbol id="m-svg__remove-assignation" viewBox="-1 -1 26 26">
+        <path fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5" stroke-linecap="round" d="M20.999 2.254l2.25 3h-7.5M21 8.254l2.25-3"/>
+        <circle fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5" cx="6.75" cy="3.754" r="3" />
+        <path fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5" d="M6.75 7.5a6 6 0 0 0-6 6v2.25a1.5 1.5 0 0 0 1.5 1.5h1.5v4.5a1.5 1.5 0 0 0 1.5 1.5h3a1.5 1.5 0 0 0 1.5-1.5v-4.5h1.5a1.5 1.5 0 0 0 1.5-1.5V13.5a6 6 0 0 0-6-6z"/>    </symbol>
+    </symbol>
+    <symbol id="m-svg__remove-circle" viewBox="0 0 24 24">
+        <circle stroke="currentColor" fill="transparent" cx="12" cy="12" r="11.5"/>
+        <line stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" x1="7" y1="12" x2="17" y2="12"/>
+    </symbol>
+    <symbol id="m-svg__remove-circle-filled" viewBox="0 0 24 24">
+        <circle fill="currentColor" cx="12" cy="12" r="12"/>
+        <polyline fill="#ffffff" points="16,13 8,13 8,11 16,11 "/>
+    </symbol>
     <symbol id="m-svg__right-answer" viewBox="-1 -1 26 26">
         <polyline fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
             2,13.3 7.4,18.7 22,5.3 "/>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Ajouter 2 icône pour retirer avec un cercle remplie ou vide
- [x] Include links to issues
[MODUL-1047](https://jira.dti.ulaval.ca/browse/MODUL-1047)
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->