### PR TITLE
MODUL-1091: Supprimer la marge à droite du m-add lorsqu'il n'y a aucun contenu

### DIFF
--- a/src/components/accordion-group/__snapshots__/accordion-group.stories.ts.snap
+++ b/src/components/accordion-group/__snapshots__/accordion-group.stories.ts.snap
@@ -2271,7 +2271,7 @@ exports[`Storyshots components|m-accordion-group/secondary-content m-link 1`] = 
       class="m-accordion-group__secondary-content"
     >
       <a
-        class="m-link m--is-unvisited m--is-button m--has-left-icon"
+        class="m-link m--is-unvisited m--is-button m--has-left-icon m--has-content"
         href="#"
         tabindex="0"
       >

--- a/src/components/add/__snapshots__/add.stories.ts.snap
+++ b/src/components/add/__snapshots__/add.stories.ts.snap
@@ -30,7 +30,7 @@ exports[`Storyshots components|m-add default 1`] = `
 
 exports[`Storyshots components|m-add disabled 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--is-disabled m--is-button m--has-left-icon"
+  class="m-link m-add m--is-unvisited m--is-disabled m--is-button m--has-left-icon m--has-content"
   href="#"
   tabindex="-1"
 >
@@ -60,7 +60,7 @@ exports[`Storyshots components|m-add disabled 1`] = `
 
 exports[`Storyshots components|m-add icon-position-left 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--is-button m--has-left-icon"
+  class="m-link m-add m--is-unvisited m--is-button m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -90,7 +90,7 @@ exports[`Storyshots components|m-add icon-position-left 1`] = `
 
 exports[`Storyshots components|m-add icon-position-right 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--is-button m--has-right-icon"
+  class="m-link m-add m--is-unvisited m--is-button m--has-right-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -120,7 +120,7 @@ exports[`Storyshots components|m-add icon-position-right 1`] = `
 
 exports[`Storyshots components|m-add icon-size 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--is-button m--has-left-icon"
+  class="m-link m-add m--is-unvisited m--is-button m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -150,7 +150,7 @@ exports[`Storyshots components|m-add icon-size 1`] = `
 
 exports[`Storyshots components|m-add underline 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--no-underline m--is-button m--has-left-icon"
+  class="m-link m-add m--is-unvisited m--no-underline m--is-button m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -180,7 +180,7 @@ exports[`Storyshots components|m-add underline 1`] = `
 
 exports[`Storyshots components|m-add/skin default 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--is-button m--has-left-icon"
+  class="m-link m-add m--is-unvisited m--is-button m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -213,7 +213,7 @@ exports[`Storyshots components|m-add/skin light 1`] = `
   style="background-color: gray; margin: 0px;"
 >
   <a
-    class="m-link m-add m--is-unvisited m--is-button m--is-skin-light m--has-left-icon"
+    class="m-link m-add m--is-unvisited m--is-button m--is-skin-light m--has-left-icon m--has-content"
     href="#"
     tabindex="0"
   >
@@ -244,7 +244,7 @@ exports[`Storyshots components|m-add/skin light 1`] = `
 
 exports[`Storyshots components|m-add/skin text 1`] = `
 <a
-  class="m-link m-add m--is-unvisited m--is-button m--is-skin-text m--has-left-icon"
+  class="m-link m-add m--is-unvisited m--is-button m--is-skin-text m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >

--- a/src/components/error-message/__snapshots__/error-message.spec.ts.snap
+++ b/src/components/error-message/__snapshots__/error-message.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`MErrorMessage given error should render correctly expanded 1`] = `
     <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
     <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
     <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
-  </div> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
+  </div> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
 </div>
 `;
 
@@ -42,7 +42,7 @@ exports[`MErrorMessage given error should render correctly expanded with stack t
     <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
     <div class="m-error-message__stacktrace"><pre></pre>
     </div>
-  </div> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
+  </div> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
 </div>
 `;
 
@@ -64,7 +64,7 @@ exports[`MErrorMessage given error with stack trace should render correctly expa
     <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
     <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
     <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
-  </div> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
+  </div> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
 </div>
 `;
 
@@ -88,7 +88,7 @@ exports[`MErrorMessage given error with stack trace should render correctly expa
     <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
     <div class="m-error-message__stacktrace"><pre>This is a stack trace</pre>
     </div>
-  </div> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
+  </div> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
 </div>
 `;
 
@@ -110,7 +110,7 @@ exports[`MErrorMessage should render correctly collapsed 1`] = `
     <div id="uuid" aria-controls="uuid-controls" tabindex="0" role="tab" class="m-accordion__header m--has-padding">
       <div class="m-accordion__header__content"><span class="m-i18n">Détails de l'erreur</span> <span class="m-i18n m-accordion__hidden">m-accordion:open</span> </div> <span title="m-accordion:open" aria-hidden="true" class="m-plus m-accordion__header-icon m--is-skin-default m--has-border m--is-left"></span>
     </div>
-  </article> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
+  </article> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
 </div>
 `;
 
@@ -132,6 +132,6 @@ exports[`MErrorMessage should render correctly expanded 1`] = `
     <p><strong><span class="m-i18n">Navigateur</span>: </strong>modul-user-agent</p>
     <p><strong><span class="m-i18n">No référence de l'erreur</span>: </strong>123456879</p>
     <p>Elle a eu lieu le &lt;strong&gt;2018-01-02&lt;/strong&gt; à &lt;strong&gt;00:01:02&lt;/strong&gt;</p>
-  </div> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
+  </div> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text"><span class="m-i18n">Pour obtenir de l'aide, contactez le soutien technique</span></span> </a>
 </div>
 `;

--- a/src/components/error-pages/error-access-denied/__snapshots__/error-access-denied.stories.ts.snap
+++ b/src/components/error-pages/error-access-denied/__snapshots__/error-access-denied.stories.ts.snap
@@ -149,7 +149,7 @@ exports[`Storyshots components|m-error-access-denied links 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.ulaval.ca"
             tabindex="0"
             target="_blank"
@@ -183,7 +183,7 @@ exports[`Storyshots components|m-error-access-denied links 1`] = `
         </li>
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.google.com"
             tabindex="0"
             target="_blank"

--- a/src/components/error-pages/error-browser-not-supported/__snapshots__/error-browser-not-supported.stories.ts.snap
+++ b/src/components/error-pages/error-browser-not-supported/__snapshots__/error-browser-not-supported.stories.ts.snap
@@ -245,7 +245,7 @@ exports[`Storyshots components|m-error-browser-not-supported linksMobile 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.ulaval.ca"
             tabindex="0"
             target="_blank"
@@ -279,7 +279,7 @@ exports[`Storyshots components|m-error-browser-not-supported linksMobile 1`] = `
         </li>
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.google.com"
             tabindex="0"
             target="_blank"

--- a/src/components/error-pages/error-config-not-supported/__snapshots__/error-config-not-supported.stories.ts.snap
+++ b/src/components/error-pages/error-config-not-supported/__snapshots__/error-config-not-supported.stories.ts.snap
@@ -159,7 +159,7 @@ exports[`Storyshots components|m-error-config-not-supported links 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.ulaval.ca"
             tabindex="0"
             target="_blank"
@@ -193,7 +193,7 @@ exports[`Storyshots components|m-error-config-not-supported links 1`] = `
         </li>
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.google.com"
             tabindex="0"
             target="_blank"

--- a/src/components/error-pages/error-cookies-not-supported/__snapshots__/error-cookies-not-supported.stories.ts.snap
+++ b/src/components/error-pages/error-cookies-not-supported/__snapshots__/error-cookies-not-supported.stories.ts.snap
@@ -47,7 +47,7 @@ exports[`Storyshots components|m-error-cookies-not-supported default 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -134,7 +134,7 @@ exports[`Storyshots components|m-error-cookies-not-supported hints 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -215,7 +215,7 @@ exports[`Storyshots components|m-error-cookies-not-supported links 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.ulaval.ca"
             tabindex="0"
             target="_blank"
@@ -249,7 +249,7 @@ exports[`Storyshots components|m-error-cookies-not-supported links 1`] = `
         </li>
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.google.com"
             tabindex="0"
             target="_blank"
@@ -333,7 +333,7 @@ exports[`Storyshots components|m-error-cookies-not-supported title 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""

--- a/src/components/error-pages/error-page-not-found/__snapshots__/error-page-not-found.stories.ts.snap
+++ b/src/components/error-pages/error-page-not-found/__snapshots__/error-page-not-found.stories.ts.snap
@@ -47,7 +47,7 @@ exports[`Storyshots components|m-error-page-not-found default 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -134,7 +134,7 @@ exports[`Storyshots components|m-error-page-not-found hints 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -215,7 +215,7 @@ exports[`Storyshots components|m-error-page-not-found links 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.ulaval.ca"
             tabindex="0"
             target="_blank"
@@ -249,7 +249,7 @@ exports[`Storyshots components|m-error-page-not-found links 1`] = `
         </li>
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.google.com"
             tabindex="0"
             target="_blank"
@@ -333,7 +333,7 @@ exports[`Storyshots components|m-error-page-not-found title 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""

--- a/src/components/error-pages/error-technical-difficulty/__snapshots__/error-technical-difficulty.stories.ts.snap
+++ b/src/components/error-pages/error-technical-difficulty/__snapshots__/error-technical-difficulty.stories.ts.snap
@@ -92,7 +92,7 @@ exports[`Storyshots components|m-error-technical-difficulty Error 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -218,7 +218,7 @@ exports[`Storyshots components|m-error-technical-difficulty default 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -344,7 +344,7 @@ exports[`Storyshots components|m-error-technical-difficulty errorDate (5 days be
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -470,7 +470,7 @@ exports[`Storyshots components|m-error-technical-difficulty errorReferenceNumber
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -597,7 +597,7 @@ exports[`Storyshots components|m-error-technical-difficulty hints 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -723,7 +723,7 @@ exports[`Storyshots components|m-error-technical-difficulty links 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.ulaval.ca"
             tabindex="0"
             target="_blank"
@@ -757,7 +757,7 @@ exports[`Storyshots components|m-error-technical-difficulty links 1`] = `
         </li>
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="http://www.google.com"
             tabindex="0"
             target="_blank"
@@ -888,7 +888,7 @@ exports[`Storyshots components|m-error-technical-difficulty showStackTrace 1`] =
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""
@@ -1012,7 +1012,7 @@ exports[`Storyshots components|m-error-technical-difficulty title 1`] = `
       >
         <li>
           <a
-            class="m-link m-message-page__link m--has-left-icon"
+            class="m-link m-message-page__link m--has-left-icon m--has-content"
             href="\\\\"
             tabindex="0"
             target=""

--- a/src/components/link/__snapshots__/link.stories.ts.snap
+++ b/src/components/link/__snapshots__/link.stories.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Storyshots components|m-link default 1`] = `
 <a
-  class="m-link"
+  class="m-link m--has-content"
   href="#"
   tabindex="0"
 >
@@ -20,7 +20,7 @@ exports[`Storyshots components|m-link default 1`] = `
 
 exports[`Storyshots components|m-link disabled 1`] = `
 <a
-  class="m-link m--is-disabled"
+  class="m-link m--is-disabled m--has-content"
   tabindex="-1"
 >
   <!---->
@@ -37,7 +37,7 @@ exports[`Storyshots components|m-link disabled 1`] = `
 
 exports[`Storyshots components|m-link icon 1`] = `
 <a
-  class="m-link m--has-left-icon"
+  class="m-link m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -67,7 +67,7 @@ exports[`Storyshots components|m-link icon 1`] = `
 
 exports[`Storyshots components|m-link icon-name 1`] = `
 <a
-  class="m-link m--has-left-icon"
+  class="m-link m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -97,7 +97,7 @@ exports[`Storyshots components|m-link icon-name 1`] = `
 
 exports[`Storyshots components|m-link icon-position="right" 1`] = `
 <a
-  class="m-link m--has-right-icon"
+  class="m-link m--has-right-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -127,7 +127,7 @@ exports[`Storyshots components|m-link icon-position="right" 1`] = `
 
 exports[`Storyshots components|m-link icon-size 1`] = `
 <a
-  class="m-link m--has-left-icon"
+  class="m-link m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -157,7 +157,7 @@ exports[`Storyshots components|m-link icon-size 1`] = `
 
 exports[`Storyshots components|m-link skin="default" 1`] = `
 <a
-  class="m-link"
+  class="m-link m--has-content"
   href="#"
   tabindex="0"
 >
@@ -175,7 +175,7 @@ exports[`Storyshots components|m-link skin="default" 1`] = `
 
 exports[`Storyshots components|m-link tabindex="1" 1`] = `
 <a
-  class="m-link"
+  class="m-link m--has-content"
   href="#"
   tabindex="1"
 >
@@ -193,7 +193,7 @@ exports[`Storyshots components|m-link tabindex="1" 1`] = `
 
 exports[`Storyshots components|m-link target 1`] = `
 <a
-  class="m-link m--has-left-icon"
+  class="m-link m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
   target="self"
@@ -224,7 +224,7 @@ exports[`Storyshots components|m-link target 1`] = `
 
 exports[`Storyshots components|m-link underline 1`] = `
 <a
-  class="m-link m--no-underline"
+  class="m-link m--no-underline m--has-content"
   href="#"
   tabindex="0"
 >
@@ -242,7 +242,7 @@ exports[`Storyshots components|m-link underline 1`] = `
 
 exports[`Storyshots components|m-link unvisited 1`] = `
 <a
-  class="m-link m--is-unvisited"
+  class="m-link m--is-unvisited m--has-content"
   href="#"
   tabindex="0"
 >
@@ -260,7 +260,7 @@ exports[`Storyshots components|m-link unvisited 1`] = `
 
 exports[`Storyshots components|m-link url 1`] = `
 <a
-  class="m-link"
+  class="m-link m--has-content"
   href="http://www.google.ca"
   tabindex="0"
 >
@@ -278,7 +278,7 @@ exports[`Storyshots components|m-link url 1`] = `
 
 exports[`Storyshots components|m-link/mode default (router-link) 1`] = `
 <a
-  class="m-link"
+  class="m-link m--has-content"
   href="#components/m-link"
   tabindex="0"
 >
@@ -296,7 +296,7 @@ exports[`Storyshots components|m-link/mode default (router-link) 1`] = `
 
 exports[`Storyshots components|m-link/mode mode="button" 1`] = `
 <a
-  class="m-link m--is-unvisited m--is-button"
+  class="m-link m--is-unvisited m--is-button m--has-content"
   href="#"
   tabindex="0"
 >
@@ -314,7 +314,7 @@ exports[`Storyshots components|m-link/mode mode="button" 1`] = `
 
 exports[`Storyshots components|m-link/mode mode="link 1`] = `
 <a
-  class="m-link"
+  class="m-link m--has-content"
   href="http://www.google.ca"
   tabindex="0"
 >
@@ -333,7 +333,7 @@ exports[`Storyshots components|m-link/mode mode="link 1`] = `
 exports[`Storyshots components|m-link/skin="light" default 1`] = `
 <div>
   <a
-    class="m-link m--is-skin-light"
+    class="m-link m--is-skin-light m--has-content"
     href="#"
     tabindex="0"
   >
@@ -353,7 +353,7 @@ exports[`Storyshots components|m-link/skin="light" default 1`] = `
 exports[`Storyshots components|m-link/skin="light" icon 1`] = `
 <div>
   <a
-    class="m-link m--is-skin-light m--has-left-icon"
+    class="m-link m--is-skin-light m--has-left-icon m--has-content"
     href="#"
     tabindex="0"
   >
@@ -385,7 +385,7 @@ exports[`Storyshots components|m-link/skin="light" icon 1`] = `
 exports[`Storyshots components|m-link/skin="light" icon-name="m-svg__clock" 1`] = `
 <div>
   <a
-    class="m-link m--is-skin-light m--has-left-icon"
+    class="m-link m--is-skin-light m--has-left-icon m--has-content"
     href="#"
     tabindex="0"
   >
@@ -417,7 +417,7 @@ exports[`Storyshots components|m-link/skin="light" icon-name="m-svg__clock" 1`] 
 exports[`Storyshots components|m-link/skin="light" icon-position="right" 1`] = `
 <div>
   <a
-    class="m-link m--is-skin-light m--has-right-icon"
+    class="m-link m--is-skin-light m--has-right-icon m--has-content"
     href="#"
     tabindex="0"
   >
@@ -449,7 +449,7 @@ exports[`Storyshots components|m-link/skin="light" icon-position="right" 1`] = `
 exports[`Storyshots components|m-link/skin="light" icon-size="20px" 1`] = `
 <div>
   <a
-    class="m-link m--is-skin-light m--has-left-icon"
+    class="m-link m--is-skin-light m--has-left-icon m--has-content"
     href="#"
     tabindex="0"
   >
@@ -480,7 +480,7 @@ exports[`Storyshots components|m-link/skin="light" icon-size="20px" 1`] = `
 
 exports[`Storyshots components|m-link/skin="text" default 1`] = `
 <a
-  class="m-link m--is-skin-text"
+  class="m-link m--is-skin-text m--has-content"
   href="#"
   tabindex="0"
 >
@@ -498,7 +498,7 @@ exports[`Storyshots components|m-link/skin="text" default 1`] = `
 
 exports[`Storyshots components|m-link/skin="text" icon 1`] = `
 <a
-  class="m-link m--is-skin-text m--has-left-icon"
+  class="m-link m--is-skin-text m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -528,7 +528,7 @@ exports[`Storyshots components|m-link/skin="text" icon 1`] = `
 
 exports[`Storyshots components|m-link/skin="text" icon-name="m-svg__clock" 1`] = `
 <a
-  class="m-link m--is-skin-text m--has-left-icon"
+  class="m-link m--is-skin-text m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -558,7 +558,7 @@ exports[`Storyshots components|m-link/skin="text" icon-name="m-svg__clock" 1`] =
 
 exports[`Storyshots components|m-link/skin="text" icon-position="right" 1`] = `
 <a
-  class="m-link m--is-skin-text m--has-right-icon"
+  class="m-link m--is-skin-text m--has-right-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -588,7 +588,7 @@ exports[`Storyshots components|m-link/skin="text" icon-position="right" 1`] = `
 
 exports[`Storyshots components|m-link/skin="text" icon-size="20px" 1`] = `
 <a
-  class="m-link m--is-skin-text m--has-left-icon"
+  class="m-link m--is-skin-text m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >

--- a/src/components/link/link.html
+++ b/src/components/link/link.html
@@ -6,7 +6,8 @@
                            'm--is-skin-text': isSkinText,
                            'm--is-skin-light': isSkinLight,
                            'm--has-right-icon' : isIconPositionRight,
-                           'm--has-left-icon' : isIconPositionLeft }"
+                           'm--has-left-icon' : isIconPositionLeft,
+                           'm--has-content': $slots.default }"
                  :to="routerLinkUrl"
                  :target="target"
                  v-if="isRouterLink"
@@ -33,7 +34,8 @@
                  'm--is-skin-text': isSkinText,
                  'm--is-skin-light': isSkinLight,
                  'm--has-right-icon' : isIconPositionRight,
-                 'm--has-left-icon' : isIconPositionLeft }"
+                 'm--has-left-icon' : isIconPositionLeft,
+                 'm--has-content': $slots.default }"
        :href="propUrl"
        :target="target"
        @click="onClick"

--- a/src/components/link/link.scss
+++ b/src/components/link/link.scss
@@ -19,7 +19,7 @@
         align-items: center;
     }
 
-    &.m--has-right-icon {
+    &.m--has-right-icon.m--has-content {
         flex-direction: row-reverse;
 
         .m-link__icon {
@@ -27,7 +27,7 @@
         }
     }
 
-    &.m--has-left-icon {
+    &.m--has-left-icon.m--has-content {
         .m-link__icon {
             margin-right: $m-margin--s;
         }

--- a/src/components/page-not-found/__snapshots__/page-not-found.spec.ts.snap
+++ b/src/components/page-not-found/__snapshots__/page-not-found.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`MPageNotFound should render correctly 1`] = `
       </div>
     </div>
   </div>
-  <p>m-page-not-found:directions</p> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text">
+  <p>m-page-not-found:directions</p> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text">
         m-page-not-found:back-to-portal
     </span> </a>
 </div>
@@ -34,7 +34,7 @@ exports[`MPageNotFound should render correctly with back-to-label override 1`] =
       </div>
     </div>
   </div>
-  <p>m-page-not-found:directions</p> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text">
+  <p>m-page-not-found:directions</p> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text">
         Some back to label
     </span> </a>
 </div>

--- a/src/components/pagination/__snapshots__/pagination.stories.ts.snap
+++ b/src/components/pagination/__snapshots__/pagination.stories.ts.snap
@@ -56,7 +56,7 @@ exports[`Storyshots components|m-pagination default 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -75,7 +75,7 @@ exports[`Storyshots components|m-pagination default 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -94,7 +94,7 @@ exports[`Storyshots components|m-pagination default 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -122,7 +122,7 @@ exports[`Storyshots components|m-pagination default 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -220,7 +220,7 @@ exports[`Storyshots components|m-pagination items-per-page="14" 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -239,7 +239,7 @@ exports[`Storyshots components|m-pagination items-per-page="14" 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -258,7 +258,7 @@ exports[`Storyshots components|m-pagination items-per-page="14" 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -286,7 +286,7 @@ exports[`Storyshots components|m-pagination items-per-page="14" 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -384,7 +384,7 @@ exports[`Storyshots components|m-pagination loading 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button m--has-content"
           href="#"
           tabindex="-1"
         >
@@ -403,7 +403,7 @@ exports[`Storyshots components|m-pagination loading 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button m--has-content"
           href="#"
           tabindex="-1"
         >
@@ -422,7 +422,7 @@ exports[`Storyshots components|m-pagination loading 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button m--has-content"
           href="#"
           tabindex="-1"
         >
@@ -450,7 +450,7 @@ exports[`Storyshots components|m-pagination loading 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-disabled m--is-button m--has-content"
           href="#"
           tabindex="-1"
         >
@@ -539,7 +539,7 @@ exports[`Storyshots components|m-pagination value 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -567,7 +567,7 @@ exports[`Storyshots components|m-pagination value 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -595,7 +595,7 @@ exports[`Storyshots components|m-pagination value 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >
@@ -623,7 +623,7 @@ exports[`Storyshots components|m-pagination value 1`] = `
         class="m-pagination__item"
       >
         <a
-          class="m-link m-pagination__item--link m--is-unvisited m--is-button"
+          class="m-link m-pagination__item--link m--is-unvisited m--is-button m--has-content"
           href="#"
           tabindex="0"
         >

--- a/src/components/repeater/__snapshots__/repeater.stories.ts.snap
+++ b/src/components/repeater/__snapshots__/repeater.stories.ts.snap
@@ -142,7 +142,7 @@ exports[`Storyshots components|m-repeater With items (Custom item template) 1`] 
       class="m-repeater__footer"
     >
       <a
-        class="m-link m-add m--is-unvisited m--is-button m--has-left-icon"
+        class="m-link m-add m--is-unvisited m--is-button m--has-left-icon m--has-content"
         href="#"
         tabindex="0"
       >
@@ -200,7 +200,7 @@ exports[`Storyshots components|m-repeater With items (Custom row template) 1`] =
       class="m-repeater__footer m--is-slot-row"
     >
       <a
-        class="m-link m-add m--is-unvisited m--is-button m--has-left-icon"
+        class="m-link m-add m--is-unvisited m--is-button m--has-left-icon m--has-content"
         href="#"
         tabindex="0"
       >

--- a/src/components/session-expired/__snapshots__/session-expired.spec.ts.snap
+++ b/src/components/session-expired/__snapshots__/session-expired.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`MSessionExpired should render correctly 1`] = `
     </div>
   </div>
   <p><span class="m-i18n">m-session-expired:directions-1</span></p>
-  <p><span class="m-i18n">m-session-expired:directions-2</span></p> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text">
+  <p><span class="m-i18n">m-session-expired:directions-2</span></p> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text">
         m-session-expired:back-to-portal
     </span> </a>
 </div>
@@ -32,7 +32,7 @@ exports[`MSessionExpired should render correctly with back-to-label override 1`]
     </div>
   </div>
   <p><span class="m-i18n">m-session-expired:directions-1</span></p>
-  <p><span class="m-i18n">m-session-expired:directions-2</span></p> <a href="/" tabindex="0" class="m-link"> <span class="m-link__text">
+  <p><span class="m-i18n">m-session-expired:directions-2</span></p> <a href="/" tabindex="0" class="m-link m--has-content"> <span class="m-link__text">
         Some back to label
     </span> </a>
 </div>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Supprimer la marge à doite du m-add lorsqu'il n'y a aucun contenu (voir image du billet [MODUL-1091](https://jira.dti.ulaval.ca/browse/MODUL-1091)).
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1091

- [x] Breaking change UI
**m-add and m-link:** Delete margin-right of icon when the slots.default is undefined