### PR TITLE
MODUL-1096: m-table : Supprimer le padding autour de la barre de chargement

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -82,7 +82,7 @@
     }
 
     th,
-    tr td {
+    td {
         box-sizing: content-box;
         padding-top: $m-spacing;
         padding-bottom: $m-spacing;
@@ -137,7 +137,7 @@
         }
     }
 
-    &__loading td {
+    &__loading.m-table__loading > td {
         padding: 0;
         height: auto;
     }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Voir la capture du billet [MODUL-1096](https://jira.dti.ulaval.ca/browse/MODUL-1096.), normalement, la barre de chargement devrait être collée entre l'entête et le corps du tableau.

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1096.