### PR TITLE
Bugfix/should not export third party types

### DIFF
--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -1,5 +1,5 @@
+import { sprintf, vsprintf } from 'sprintf-js';
 import Vue, { PluginObject } from 'vue';
-import { sprintf, vsprintf } from '../str/str';
 
 
 declare module 'vue/types/vue' {

--- a/src/utils/str/str.ts
+++ b/src/utils/str/str.ts
@@ -478,5 +478,4 @@ export function normalizeString(str: string): string {
 
 export const NBSP: string = '\xa0';
 
-export { sprintf, vsprintf } from 'sprintf-js';
 


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR

Fix pour pas que modul export des types provenant de librairie externe qui force les projets qui utilise  modul à installer les types manquant.

Dans ce cas, sprintf-js qui est utilisé par i18n.

- [ ] Include links to issues
<!-- Links here... -->
- [ ] Openshift deployment requested


