### PR TITLE
Bugfix/modul 1145 http query string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11031,12 +11031,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -11051,17 +11053,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -11178,7 +11183,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -11190,6 +11196,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -11204,6 +11211,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -11211,12 +11219,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -11235,6 +11245,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -11315,7 +11326,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -11327,6 +11339,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -11449,6 +11462,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -17585,7 +17599,8 @@
         "qs": {
             "version": "6.6.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
-            "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+            "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==",
+            "dev": true
         },
         "querystring": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "moment": "^2.19.3",
         "popper.js": "^1.12.9",
         "portal-vue": "~1.1.1",
-        "qs": "^6.5.1",
         "sprintf-js": "^1.1.1",
         "vue-touch": "^2.0.0-beta.4",
         "zingtouch": "^1.0.6"

--- a/src/utils/http/http-param-serializer.ts
+++ b/src/utils/http/http-param-serializer.ts
@@ -15,5 +15,9 @@ export function serializeParams(params: any): any {
 }
 
 function serializeValue(value: any): string {
-    return typeof value !== 'object' ? value : JSON.stringify(value);
+    return typeof value !== 'object'
+        ? value
+        : toString.call(value) === '[object Date]'
+            ? (value as Date).toISOString()
+            : JSON.stringify(value);
 }

--- a/src/utils/http/http-param-serializer.ts
+++ b/src/utils/http/http-param-serializer.ts
@@ -1,0 +1,19 @@
+export function serializeParams(params: any): any {
+    let options: string[] = [];
+    for (const key in params) {
+        if (typeof params[key] === 'object' && params[key] !== undefined && params[key].length !== undefined) {
+            // array
+            if (params[key].length > 0) {
+                params[key].forEach((el: any) => options.push(`${key}=${serializeValue(el)}`)); // array not empty
+            }
+        } else if (params[key] !== undefined) {
+            options.push(`${key}=${serializeValue(params[key])}`);
+        }
+    }
+
+    return options.join('&');
+}
+
+function serializeValue(value: any): string {
+    return typeof value !== 'object' ? value : JSON.stringify(value);
+}

--- a/src/utils/http/http.spec.ts
+++ b/src/utils/http/http.spec.ts
@@ -40,6 +40,10 @@ describe('http serializer', () => {
             expect(serializeParams({ param1: [{ key: 'k1', value: 'v1' }, { key: 'k2', value: 'v2' }] })).toEqual('param1={"key":"k1","value":"v1"}&param1={"key":"k2","value":"v2"}');
         });
 
+        it('should serialize arrays with undefined values', () => {
+            expect(serializeParams({ param1: [1, undefined, 3] })).toEqual('param1=1&param1=undefined&param1=3');
+        });
+
         it('should not serialize empty arrays', () => {
             expect(serializeParams({ param1: [], param2: 'text' })).toEqual('param2=text');
         });

--- a/src/utils/http/http.spec.ts
+++ b/src/utils/http/http.spec.ts
@@ -51,5 +51,10 @@ describe('http serializer', () => {
         it('should serialize complex objects', () => {
             expect(serializeParams({ param1: { a1: 'text', a2: 33, a3: true } })).toEqual('param1={"a1":"text","a2":33,"a3":true}');
         });
+
+        it('should serialize dates', () => {
+            // support DST
+            expect(['param1=2019-07-23T04:00:00.000Z', 'param1=2019-07-23T05:00:00.000Z']).toContain(serializeParams({ param1: new Date(2019, 6, 23) }));
+        });
     });
 });

--- a/src/utils/http/http.spec.ts
+++ b/src/utils/http/http.spec.ts
@@ -1,8 +1,9 @@
 import Vue from 'vue';
 import { resetModulPlugins } from '../../../tests/helpers/component';
-import HttpPlugin, { HttpService } from './http';
+import HttpPlugin from './http';
+import { serializeParams } from './http-param-serializer';
 
-describe('i18n plugin', () => {
+describe('http plugin', () => {
     describe('when not installed', () => {
         it('should not be registered on the Vue prototype', () => {
             expect(Vue.prototype.$http).toBeUndefined();
@@ -14,9 +15,37 @@ describe('i18n plugin', () => {
             resetModulPlugins();
         });
 
-        it('should register $i18n on the Vue prototype', () => {
+        it('should register $http on the Vue prototype', () => {
             Vue.use(HttpPlugin);
             expect(Vue.prototype.$http).toBeDefined();
+        });
+    });
+});
+
+describe('http serializer', () => {
+    describe('given params', () => {
+        it('should serialize primitives', () => {
+            expect(serializeParams({ param1: 1, param2: 'text', param3: false })).toEqual('param1=1&param2=text&param3=false');
+        });
+
+        it('should not serialize undefined values', () => {
+            expect(serializeParams({ param1: 1, param2: undefined, param3: 'text', param4: undefined })).toEqual('param1=1&param3=text');
+        });
+
+        it('should serialize arrays', () => {
+            expect(serializeParams({ param1: [1, 2, 3] })).toEqual('param1=1&param1=2&param1=3');
+        });
+
+        it('should serialize arrays with object values', () => {
+            expect(serializeParams({ param1: [{ key: 'k1', value: 'v1' }, { key: 'k2', value: 'v2' }] })).toEqual('param1={"key":"k1","value":"v1"}&param1={"key":"k2","value":"v2"}');
+        });
+
+        it('should not serialize empty arrays', () => {
+            expect(serializeParams({ param1: [], param2: 'text' })).toEqual('param2=text');
+        });
+
+        it('should serialize complex objects', () => {
+            expect(serializeParams({ param1: { a1: 'text', a2: 33, a3: true } })).toEqual('param1={"a1":"text","a2":33,"a3":true}');
         });
     });
 });

--- a/src/utils/http/http.spec.ts
+++ b/src/utils/http/http.spec.ts
@@ -54,7 +54,7 @@ describe('http serializer', () => {
 
         it('should serialize dates', () => {
             // support DST
-            expect(['param1=2019-07-23T04:00:00.000Z', 'param1=2019-07-23T05:00:00.000Z']).toContain(serializeParams({ param1: new Date(2019, 6, 23) }));
+            expect(['param1=2019-07-23T00:00:00.000Z', 'param1=2019-07-23T04:00:00.000Z', 'param1=2019-07-23T05:00:00.000Z']).toContain(serializeParams({ param1: new Date(2019, 6, 23) }));
         });
     });
 });

--- a/src/utils/http/http.ts
+++ b/src/utils/http/http.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
-import qs from 'qs/lib';
 import { PluginObject } from 'vue';
 import { WindowErrorHandler } from '../errors/window-error-handler';
 import * as strUtils from '../str/str';
+import { serializeParams } from './http-param-serializer';
 import { RequestConfig, RestAdapter } from './rest';
 
 const AUTHORIZATION_HEADER: string = 'Authorization';
@@ -115,14 +115,12 @@ export class HttpService implements RestAdapter {
                 };
             }
 
-            axiosConfig.data = qs.stringify(config.formParams, { arrayFormat: 'repeat' });
+            axiosConfig.data = serializeParams(config.formParams);
         } else {
             axiosConfig.data = config.data;
         }
 
-        axiosConfig.paramsSerializer = params => {
-            return qs.stringify(params, { arrayFormat: 'repeat' });
-        };
+        axiosConfig.paramsSerializer = params => serializeParams(params);
 
         return axiosConfig;
     }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Fix the query string serializer that was not supporting json query parameters.

### **Potential breaking change**
Le serializer des query params ne formate pas correctement les types complexes. Après validation dans les différents projets, les types complexes devraient être passés en JSON et non comme le serializer le fait présentement.

Comportement attendu dans nos services en production: https://docs.angularjs.org/api/ng/service/$httpParamSerializer

Il y a un potentiel de breaking change si des services utilisent une notation non-JSON, ou encore si du code custom a été écrit pour contourner quelconque problème de sérialisation.

- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1145
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->
