### PR TITLE
MODUL-1092 - Ajouter un événement à la fin de l'animation de fermeture des fenêtres (mixin portal)

### DIFF
--- a/src/components/dropdown/dropdown.html
+++ b/src/components/dropdown/dropdown.html
@@ -93,8 +93,8 @@
              :lazy="false"
              @open="onOpen"
              @close="onClose"
-             @portal-content-visible="calculateFilterableListeHeight"
-             @portal-content-mounted="portalContentMounted">
+             @portal-after-open="calculateFilterableListeHeight"
+             @portal-mounted="portalMounted">
         <template slot="header"
                   v-if="isMqMaxS && (hasLabel || filterable)">
             <h2 class="m-dropdown__header__label"

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -245,7 +245,7 @@ export class MDropdown extends BaseDropdown implements MDropdownInterface {
         this.setInputWidth();
     }
 
-    private portalContentMounted(): void {
+    private portalMounted(): void {
         this.buildItemsMap();
 
         this.observer = new MutationObserver(() => {

--- a/src/components/file-upload/file-upload.html
+++ b/src/components/file-upload/file-upload.html
@@ -3,7 +3,7 @@
          :open.sync="propOpen"
          @open="onOpen"
          @close="onClose"
-         @portal-content-visible="onPortalContentVisible"
+         @portal-after-open="onPortalAfterOpen"
          :close-on-backdrop="false"
          :padding-body="false">
 

--- a/src/components/file-upload/file-upload.ts
+++ b/src/components/file-upload/file-upload.ts
@@ -144,7 +144,7 @@ export class MFileUpload extends ModulVue {
         }
     }
 
-    private onPortalContentVisible(): void {
+    private onPortalAfterOpen(): void {
         this.dropEvents.forEach((evt) => {
             this.$refs.modal.$refs.modalWrap.addEventListener(evt, defaultDragEvent);
         });

--- a/src/components/popper/popper.ts
+++ b/src/components/popper/popper.ts
@@ -153,7 +153,7 @@ export class MPopper extends ModulVue implements PortalMixinImpl {
         // mouseup will always be caught even if click is stopped.
         document.addEventListener('mouseup', this.onDocumentClick);
 
-        this.$on('portal-content-mounted', this.setPopperMutationObserver);
+        this.$on('portal-mounted', this.setPopperMutationObserver);
 
     }
 
@@ -163,7 +163,7 @@ export class MPopper extends ModulVue implements PortalMixinImpl {
 
         if (this.observer) { this.observer.disconnect(); }
 
-        this.$off('portal-content-mounted', this.setPopperMutationObserver);
+        this.$off('portal-mounted', this.setPopperMutationObserver);
 
         this.destroyPopper();
     }

--- a/src/components/popup/popup.html
+++ b/src/components/popup/popup.html
@@ -3,7 +3,7 @@
     <m-popper :open.sync="propOpen"
               @open="onOpen"
               @close="onClose"
-              @portal-content-visible="onPortalContentVisible"
+              @portal-after-open="onPortalAfterOpen"
               :disabled="disabled"
               :id="id"
               ref="popper"
@@ -30,7 +30,7 @@
               :background="background"
               :lazy="lazy"
               v-if="!isMqMaxS"
-              @portal-content-mounted="onPortalContentMounted">
+              @portal-mounted="onPortalMounted">
         <div slot="trigger"
              v-if="hasTriggerSlot">
             <slot name="trigger"></slot>
@@ -44,7 +44,7 @@
     <m-sidebar :open.sync="propOpen"
                @open="onOpen()"
                @close="onClose()"
-               @portal-content-visible="onPortalContentVisible"
+               @portal-after-open="onPortalAfterOpen"
                :close-on-backdrop="closeOnBackdrop"
                :disabled="disabled"
                :focus-management="focusManagement"
@@ -59,7 +59,7 @@
                :preload="preload"
                v-if="isMqMaxS"
                :lazy="lazy"
-               @portal-content-mounted="onPortalContentMounted">
+               @portal-mounted="onPortalMounted">
         <div slot="trigger"
              v-if="hasTriggerSlot">
             <slot name="trigger"></slot>

--- a/src/components/popup/popup.ts
+++ b/src/components/popup/popup.ts
@@ -106,12 +106,12 @@ export class MPopup extends ModulVue {
         return this.trigger || this.as<OpenTriggerMixin>().triggerHook || undefined;
     }
 
-    private onPortalContentMounted(): void {
-        this.$emit('portal-content-mounted');
+    private onPortalMounted(): void {
+        this.$emit('portal-mounted');
     }
 
-    private onPortalContentVisible(): void {
-        this.$emit('portal-content-visible');
+    private onPortalAfterOpen(): void {
+        this.$emit('portal-after-open');
     }
 
     private get hasTriggerSlot(): boolean {

--- a/src/mixins/portal/portal.ts
+++ b/src/mixins/portal/portal.ts
@@ -121,7 +121,7 @@ export class Portal extends ModulVue implements PortalMixin {
         }
         if (this.$modul.peekElement() === this.stackId) {
             if (this.$listeners && this.$listeners.beforeClose) {
-                this.$emit('beforeClose', (close: boolean) => {
+                this.$emit('portal-before-close', (close: boolean) => {
                     this.propOpen = !close;
                 });
             } else {
@@ -180,12 +180,12 @@ export class Portal extends ModulVue implements PortalMixin {
                             // could appear behind the content of the page if it was toggled too quickly.
                             this.opening = true;
                             setTimeout(() => {
-                                this.$emit('portal-content-visible');
+                                this.$emit('portal-after-open');
                                 this.setFocusToPortal();
                                 this.opening = false;
                             }, this.transitionDuration);
                         } else {
-                            this.$emit('portal-content-visible');
+                            this.$emit('portal-after-open');
                         }
                     }
                 });
@@ -200,8 +200,11 @@ export class Portal extends ModulVue implements PortalMixin {
                             // $emit update:open has been launched, animation already occurs
                             if (!this.opening) {
                                 this.portalTargetEl.style.position = '';
+                                this.$emit('portal-after-close');
                             }
                         }, this.transitionDuration);
+                    } else {
+                        this.$emit('portal-after-close');
                     }
                 }
             }
@@ -295,7 +298,7 @@ export class Portal extends ModulVue implements PortalMixin {
             this.$nextTick(() => {
                 this.portalTargetMounted = true;
                 this.portalTargetEl = document.querySelector(this.portalTargetSelector) as HTMLElement;
-                this.$emit('portal-content-mounted');
+                this.$emit('portal-mounted');
                 onPortalReady();
             });
         } else {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

- [x] Provide a small description of the changes introduced by this PR

Uniformation de la nomenclature des emits des mixins portal.ts
Ces modifications impacteront tout les composant utilisant la mixin portal.ts

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1092


- [x] Include this section in the release notes

New $emit adds after the closing delay : **portal-after-close**

Emits standardization for mixins portal.ts

| Old emit | New emit |
| ------------- | ------------- |
| beforeClose | portal-before-close  |
| portal-content-visible  | portal-after-open |
| portal-content-mounted  | portal-mounted |
| - | portal-after-close |