### PR TITLE
MODUL-1152 - Gestion focus avatar

### DIFF
--- a/src/components/avatar/avatar.html
+++ b/src/components/avatar/avatar.html
@@ -6,10 +6,10 @@
      @keydown.enter="onClick"
      @touchend.prevent="onTouchend"
      @keyup.tab="focusDisplay(true)"
-     @mouseover="setHover(true)"
-     @mouseleave="setHover(false)"
-     @focus="setHover(true)"
-     @blur="setHover(false)"
+     @mouseover="hover = true"
+     @mouseleave="hover = false"
+     @focus="hover = true"
+     @blur="hover = false"
      ref="avatar">
     <slot>
         <m-icon class="m-avatar__default-image"

--- a/src/components/avatar/avatar.html
+++ b/src/components/avatar/avatar.html
@@ -4,6 +4,7 @@
      :tabindex="tabindex"
      @click="onClick"
      @keydown.enter="onClick"
+     @touchend.prevent="onTouchend"
      @keyup.tab="focusDisplay(true)"
      @mouseover="setHover(true)"
      @mouseleave="setHover(false)"
@@ -17,5 +18,5 @@
                 :size="size"></m-icon>
     </slot>
     <slot name="content"
-          :hover="isHover"></slot>
+          :content-visible="showContent"></slot>
 </div>

--- a/src/components/avatar/avatar.html
+++ b/src/components/avatar/avatar.html
@@ -1,13 +1,14 @@
 <div class="m-avatar"
-     :class="{ 'm--is-clickable': this.clickable }"
+     :class="interactionClass"
      :style="sizeStyle"
+     :tabindex="tabindex"
      @click="onClick"
      @keydown.enter="onClick"
+     @keyup.tab="focusDisplay(true)"
      @mouseover="setHover(true)"
      @mouseleave="setHover(false)"
      @focus="setHover(true)"
      @blur="setHover(false)"
-     :tabindex="tabindex"
      ref="avatar">
     <slot>
         <m-icon class="m-avatar__default-image"
@@ -16,5 +17,5 @@
                 :size="size"></m-icon>
     </slot>
     <slot name="content"
-          :hover="hover"></slot>
+          :hover="isHover"></slot>
 </div>

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -5,7 +5,7 @@
     position: relative;
     color: $m-color--grey;
     border-radius: 50%;
-    -webkit-mask-image: -webkit-radial-gradient(white, black); // Fix a translate problem on iPhone
+    -webkit-mask-image: -webkit-radial-gradient(white, black); // Fix a translate problem on safari - https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
 
     &.m--is-clickable {
         cursor: pointer;

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -5,10 +5,13 @@
     position: relative;
     color: $m-color--grey;
     border-radius: 50%;
-    outline: none;
 
     &.m--is-clickable {
         cursor: pointer;
+    }
+
+    &:not(.m--is-focus-visible) {
+        outline: none;
     }
 
     .m--is-avatar-large {

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -5,6 +5,7 @@
     position: relative;
     color: $m-color--grey;
     border-radius: 50%;
+    -webkit-mask-image: -webkit-radial-gradient(white, black); // Fix a translate problem on iPhone
 
     &.m--is-clickable {
         cursor: pointer;

--- a/src/components/avatar/avatar.spec.ts
+++ b/src/components/avatar/avatar.spec.ts
@@ -10,6 +10,14 @@ const initializeShallowWrapper: any = () => {
     wrapper = shallowMount(MAvatar, {
         propsData: {
             clickable: propsClickable
+        },
+        mocks: {
+            $modul: {
+                event: {
+                    $on: jest.fn(),
+                    $off: jest.fn()
+                }
+            }
         }
     });
 };
@@ -78,46 +86,50 @@ describe('MAvatar', () => {
     });
 
     describe(`When mouseover`, () => {
-        it(`should call setHover(true)`, () => {
+        it(`hover = true`, () => {
             initializeShallowWrapper();
+            wrapper.vm.hover = false;
 
             wrapper.setMethods({ setHover: jest.fn() });
             wrapper.find(REF_AVATAR).trigger('mouseover');
 
-            expect(wrapper.vm.setHover).toHaveBeenCalledWith(true);
+            expect(wrapper.vm.hover).toBe(true);
         });
     });
 
     describe(`When mouseleave`, () => {
-        it(`should call setHover(false)`, () => {
+        it(`hover = false`, () => {
             initializeShallowWrapper();
+            wrapper.vm.hover = true;
 
             wrapper.setMethods({ setHover: jest.fn() });
             wrapper.find(REF_AVATAR).trigger('mouseleave');
 
-            expect(wrapper.vm.setHover).toHaveBeenCalledWith(false);
+            expect(wrapper.vm.hover).toBe(false);
         });
     });
 
     describe(`When focus`, () => {
         it(`should call setHover(true)`, () => {
             initializeShallowWrapper();
+            wrapper.vm.hover = false;
 
             wrapper.setMethods({ setHover: jest.fn() });
             wrapper.find(REF_AVATAR).trigger('focus');
 
-            expect(wrapper.vm.setHover).toHaveBeenCalledWith(true);
+            expect(wrapper.vm.hover).toBe(true);
         });
     });
 
     describe(`When blur`, () => {
         it(`should call setHover(false)`, () => {
             initializeShallowWrapper();
+            wrapper.vm.hover = true;
 
             wrapper.setMethods({ setHover: jest.fn() });
             wrapper.find(REF_AVATAR).trigger('blur');
 
-            expect(wrapper.vm.setHover).toHaveBeenCalledWith(false);
+            expect(wrapper.vm.hover).toBe(false);
         });
     });
 

--- a/src/components/avatar/avatar.spec.ts
+++ b/src/components/avatar/avatar.spec.ts
@@ -66,6 +66,17 @@ describe('MAvatar', () => {
         });
     });
 
+    describe(`When keyup.tab.enter`, () => {
+        it(`should call focusDisplay(true)`, () => {
+            initializeShallowWrapper();
+
+            wrapper.setMethods({ focusDisplay: jest.fn() });
+            wrapper.find(REF_AVATAR).trigger('keyup.tab');
+
+            expect(wrapper.vm.focusDisplay).toHaveBeenCalledWith(true);
+        });
+    });
+
     describe(`When mouseover`, () => {
         it(`should call setHover(true)`, () => {
             initializeShallowWrapper();

--- a/src/components/avatar/avatar.spec.ts
+++ b/src/components/avatar/avatar.spec.ts
@@ -121,5 +121,54 @@ describe('MAvatar', () => {
         });
     });
 
+    describe(`When touchend`, () => {
+        it(`should call onTouchend()`, () => {
+            propsClickable = false;
+            initializeShallowWrapper();
+
+            wrapper.setMethods({ onTouchend: jest.fn() });
+            wrapper.find(REF_AVATAR).trigger('touchend');
+
+            expect(wrapper.vm.onTouchend).toHaveBeenCalledTimes(1);
+        });
+
+        describe(`when clickable = true`, () => {
+
+            beforeEach(() => {
+                propsClickable = true;
+                initializeShallowWrapper();
+            });
+
+            describe(`and the avatar is not touched`, () => {
+                it(`should not emit touch`, () => {
+                    wrapper.vm.isTouched = false;
+
+                    wrapper.vm.onTouchend();
+
+                    expect(wrapper.emitted('touch')).toBeUndefined();
+                });
+            });
+
+            describe(`and the avatar is touched`, () => {
+                it(`should emit touch`, () => {
+                    wrapper.vm.isTouched = true;
+
+                    wrapper.vm.onTouchend();
+
+                    expect(wrapper.emitted('touch')).toBeDefined();
+                });
+            });
+        });
+
+        describe(`when clickable = false`, () => {
+            it(`should not emit touch`, () => {
+                initializeShallowWrapper();
+                wrapper.vm.onTouchend();
+
+                expect(wrapper.emitted('touch')).toBeUndefined();
+            });
+        });
+    });
+
 });
 

--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -29,7 +29,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${AVATAR_NAME}`, module)
     }))
     .add('Custom slot - animation', () => ({
         template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true">
-                        <div slot="content" slot-scope={hover} style="
+                        <div slot="content" slot-scope={contentVisible} style="
                             transition: all 0.1s linear;
                             width: 100%;
                             text-align: center;
@@ -41,7 +41,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${AVATAR_NAME}`, module)
                             justify-content: center;
                             background-color: #333;
                             color: white"
-                            :style="[hover ? { 'transform': 'translateY(-100%)' } : {}]"
+                            :style="[contentVisible ? { 'transform': 'translateY(-100%)' } : {}]"
                         >
                             <span class="m-avatar__default-button">Edit</span>
                         </div>

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -27,8 +27,14 @@ export class MAvatar extends Vue {
     @Prop({ default: false })
     clickable: boolean;
 
-    isHover: boolean = false;
     isFocusVisible: boolean = false;
+    isHovered: boolean = false;
+    isTouched: boolean = false;
+    timeoutContentVisible: any = undefined;
+
+    created(): void {
+        document.addEventListener('click', this.onDocumentClick);
+    }
 
     get sizeStyle(): { [property: string]: string } {
         return {
@@ -56,9 +62,13 @@ export class MAvatar extends Vue {
         };
     }
 
+    get showContent(): boolean {
+        return this.isHovered || this.isTouched;
+    }
+
     setHover(hover: boolean): void {
         this.focusDisplay(false);
-        this.isHover = hover;
+        this.isHovered = hover;
     }
 
     focusDisplay(focusVisible: boolean): void {
@@ -71,6 +81,30 @@ export class MAvatar extends Vue {
             this.emitClick();
         }
     }
+
+    onTouchend(): void {
+        this.focusDisplay(false);
+        if (this.clickable) {
+            if (this.isTouched) {
+                clearTimeout(this.timeoutContentVisible);
+                this.isTouched = false;
+                this.emitTouch();
+            } else {
+                this.isTouched = true;
+                this.timeoutContentVisible = setTimeout(() => {
+                    this.isTouched = false;
+                }, 5000);
+            }
+        }
+    }
+
+    private onDocumentClick(): void {
+        clearTimeout(this.timeoutContentVisible);
+        this.isTouched = false;
+    }
+
+    @Emit('touch')
+    emitTouch(): void { }
 
     @Emit('click')
     emitClick(): void { }

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -30,10 +30,10 @@ export class MAvatar extends Vue {
     isFocusVisible: boolean = false;
     isHovered: boolean = false;
     isTouched: boolean = false;
-    timeoutContentVisible: any = undefined;
+    timeoutContentVisible: number = 0;
 
-    created(): void {
-        document.addEventListener('click', this.onDocumentClick);
+    destroy(): void {
+        this.resetTouch();
     }
 
     get sizeStyle(): { [property: string]: string } {
@@ -63,11 +63,14 @@ export class MAvatar extends Vue {
     }
 
     get showContent(): boolean {
-        return this.isHovered || this.isTouched;
+        return this.hover || this.isTouched;
     }
 
-    setHover(hover: boolean): void {
-        this.focusDisplay(false);
+    get hover(): boolean {
+        return this.isHovered;
+    }
+
+    set hover(hover: boolean) {
         this.isHovered = hover;
     }
 
@@ -76,29 +79,28 @@ export class MAvatar extends Vue {
     }
 
     onClick(): void {
-        this.focusDisplay(false);
         if (this.clickable) {
             this.emitClick();
         }
     }
 
     onTouchend(): void {
-        this.focusDisplay(false);
         if (this.clickable) {
             if (this.isTouched) {
-                clearTimeout(this.timeoutContentVisible);
-                this.isTouched = false;
+                this.resetTouch();
                 this.emitTouch();
             } else {
+                this.$modul.event.$on('click', this.resetTouch);
                 this.isTouched = true;
-                this.timeoutContentVisible = setTimeout(() => {
+                this.timeoutContentVisible = window.setTimeout(() => {
                     this.isTouched = false;
                 }, 5000);
             }
         }
     }
 
-    private onDocumentClick(): void {
+    private resetTouch(): void {
+        this.$modul.event.$off('click', this.resetTouch);
         clearTimeout(this.timeoutContentVisible);
         this.isTouched = false;
     }

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -27,7 +27,8 @@ export class MAvatar extends Vue {
     @Prop({ default: false })
     clickable: boolean;
 
-    hover: boolean = false;
+    isHover: boolean = false;
+    isFocusVisible: boolean = false;
 
     get sizeStyle(): { [property: string]: string } {
         return {
@@ -48,11 +49,24 @@ export class MAvatar extends Vue {
         return this.clickable ? 0 : -1;
     }
 
-    setHover(isHover: boolean): void {
-        this.hover = isHover;
+    get interactionClass(): { [property: string]: boolean } {
+        return {
+            'm--is-clickable': this.clickable,
+            'm--is-focus-visible': this.isFocusVisible
+        };
+    }
+
+    setHover(hover: boolean): void {
+        this.focusDisplay(false);
+        this.isHover = hover;
+    }
+
+    focusDisplay(focusVisible: boolean): void {
+        this.isFocusVisible = focusVisible;
     }
 
     onClick(): void {
+        this.focusDisplay(false);
         if (this.clickable) {
             this.emitClick();
         }


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Dans le m-avatar, j'ai ajouté une meilleure gestion du focus. Les boîtes bleus sera visible uniquement lors de la navigation avec TAB. J'en ai profité pour faire une meilleure gestion du mobile (touch). Lorsqu'on clique sur l'avatar pour une première fois, on affiche l'effet de survol et si on reclick dessus, l'action est appelée. 
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1152
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [x] Include this section in the release notes
**BREAKING CHANGE:** In the m-avatar, the parameter in the scoped-slot #content named "hover" is now called "contentVisible".
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
