### PR TITLE
Add encoding to value of query string

### DIFF
--- a/src/utils/http/http-param-serializer.ts
+++ b/src/utils/http/http-param-serializer.ts
@@ -16,7 +16,7 @@ export function serializeParams(params: any): any {
 
 function serializeValue(value: any): string {
     return typeof value !== 'object'
-        ? value
+        ? encodeURIComponent(value)
         : toString.call(value) === '[object Date]'
             ? (value as Date).toISOString()
             : JSON.stringify(value);

--- a/src/utils/http/http.spec.ts
+++ b/src/utils/http/http.spec.ts
@@ -52,6 +52,10 @@ describe('http serializer', () => {
             expect(serializeParams({ param1: { a1: 'text', a2: 33, a3: true } })).toEqual('param1={"a1":"text","a2":33,"a3":true}');
         });
 
+        it(`should encode values`, () => {
+            expect(serializeParams({ param1: 'lksjadf==#sjhdfdfas' })).toEqual('param1=lksjadf%3D%3D%23sjhdfdfas');
+        });
+
         it('should serialize dates', () => {
             // support DST
             expect(['param1=2019-07-23T00:00:00.000Z', 'param1=2019-07-23T04:00:00.000Z', 'param1=2019-07-23T05:00:00.000Z']).toContain(serializeParams({ param1: new Date(2019, 6, 23) }));


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Add encoding so that ?token=lksjadf==#sjhdfdfas becomes ?token=lksjadf%3D%3D%23sjhdfdfas
The removal of qs.stringify brought up this issue.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/ENA2-7102
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
