### PR TITLE
MODUL-1088: Ajouter un entête à la fenêtre du datepicker en version mobile

### DIFF
--- a/src/components/datepicker/datepicker.html
+++ b/src/components/datepicker/datepicker.html
@@ -65,6 +65,9 @@
              placement="bottom"
              @open="onOpen"
              @close="onClose">
+        <h2 v-if="label && isMqMaxS"
+            class="m-datepicker__header-label"
+            slot="header">{{label}}</h2>
         <m-calendar :min-date="minDateString"
                     :max-date="maxDateString"
                     :show-month-before-after="false"

--- a/src/components/datepicker/datepicker.scss
+++ b/src/components/datepicker/datepicker.scss
@@ -17,4 +17,13 @@ $m-datepicker--item-dimension: $m-touch-size !default;
         margin-top: $m-margin--xs;
         transition: margin-top $m-transition-duration ease;
     }
+
+    &__header-label {
+        margin: 0;
+        padding: $m-padding--s $m-padding;
+        font-size: $m-font-size--s;
+        font-weight: $m-font-weight--semi-bold;
+        color: $m-color--white;
+        background: $m-color--interactive;
+    }
 }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

- [x] Provide a small description of the changes introduced by this PR
Ajouter le label du datepicker dans l'entête de la fenêtre en version mobile (voir l'image du billet [MODUL-1088](https://jira.dti.ulaval.ca/browse/MODUL-1088))
**Raison de l'ajout de l'entête**
Dans le sélecteur de période en version mobile lorsque la fenêtre est ouverte, il est difficile de savoir si nous sélectionnons la date de début ou la date de fin.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1088

<!--
- [ ] Include this section in the release notes

- [ ] Other info
-->
