### PR TITLE
Remove extra margin at the bottom of the date picker when no message is present

### DIFF
--- a/src/components/datepicker/__snapshots__/datepicker.stories.ts.snap
+++ b/src/components/datepicker/__snapshots__/datepicker.stories.ts.snap
@@ -77,11 +77,15 @@ exports[`Storyshots components|m-datepicker date big min and max limit 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div
@@ -104,7 +108,7 @@ exports[`Storyshots components|m-datepicker date big min and max limit 1`] = `
 exports[`Storyshots components|m-datepicker date format invalid 1`] = `
 <div>
   <div
-    class="m-datepicker m--has-error"
+    class="m-datepicker m--has-error m--has-validation-message"
     style="width: 100%; max-width: 136px;"
   >
     <div
@@ -178,34 +182,38 @@ exports[`Storyshots components|m-datepicker date format invalid 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <p
-        class="m-validation-message__error"
+      <div
+        class="m-validation-message m-datepicker__validation__message"
       >
-        <svg
-          class="m-icon m-validation-message__icon"
-          height="1em"
-          width="1em"
+        <p
+          class="m-validation-message__error"
         >
-          <title>
-            Erreur
-          </title>
+          <svg
+            class="m-icon m-validation-message__icon"
+            height="1em"
+            width="1em"
+          >
+            <title>
+              Erreur
+            </title>
+             
+            <use
+              aria-hidden="true"
+              class=""
+            />
+          </svg>
            
-          <use
-            aria-hidden="true"
-            class=""
-          />
-        </svg>
+          <span
+            class="m-validation-message__text"
+          >
+            Format invalide
+          </span>
+        </p>
          
-        <span
-          class="m-validation-message__text"
-        >
-          Format invalide
-        </span>
-      </p>
-       
-      <!---->
+        <!---->
+      </div>
     </div>
      
     <div
@@ -228,7 +236,7 @@ exports[`Storyshots components|m-datepicker date format invalid 1`] = `
 exports[`Storyshots components|m-datepicker date off limit  max 1`] = `
 <div>
   <div
-    class="m-datepicker m--has-error"
+    class="m-datepicker m--has-error m--has-validation-message"
     style="width: 100%; max-width: 136px;"
   >
     <div
@@ -302,34 +310,38 @@ exports[`Storyshots components|m-datepicker date off limit  max 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <p
-        class="m-validation-message__error"
+      <div
+        class="m-validation-message m-datepicker__validation__message"
       >
-        <svg
-          class="m-icon m-validation-message__icon"
-          height="1em"
-          width="1em"
+        <p
+          class="m-validation-message__error"
         >
-          <title>
-            Erreur
-          </title>
+          <svg
+            class="m-icon m-validation-message__icon"
+            height="1em"
+            width="1em"
+          >
+            <title>
+              Erreur
+            </title>
+             
+            <use
+              aria-hidden="true"
+              class=""
+            />
+          </svg>
            
-          <use
-            aria-hidden="true"
-            class=""
-          />
-        </svg>
+          <span
+            class="m-validation-message__text"
+          >
+            Date hors limites
+          </span>
+        </p>
          
-        <span
-          class="m-validation-message__text"
-        >
-          Date hors limites
-        </span>
-      </p>
-       
-      <!---->
+        <!---->
+      </div>
     </div>
      
     <div
@@ -352,7 +364,7 @@ exports[`Storyshots components|m-datepicker date off limit  max 1`] = `
 exports[`Storyshots components|m-datepicker date off limit min 1`] = `
 <div>
   <div
-    class="m-datepicker m--has-error"
+    class="m-datepicker m--has-error m--has-validation-message"
     style="width: 100%; max-width: 136px;"
   >
     <div
@@ -426,34 +438,38 @@ exports[`Storyshots components|m-datepicker date off limit min 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <p
-        class="m-validation-message__error"
+      <div
+        class="m-validation-message m-datepicker__validation__message"
       >
-        <svg
-          class="m-icon m-validation-message__icon"
-          height="1em"
-          width="1em"
+        <p
+          class="m-validation-message__error"
         >
-          <title>
-            Erreur
-          </title>
+          <svg
+            class="m-icon m-validation-message__icon"
+            height="1em"
+            width="1em"
+          >
+            <title>
+              Erreur
+            </title>
+             
+            <use
+              aria-hidden="true"
+              class=""
+            />
+          </svg>
            
-          <use
-            aria-hidden="true"
-            class=""
-          />
-        </svg>
+          <span
+            class="m-validation-message__text"
+          >
+            Date hors limites
+          </span>
+        </p>
          
-        <span
-          class="m-validation-message__text"
-        >
-          Date hors limites
-        </span>
-      </p>
-       
-      <!---->
+        <!---->
+      </div>
     </div>
      
     <div
@@ -549,11 +565,15 @@ exports[`Storyshots components|m-datepicker default 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -649,11 +669,15 @@ exports[`Storyshots components|m-datepicker disabled 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -747,34 +771,38 @@ exports[`Storyshots components|m-datepicker error-message 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <p
-      class="m-validation-message__error"
+    <div
+      class="m-validation-message m-datepicker__validation__message"
     >
-      <svg
-        class="m-icon m-validation-message__icon"
-        height="1em"
-        width="1em"
+      <p
+        class="m-validation-message__error"
       >
-        <title>
-          Erreur
-        </title>
+        <svg
+          class="m-icon m-validation-message__icon"
+          height="1em"
+          width="1em"
+        >
+          <title>
+            Erreur
+          </title>
+           
+          <use
+            aria-hidden="true"
+            class=""
+          />
+        </svg>
          
-        <use
-          aria-hidden="true"
-          class=""
-        />
-      </svg>
+        <span
+          class="m-validation-message__text"
+        >
+          this is an error
+        </span>
+      </p>
        
-      <span
-        class="m-validation-message__text"
-      >
-        this is an error
-      </span>
-    </p>
-     
-    <!---->
+      <!---->
+    </div>
   </div>
    
   <div
@@ -869,11 +897,15 @@ exports[`Storyshots components|m-datepicker events 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div
@@ -972,15 +1004,19 @@ exports[`Storyshots components|m-datepicker helper-message 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <p
-      class="m-validation-message__helper"
+    <div
+      class="m-validation-message m-datepicker__validation__message"
     >
-      AAAA-MM-JJ
-    </p>
+      <!---->
+       
+      <p
+        class="m-validation-message__helper"
+      >
+        AAAA-MM-JJ
+      </p>
+    </div>
   </div>
    
   <div
@@ -1000,7 +1036,7 @@ exports[`Storyshots components|m-datepicker helper-message 1`] = `
 
 exports[`Storyshots components|m-datepicker hide-internal-error-message 1`] = `
 <div
-  class="m-datepicker m--has-error"
+  class="m-datepicker m--has-error m--has-validation-message"
   style="width: 100%; max-width: 136px;"
 >
   <div
@@ -1074,11 +1110,15 @@ exports[`Storyshots components|m-datepicker hide-internal-error-message 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -1176,11 +1216,15 @@ exports[`Storyshots components|m-datepicker label 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -1278,11 +1322,15 @@ exports[`Storyshots components|m-datepicker label-up 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -1377,11 +1425,15 @@ exports[`Storyshots components|m-datepicker min="2008-01-01" && max="2014-12-31"
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div
@@ -1477,11 +1529,15 @@ exports[`Storyshots components|m-datepicker placeholder 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -1577,11 +1633,15 @@ exports[`Storyshots components|m-datepicker readonly 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -1676,11 +1736,15 @@ exports[`Storyshots components|m-datepicker skip-input-validation=true 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div
@@ -1776,11 +1840,15 @@ exports[`Storyshots components|m-datepicker valid 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div
@@ -1882,11 +1950,15 @@ exports[`Storyshots components|m-datepicker waiting 1`] = `
   </div>
    
   <div
-    class="m-validation-message m-datepicker__validation-message"
+    class="m-datepicker__validation"
   >
-    <!---->
-     
-    <!---->
+    <div
+      class="m-validation-message m-datepicker__validation__message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
   </div>
    
   <div

--- a/src/components/datepicker/datepicker.html
+++ b/src/components/datepicker/datepicker.html
@@ -48,13 +48,15 @@
                     v-if="open"></m-i18n>
         </m-icon-button>
     </m-input-style>
-    <m-validation-message class="m-datepicker__validation-message"
-                          :disabled="isDisabled"
-                          :waiting="isWaiting"
-                          :error="calandarError"
-                          :error-message="calandarErrorMessage"
-                          :valid-message="validMessage"
-                          :helper-message="helperMessage"></m-validation-message>
+    <div class="m-datepicker__validation">
+        <m-validation-message class="m-datepicker__validation__message"
+                              :disabled="isDisabled"
+                              :waiting="isWaiting"
+                              :error="calandarError"
+                              :error-message="calandarErrorMessage"
+                              :valid-message="validMessage"
+                              :helper-message="helperMessage"></m-validation-message>
+    </div>
     <m-popup ref="popup"
              :open.sync="open"
              :disabled="!active"

--- a/src/components/datepicker/datepicker.scss
+++ b/src/components/datepicker/datepicker.scss
@@ -8,14 +8,19 @@ $m-datepicker--item-dimension: $m-touch-size !default;
     @include m-input-inline-spacing();
 
     &.m--has-validation-message {
-        .m-datepicker__validation-message {
+        .m-datepicker__validation {
             margin-top: $m-spacing--xs;
         }
     }
 
-    &__validation-message {
-        margin-top: $m-margin--xs;
+    &__validation {
         transition: margin-top $m-transition-duration ease;
+        display: flex;
+        justify-content: flex-end;
+
+        &__message {
+            flex: 1 1 auto;
+        }
     }
 
     &__header-label {

--- a/src/components/datepicker/datepicker.spec.ts
+++ b/src/components/datepicker/datepicker.spec.ts
@@ -60,7 +60,7 @@ describe('MDatepicker', () => {
         expect(wrapper.emitted().change).toBeTruthy();
         expect(wrapper.emitted().change[0]).toEqual(['']);
 
-        let validationMessage: Wrapper<any> = wrapper.find('.m-datepicker__validation-message');
+        let validationMessage: Wrapper<any> = wrapper.find('.m-datepicker__validation__message');
 
         expect(validationMessage.props().error).toBe(true);
         expect(validationMessage.props().errorMessage).toBe('m-datepicker:format-error');
@@ -85,7 +85,7 @@ describe('MDatepicker', () => {
         expect(wrapper.emitted().change).toBeTruthy();
         expect(wrapper.emitted().change[0]).toEqual(['']);
 
-        let validationMessage: Wrapper<any> = wrapper.find('.m-datepicker__validation-message');
+        let validationMessage: Wrapper<any> = wrapper.find('.m-datepicker__validation__message');
 
         expect(validationMessage.props().error).toBe(false);
         expect(validationMessage.props().errorMessage).toBe('');
@@ -104,7 +104,7 @@ describe('MDatepicker', () => {
         expect(wrapper.emitted().change).toBeTruthy();
         expect(wrapper.emitted().change[0]).toEqual(['2019-06-06']);
 
-        let validationMessage: Wrapper<any> = wrapper.find('.m-datepicker__validation-message');
+        let validationMessage: Wrapper<any> = wrapper.find('.m-datepicker__validation__message');
 
         expect(validationMessage.props().error).toBe(false);
         expect(validationMessage.props().errorMessage).toBe('');

--- a/src/components/datepicker/datepicker.ts
+++ b/src/components/datepicker/datepicker.ts
@@ -259,6 +259,11 @@ export class MDatepicker extends ModulVue {
         this.$emit('change', this.convertStringToModel(this.internalDateModel));
     }
 
+    public get hasErrorMessage(): boolean {
+        return (!!this.as<InputState>().errorMessage || this.as<InputState>().errorMessage === ' '
+            || !!(this.internalCalendarErrorMessage || '').trim()) &&
+            !this.as<InputState>().disabled && !this.as<InputState>().waiting;
+    }
 
     // Focus management.
 

--- a/src/components/form/__snapshots__/form.stories.ts.snap
+++ b/src/components/form/__snapshots__/form.stories.ts.snap
@@ -689,11 +689,15 @@ exports[`Storyshots components|m-form/all fields datepicker 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div
@@ -4751,11 +4755,15 @@ exports[`Storyshots components|m-form/validators date between 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div
@@ -4905,11 +4913,15 @@ exports[`Storyshots components|m-form/validators date format 1`] = `
     </div>
      
     <div
-      class="m-validation-message m-datepicker__validation-message"
+      class="m-datepicker__validation"
     >
-      <!---->
-       
-      <!---->
+      <div
+        class="m-validation-message m-datepicker__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
     </div>
      
     <div

--- a/src/components/periodpicker/__snapshots__/periodpicker.stories.ts.snap
+++ b/src/components/periodpicker/__snapshots__/periodpicker.stories.ts.snap
@@ -91,11 +91,15 @@ exports[`Storyshots components|m-periodpicker default 1`] = `
           </div>
            
           <div
-            class="m-validation-message m-datepicker__validation-message"
+            class="m-datepicker__validation"
           >
-            <!---->
-             
-            <!---->
+            <div
+              class="m-validation-message m-datepicker__validation__message"
+            >
+              <!---->
+               
+              <!---->
+            </div>
           </div>
            
           <div
@@ -196,11 +200,15 @@ exports[`Storyshots components|m-periodpicker default 1`] = `
           </div>
            
           <div
-            class="m-validation-message m-datepicker__validation-message"
+            class="m-datepicker__validation"
           >
-            <!---->
-             
-            <!---->
+            <div
+              class="m-validation-message m-datepicker__validation__message"
+            >
+              <!---->
+               
+              <!---->
+            </div>
           </div>
            
           <div


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Remove extra margin at the bottom of the date picker when no message is present
The datepicker will now behave like all other modUL fields
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1099
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
