### PR TITLE
Make copy-to-clipboard use all it's container width by default

### DIFF
--- a/src/components/copy-to-clipboard/__snapshots__/copy-to-clipboard.stories.ts.snap
+++ b/src/components/copy-to-clipboard/__snapshots__/copy-to-clipboard.stories.ts.snap
@@ -1,94 +1,179 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots components|m-copy-to-clipboard custom 1`] = `
-<div
-  class="m-copy-to-clipboard"
->
+<div>
   <div
-    class="m-textfield m--is-readonly m--has-label m--is-type-text"
-    style="width: 100%; max-width: 288px;"
+    class="m-copy-to-clipboard"
   >
     <div
-      class="m-input-style m--is-readonly m--is-label-up m--has-label m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
+      class="m-textfield m--is-readonly m--has-label m--is-type-text"
+      style="width: 100%; max-width: 288px;"
     >
       <div
-        class="m-input-style__main"
+        class="m-input-style m--is-readonly m--is-label-up m--has-label m--has-value m--is-tag-default"
+        style="margin-top: 10px;"
       >
         <div
-          class="m-input-style__body"
+          class="m-input-style__main"
         >
-          <label
-            class="m-input-style__label"
-            for="mTextfield-uuid"
-            style="margin-right: 0px;"
-          >
-            <span
-              class="m-input-style__text"
-            >
-              <span>
-                some label
-              </span>
-               
-              <!---->
-            </span>
-          </label>
-           
           <div
-            class="m-input-style__input"
+            class="m-input-style__body"
           >
-            <!---->
-             
-            <div
-              class="m-input-style__content"
+            <label
+              class="m-input-style__label"
+              for="mTextfield-uuid"
+              style="margin-right: 0px;"
             >
-              <input
-                class="m-textfield__input"
-                id="mTextfield-uuid"
-                maxlength="Infinity"
-                readonly="readonly"
-                type="text"
-              />
-                
-              <!---->
-               
-              <!---->
-               
-              <!---->
-            </div>
+              <span
+                class="m-input-style__text"
+              >
+                <span>
+                  some label
+                </span>
+                 
+                <!---->
+              </span>
+            </label>
              
             <div
-              class="m-input-style__suffix"
+              class="m-input-style__input"
             >
               <!---->
                
-              <!---->
+              <div
+                class="m-input-style__content"
+              >
+                <input
+                  class="m-textfield__input"
+                  id="mTextfield-uuid"
+                  maxlength="Infinity"
+                  readonly="readonly"
+                  type="text"
+                />
+                  
+                <!---->
+                 
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                <!---->
+                 
+                <!---->
+              </div>
             </div>
           </div>
+           
+          <!---->
+        </div>
+      </div>
+       
+      <div
+        class="m-textfield__validation"
+      >
+        <div
+          class="m-validation-message m-textfield__validation__message"
+        >
+          <!---->
+           
+          <!---->
         </div>
          
         <!---->
       </div>
     </div>
      
+    <button>
+      Some button
+    </button>
+  </div>
+   
+  <div
+    class="m-copy-to-clipboard"
+  >
     <div
-      class="m-textfield__validation"
+      class="m-textfield m--is-readonly m--is-type-text"
+      style="width: 100%;"
     >
       <div
-        class="m-validation-message m-textfield__validation__message"
+        class="m-input-style m--is-readonly m--has-value m--is-tag-default"
+        style="margin-top: 10px;"
       >
-        <!---->
+        <div
+          class="m-input-style__main"
+        >
+          <div
+            class="m-input-style__body"
+          >
+            <span
+              class="m-input-style__label"
+              style="z-index: -1;"
+            >
+              <span
+                class="m-input-style__text"
+              />
+            </span>
+             
+            <div
+              class="m-input-style__input"
+            >
+              <div
+                class="m-input-style__prefix"
+              />
+               
+              <div
+                class="m-input-style__content"
+              >
+                <input
+                  class="m-textfield__input"
+                  id="mTextfield-uuid"
+                  maxlength="Infinity"
+                  readonly="readonly"
+                  type="text"
+                />
+                  
+                <!---->
+                 
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                <button>
+                  Some button
+                </button>
+                 
+                <!---->
+              </div>
+            </div>
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+       
+      <div
+        class="m-textfield__validation"
+      >
+        <div
+          class="m-validation-message m-textfield__validation__message"
+        >
+          <!---->
+           
+          <!---->
+        </div>
          
         <!---->
       </div>
-       
-      <!---->
     </div>
   </div>
-   
-  <button>
-    Some button
-  </button>
 </div>
 `;
 
@@ -98,7 +183,7 @@ exports[`Storyshots components|m-copy-to-clipboard custom user feedback 1`] = `
 >
   <div
     class="m-textfield m--is-readonly m--is-type-text"
-    style="width: 100%; max-width: 288px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style m--is-readonly m--has-value m--is-tag-default"
@@ -195,7 +280,7 @@ exports[`Storyshots components|m-copy-to-clipboard default 1`] = `
 >
   <div
     class="m-textfield m--is-readonly m--is-type-text"
-    style="width: 100%; max-width: 288px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style m--is-readonly m--is-tag-default"
@@ -292,7 +377,7 @@ exports[`Storyshots components|m-copy-to-clipboard default with value 1`] = `
 >
   <div
     class="m-textfield m--is-readonly m--is-type-text"
-    style="width: 100%; max-width: 288px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style m--is-readonly m--has-value m--is-tag-default"
@@ -389,7 +474,7 @@ exports[`Storyshots components|m-copy-to-clipboard user feedback 1`] = `
 >
   <div
     class="m-textfield m--is-readonly m--is-type-text"
-    style="width: 100%; max-width: 288px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style m--is-readonly m--has-value m--is-tag-default"

--- a/src/components/copy-to-clipboard/copy-to-clipboard.html
+++ b/src/components/copy-to-clipboard/copy-to-clipboard.html
@@ -6,12 +6,16 @@
      @click="selectText">
     <slot :input-props="inputProps"
           :button-handlers="buttonHandlers">
-        <m-textfield v-bind="inputProps">
+        <m-textfield :max-width="fieldMaxWidth"
+                     v-bind="inputProps">
             <template slot="suffix">
-                <m-link mode="button"
-                        :underline="false"
-                        v-on="buttonHandlers"
-                        class="m-copy-to-clipboard__button">{{labelCopyBtn}}</m-link>
+                <slot name="inputButton"
+                      :button-handlers="buttonHandlers">
+                    <m-link mode="button"
+                            :underline="false"
+                            v-on="buttonHandlers"
+                            class="m-copy-to-clipboard__button">{{labelCopyBtn}}</m-link>
+                </slot>
             </template>
         </m-textfield>
     </slot>

--- a/src/components/copy-to-clipboard/copy-to-clipboard.stories.ts
+++ b/src/components/copy-to-clipboard/copy-to-clipboard.stories.ts
@@ -38,13 +38,20 @@ storiesOf(`${componentsHierarchyRootSeparator}${COPY_TO_CLIPBOARD_NAME}`, module
     }))
     .add('custom', () => ({
         template: `
-        <${componentName} :value="value">
-            <template slot-scope="{ inputProps, buttonHandlers }">
-                <m-textfield v-bind="inputProps" :label="'some label'">
-                </m-textfield>
-                <button v-on="buttonHandlers">Some button</button>
-            </template>
-        </${componentName}>`,
+        <div>
+            <${componentName} :value="value">
+                <template slot-scope="{ inputProps, buttonHandlers }">
+                    <m-textfield v-bind="inputProps" :label="'some label'">
+                    </m-textfield>
+                    <button v-on="buttonHandlers">Some button</button>
+                </template>
+            </${componentName}>
+            <${componentName} :value="value">
+                <template slot="inputButton" slot-scope="{ buttonHandlers }">
+                    <button v-on="buttonHandlers">Some button</button>
+                </template>
+            </${componentName}>
+        </div>`,
         data: () => ({
             value: 'some value'
         }),

--- a/src/components/copy-to-clipboard/copy-to-clipboard.ts
+++ b/src/components/copy-to-clipboard/copy-to-clipboard.ts
@@ -1,6 +1,7 @@
 import ClipboardJs from 'clipboard';
 import { PluginObject } from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import { InputMaxWidth } from '../../mixins/input-width/input-width';
 import { InputSelectable } from '../../utils/input/input';
 import { ModulVue } from '../../utils/vue/vue';
 import { COPY_TO_CLIPBOARD_FEEDBACK_NAME, COPY_TO_CLIPBOARD_NAME } from '../component-names';
@@ -60,6 +61,7 @@ export class MCopyToClipboard extends ModulVue {
     })
     value: string;
 
+    fieldMaxWidth: InputMaxWidth = InputMaxWidth.None;
     labelCopyBtn: string = this.$i18n.translate('m-copy-to-clipboard:copy');
     selectedText: string = '';
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Make copy-to-clipboard use all it's container width by default
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1125
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
