### PR TITLE
MODUL-1086 - Changer font-size des titres en mobile

### DIFF
--- a/src/styles/variables/_var-font.scss
+++ b/src/styles/variables/_var-font.scss
@@ -24,11 +24,11 @@ $m-font-size--h4: 24px !default;
 $m-font-size--h5: 20px !default;
 $m-font-size--h6: 16px !default;
 
-$m-font-size--mobile-h1: 28px !default;
+$m-font-size--mobile-h1: 26px !default;
 $m-font-size--mobile-h2: 24px !default;
-$m-font-size--mobile-h3: 20px !default;
-$m-font-size--mobile-h4: 16px !default;
-$m-font-size--mobile-h5: 16px !default;
+$m-font-size--mobile-h3: 22px !default;
+$m-font-size--mobile-h4: 20px !default;
+$m-font-size--mobile-h5: 18px !default;
 $m-font-size--mobile-h6: 16px !default;
 
 // ======================================================================


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Avec l'arrivée des titres dans le RTE, on va avoir beaucoup d'occurences de h4-5-6. Il devient donc important de différencier chaque niveau, même en mobile (actuellement H4-5-6 sont identique à 16px et une graisse de 500).
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1086
- [x] Include this section in the release notes
En mobile, la grosseur des titres a été modifié.
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Other info


<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
