### PR TITLE
MODUL-1114 - the searchfield placeholder color is too light

### DIFF
--- a/src/components/searchfield/__snapshots__/searchfield.stories.ts.snap
+++ b/src/components/searchfield/__snapshots__/searchfield.stories.ts.snap
@@ -248,6 +248,106 @@ exports[`Storyshots components|m-searchfield error state 1`] = `
 </div>
 `;
 
+exports[`Storyshots components|m-searchfield placeholder 1`] = `
+<div>
+  <div>
+    <div
+      class="m-searchfield"
+      style="width: 100%; max-width: 288px;"
+    >
+      <div
+        class="m-input-style m--is-tag-default"
+        style="margin-top: 10px;"
+        word-wrap="true"
+      >
+        <div
+          class="m-input-style__main"
+        >
+          <div
+            class="m-input-style__body"
+          >
+            <span
+              class="m-input-style__label"
+              style="z-index: -1;"
+            >
+              <span
+                class="m-input-style__text"
+              />
+            </span>
+             
+            <div
+              class="m-input-style__input"
+            >
+              <div
+                class="m-input-style__prefix"
+              />
+               
+              <div
+                class="m-input-style__content"
+              >
+                <input
+                  class="m-textfield__input"
+                  id="mSearchfield-uuid"
+                  placeholder="placeholder"
+                  type="search"
+                />
+                   
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                 
+                <!---->
+              </div>
+            </div>
+          </div>
+           
+          <div
+            class="m-input-style__append"
+          >
+            <button
+              aria-controls="mSearchfield-uuid"
+              class="m-searchfield__search-button"
+              title="Rechercher"
+            >
+              <svg
+                aria-hidden="true"
+                class="m-icon"
+                height="22px"
+                width="22px"
+              >
+                <!---->
+                 
+                <use
+                  aria-hidden="true"
+                  class=""
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+       
+      <div
+        class="m-searchfield__validation"
+      >
+        <div
+          class="m-validation-message"
+        >
+          <!---->
+           
+          <!---->
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots components|m-searchfield valid state 1`] = `
 <div>
   <div>

--- a/src/components/searchfield/searchfield.scss
+++ b/src/components/searchfield/searchfield.scss
@@ -8,11 +8,6 @@
     display: inline-flex;
     flex-direction: column;
 
-    .m-input-style input::placeholder {
-        color: $m-color--text-light;
-        font-weight: $m-font-weight--light;
-    }
-
     @include m-input-inline-spacing();
 
     &__search-button {
@@ -64,6 +59,11 @@
 
     // overrides :-(
     .m-input-style {
+        input::placeholder {
+            color: $m-color--text-light;
+            font-weight: $m-font-weight--light;
+        }
+
         .m-input-style__main {
             background-color: $m-searchfield-color;
         }

--- a/src/components/searchfield/searchfield.scss
+++ b/src/components/searchfield/searchfield.scss
@@ -8,7 +8,7 @@
     display: inline-flex;
     flex-direction: column;
 
-    ::placeholder {
+    .m-input-style input::placeholder {
         color: $m-color--text-light;
         font-weight: $m-font-weight--light;
     }

--- a/src/components/searchfield/searchfield.stories.ts
+++ b/src/components/searchfield/searchfield.stories.ts
@@ -17,6 +17,16 @@ storiesOf(`${componentsHierarchyRootSeparator}${SEARCHFIELD_NAME}`, module)
             value: undefined
         })
     }))
+    .add('placeholder', () => ({
+        template: `
+            <div>
+                <div><${SEARCHFIELD_NAME} v-model="value" placeholder="placeholder"></${SEARCHFIELD_NAME}></div>
+            </div>
+        `,
+        data: () => ({
+            value: undefined
+        })
+    }))
     .add('with label', () => ({
         template: `
             <div>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Increase css specificity to overrider input-style placeholder color
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1114
