### PR TITLE
MODUL-1127 m-form : coquille dans la traduction française des messages

### DIFF
--- a/src/components/form/form.lang.fr.json
+++ b/src/components/form/form.lang.fr.json
@@ -1,7 +1,7 @@
 {
     "m-form": {
-        "multipleErrorsToCorrect": "<strong>%(totalNbOfErrors)s information</strong> est à corriger pour continuer.",
-        "multipleErrorsToCorrect.p": "<strong>%(totalNbOfErrors)s informations</strong> sont à corriger pour continuer.",
+        "multipleErrorsToCorrect": "<strong>%(totalNbOfErrors)s information</strong> est à revoir pour continuer.",
+        "multipleErrorsToCorrect.p": "<strong>%(totalNbOfErrors)s informations</strong> sont à revoir pour continuer.",
         "requiredValidatorErrorMessage": "Ce champ est requis.",
         "requiredValidatorErrorSummaryMessage": "Le champ %(controlLabel)s est requis.",
         "minLengthValidatorErrorMessage": "Le nombre minimal de caractères pour ce champ est %(minLength)s.",


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [ ] Provide a small description of the changes introduced by this PR
Rétablir la formulation initiale « à revoir » plutôt que « à corriger ».
- [ ] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1127

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
Error message in m-form toast displayed when more than one error happens at submit has slighly changed.
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
