### PR TITLE
MODUL-1080 : Ajouter l'attribut HTML max-length sur le <textarea> contenu à l'intérieur du <m-textfield>

### DIFF
--- a/src/components/character-count/__snapshots__/character-count.spec.ts.snap
+++ b/src/components/character-count/__snapshots__/character-count.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MCharacterCount should render correctly 1`] = `""`;
+exports[`MCharacterCount should render correctly 1`] = `<div class="m-character-count"></div>`;
 
 exports[`MCharacterCount should render correctly when maxLength prop is set 1`] = `
 <div class="m-character-count">

--- a/src/components/character-count/character-count.html
+++ b/src/components/character-count/character-count.html
@@ -1,7 +1,7 @@
-<m-accordion-transition :transition="transition">
-    <div class="m-character-count"
-         v-if="hasCounter">
-        <div class="m-character-count__wrap"
+<div class="m-character-count">
+    <m-accordion-transition :transition="transition">
+        <div v-if="hasCounter"
+             class="m-character-count__wrap"
              aria-hidden="true"><span>{{ valueLength }}</span>/{{ maxLength }}</div>
-    </div>
-</m-accordion-transition>
+    </m-accordion-transition>
+</div>

--- a/src/components/character-count/character-count.ts
+++ b/src/components/character-count/character-count.ts
@@ -27,7 +27,7 @@ export class MCharacterCount extends Vue {
     @Prop({ default: true })
     public transition: boolean;
 
-    private get hasCounter(): boolean {
+    public get hasCounter(): boolean {
         return this.maxLength > 0 && this.valueLength >= Math.max(0, Math.min(this.threshold, this.maxLength));
     }
 }

--- a/src/components/form/__snapshots__/form.stories.ts.snap
+++ b/src/components/form/__snapshots__/form.stories.ts.snap
@@ -3960,7 +3960,11 @@ exports[`Storyshots components|m-form/rules required and 20 characters max 1`] =
           <!---->
         </div>
          
-        <!---->
+        <div
+          class="m-character-count m-textfield__validation__character-count"
+        >
+          <!---->
+        </div>
       </div>
     </div>
      

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -53,7 +53,6 @@
                            v-if="characterCount"
                            :value-length="valueLength"
                            :max-length="maxLength"
-                           :threshold="characterCountThreshold"
-                           :transition="hasCounterTransition"></m-character-count>
+                           :threshold="characterCountThreshold"></m-character-count>
     </div>
 </div>

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -1,7 +1,6 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
-
 import TextareaAutoHeightPlugin from '../../directives/textarea-auto-height/textarea-auto-height';
 import { ElementQueries } from '../../mixins/element-queries/element-queries';
 import { InputLabel } from '../../mixins/input-label/input-label';
@@ -10,11 +9,12 @@ import { InputState } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
 import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
+import CharacterCountPlugin from '../character-count/character-count';
 import { TEXTAREA_NAME } from '../component-names';
 import InputStyle from '../input-style/input-style';
 import ValidationMesagePlugin from '../validation-message/validation-message';
 import WithRender from './textarea.html?style=./textarea.scss';
-import CharacterCountPlugin from '../character-count/character-count';
+
 
 @WithRender
 @Component({
@@ -54,10 +54,6 @@ export class MTextarea extends ModulVue implements InputManagementData {
 
     private get isTextareaValid(): boolean {
         return this.as<InputState>().isValid;
-    }
-
-    private get hasCounterTransition(): boolean {
-        return !this.as<InputState>().hasErrorMessage;
     }
 }
 

--- a/src/components/textfield/__snapshots__/textfield.stories.ts.snap
+++ b/src/components/textfield/__snapshots__/textfield.stories.ts.snap
@@ -1234,6 +1234,7 @@ exports[`Storyshots components|m-textfield word-wrap 1`] = `
           <textarea
             class="m-textfield__input"
             id="mTextfield-uuid"
+            maxlength="Infinity"
             rows="1"
           />
            
@@ -1342,7 +1343,11 @@ exports[`Storyshots components|m-textfield/Counter all props 1`] = `
         <!---->
       </div>
        
-      <!---->
+      <div
+        class="m-character-count m-textfield__validation__character-count"
+      >
+        <!---->
+      </div>
     </div>
   </div>
    
@@ -1867,6 +1872,125 @@ exports[`Storyshots components|m-textfield/Counter max-length="20" 1`] = `
       style="color: red;"
     >
       false
+    </span>
+  </p>
+</div>
+`;
+
+exports[`Storyshots components|m-textfield/Counter max-length="200" and :word-wrap="true" 1`] = `
+<div>
+  <div
+    class="m-textfield m--has-word-wrap m--is-type-text"
+    style="width: 100%; max-width: 288px;"
+  >
+    <div
+      class="m-input-style m--has-value m--is-tag-default"
+    >
+      <div
+        class="m-input-style__content"
+        style="margin-top: 10px;"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__body"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__left-content"
+          >
+            <!---->
+             
+            <!---->
+             
+            <textarea
+              class="m-textfield__input"
+              id="mTextfield-uuid"
+              maxlength="200"
+              placeholder="Enter a value"
+              rows="1"
+            />
+             
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__right-content"
+          />
+           
+          <!---->
+        </div>
+      </div>
+    </div>
+     
+    <div
+      class="m-textfield__validation"
+    >
+      <div
+        class="m-validation-message m-textfield__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <br />
+   
+  <p>
+    <span
+      style="color: blue;"
+    >
+      max-length
+    </span>
+     is equal to 
+    <span
+      style="color: red;"
+    >
+      "200"
+    </span>
+  </p>
+   
+  <p>
+    <span
+      style="color: blue;"
+    >
+      length-overflow
+    </span>
+     is equal to 
+    <span
+      style="color: red;"
+    >
+      false
+    </span>
+  </p>
+   
+  <p>
+    <span
+      style="color: blue;"
+    >
+      word-wrap
+    </span>
+     is equal to 
+    <span
+      style="color: red;"
+    >
+      true
     </span>
   </p>
 </div>

--- a/src/components/textfield/textfield.html
+++ b/src/components/textfield/textfield.html
@@ -78,6 +78,7 @@
                   :disabled="isDisabled || isWaiting"
                   :placeholder="placeholder"
                   :readonly="isReadonly"
+                  :maxlength="maxLengthNumber"
                   @focus="onFocus"
                   @blur="onBlur"
                   @change="onChange"
@@ -103,7 +104,6 @@
                            class="m-textfield__validation__character-count"
                            :value-length="valueLength"
                            :max-length="maxLength"
-                           :threshold="characterCountThreshold"
-                           :transition="hasCounterTransition"></m-character-count>
+                           :threshold="characterCountThreshold"></m-character-count>
     </div>
 </div>

--- a/src/components/textfield/textfield.stories.ts
+++ b/src/components/textfield/textfield.stories.ts
@@ -181,6 +181,16 @@ storiesOf(`${componentsHierarchyRootSeparator}${TEXTFIELD_NAME}/Counter`, module
                         <p><span style="color: blue">length-overflow</span> is equal to <span style="color: red">false</span></p>
                    </div>`
     }))
+    .add('max-length="200" and :word-wrap="true"', () => ({
+        template: `<div>
+                        <m-textfield :word-wrap="true" :length-overflow="false" placeholder="Enter a value" max-length="200"
+                        value="This is a value"></m-textfield>
+                        <br>
+                        <p><span style="color: blue">max-length</span> is equal to <span style="color: red">"200"</span></p>
+                        <p><span style="color: blue">length-overflow</span> is equal to <span style="color: red">false</span></p>
+                        <p><span style="color: blue">word-wrap</span> is equal to <span style="color: red">true</span></p>
+                   </div>`
+    }))
     .add('character-count', () => ({
         template: `<div>
                         <m-textfield :character-count="true" placeholder="Enter a value" max-length="20"

--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -172,10 +172,6 @@ export class MTextfield extends ModulVue implements InputManagementData {
         return this.type === MTextfieldType.Search;
     }
 
-    private get hasCounterTransition(): boolean {
-        return !this.as<InputState>().hasErrorMessage;
-    }
-
     private resetModel(): void {
         this.$emit('input', '');
     }


### PR DESCRIPTION
…tenu à l'intérieur du <m-textfield>

## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
* Ajouter l'attribut HTML max-length sur le <textarea> contenu à l'intérieur du `m-textfield`
* Améliorer l'animation d'apparition (accordion-transition) du composant `m-character-count`
* Supprimer le getter `hasCounterTransition()` du `m-textfield` et du `m-textarea`. L'animation du `m-character-count` doit toujours être active même lorsque le champ est en erreur.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1080

