### PR TITLE
Updated Vue peer dependency to 2.6.4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "zingtouch": "^1.0.6"
     },
     "peerDependencies": {
-        "vue": "^2.5.9",
+        "vue": "^2.6.4",
         "vue-router": "^3.0.1"
     },
     "devDependencies": {
@@ -128,7 +128,7 @@
         "typescript-tslint-plugin": "^0.3.0",
         "uglifyjs-webpack-plugin": "^2.1.2",
         "url-loader": "^1.1.2",
-        "vue": "^2.5.23",
+        "vue": "^2.6.10",
         "vue-class-component": "^6.1.1",
         "vue-loader": "^15.7.0",
         "vue-property-decorator": "^6.0.0",


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

- [x] Provide a small description of the changes introduced by this PR

Dans le but d'unifier graduellement les composantes-modul vers la nouvelle syntaxe des slots vue 2.6.4+(https://vuejs.org/v2/guide/components-slots.html#Named-Slots)  tel que discuté dans #1097  
Je propose de bumpé la version minimal requise de vue a 2.6.4 + au lieu de 2.5.9 . 

Selon ce que j'ai vu dans ena2 et ael il ne devrait pas y avoir d'impact dans ces projets.


- [x] Include this section in the release notes

**modul now required vue 2.6.4+** to ensure your project meets the required peer depency run `npm install ` you should not see any peer dependencies warning regardins modul-component

if a warning occur , run this command to update Vue

`npm update vue`