### PR TITLE
MODUL-1100 - Ajouter un margin-right automatique sur le dropdown et le textarea

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -10,6 +10,8 @@ $m-dropdown--margin: $m-padding--xs !default;
     display: inline-flex;
     flex-direction: column;
 
+    @include m-input-inline-spacing();
+
     &.m--has-validation-message {
         .m-dropdown__validation-message {
             margin-top: $m-spacing--xs;

--- a/src/components/textarea/textarea.scss
+++ b/src/components/textarea/textarea.scss
@@ -5,6 +5,8 @@
     display: inline-flex;
     flex-direction: column;
 
+    @include m-input-inline-spacing();
+
     &.m--has-validation-message {
         .m-textarea__validation {
             margin-top: $m-spacing--xs;

--- a/src/components/timepicker/timepicker.scss
+++ b/src/components/timepicker/timepicker.scss
@@ -6,6 +6,8 @@ $m-timepicker--height-multiplier: 5;
     display: inline-flex;
     flex-direction: column;
 
+    @include m-input-inline-spacing();
+
     &.m--has-validation-message {
         .m-timepicker__validation-message {
             margin-top: $m-spacing--xs;


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist
<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
* Ajouter un margin-right automatique sur le dropdown comme sur les autres inputs
* Ajouter la mixin CSS **m-input-inline-spacing();** sur le m-dropdown et le m-textarea

Voir image du billet [MODUL-1100](https://jira.dti.ulaval.ca/browse/MODUL-1100)
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1100
