### PR TITLE
Feature/modul 1166 avatar touch

### DIFF
--- a/src/components/avatar/avatar.spec.ts
+++ b/src/components/avatar/avatar.spec.ts
@@ -5,6 +5,7 @@ const REF_AVATAR: RefSelector = { ref: 'avatar' };
 
 let wrapper: Wrapper<MAvatar>;
 let propsClickable: boolean = false;
+let slotContent: string = '';
 
 const initializeShallowWrapper: any = () => {
     wrapper = shallowMount(MAvatar, {
@@ -18,6 +19,9 @@ const initializeShallowWrapper: any = () => {
                     $off: jest.fn()
                 }
             }
+        },
+        scopedSlots: {
+            content: slotContent
         }
     });
 };
@@ -26,6 +30,7 @@ describe('MAvatar', () => {
 
     beforeEach(() => {
         propsClickable = false;
+        slotContent = '';
     });
 
     describe(`When someone click on the avatar`, () => {
@@ -148,12 +153,11 @@ describe('MAvatar', () => {
 
             beforeEach(() => {
                 propsClickable = true;
-                initializeShallowWrapper();
             });
 
-            describe(`and the avatar is not touched`, () => {
-                it(`should not emit touch`, () => {
-                    wrapper.vm.isTouched = false;
+            describe(`and there's no content slot`, () => {
+                it(`should emit touch`, () => {
+                    initializeShallowWrapper();
 
                     wrapper.vm.onTouchend();
 
@@ -161,13 +165,28 @@ describe('MAvatar', () => {
                 });
             });
 
-            describe(`and the avatar is touched`, () => {
-                it(`should emit touch`, () => {
-                    wrapper.vm.isTouched = true;
+            describe('with a content slot', () => {
+                describe(`and the avatar is not touched`, () => {
+                    it(`should not emit touch`, () => {
+                        slotContent = '<div class="content-slot" />';
+                        initializeShallowWrapper();
 
-                    wrapper.vm.onTouchend();
+                        wrapper.vm.isTouched = false;
+                        wrapper.vm.onTouchend();
 
-                    expect(wrapper.emitted('touch')).toBeDefined();
+                        expect(wrapper.emitted('touch')).toBeUndefined();
+                    });
+                });
+
+                describe(`and the avatar is touched`, () => {
+                    it(`should emit touch`, () => {
+                        initializeShallowWrapper();
+                        wrapper.vm.isTouched = true;
+
+                        wrapper.vm.onTouchend();
+
+                        expect(wrapper.emitted('touch')).toBeDefined();
+                    });
                 });
             });
         });

--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -1,6 +1,7 @@
 import { actions } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/vue';
 import Vue from 'vue';
+import { DefaultMethods } from 'vue/types/options';
 import { componentsHierarchyRootSeparator } from '../../../conf/storybook/utils';
 import { AVATAR_NAME } from '../component-names';
 import AvatarPlugin, { MAvatarSize } from './avatar';
@@ -8,6 +9,10 @@ import AvatarPlugin, { MAvatarSize } from './avatar';
 Vue.use(AvatarPlugin);
 
 const image192: string = 'http://placekitten.com/192/192';
+const methods: DefaultMethods<Vue> = actions(
+    'click',
+    'touch'
+);
 
 storiesOf(`${componentsHierarchyRootSeparator}${AVATAR_NAME}`, module)
     .add('Small', () => ({
@@ -26,17 +31,11 @@ storiesOf(`${componentsHierarchyRootSeparator}${AVATAR_NAME}`, module)
         template: `<m-avatar :size="${MAvatarSize.LARGE}"><m-icon name="m-svg__profile" :size="${MAvatarSize.LARGE}"></m-icon></m-avatar>`
     }))
     .add('Clickable', () => ({
-        methods: actions(
-            'click',
-            'touch'
-        ),
+        methods,
         template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true" @click="click" @touch="touch"><img src="${image192}"></m-avatar>`
     }))
     .add('Custom slot - animation', () => ({
-        methods: actions(
-            'click',
-            'touch'
-        ),
+        methods,
         template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true" @click="click" @touch="touch">
                         <div slot="content" slot-scope={contentVisible} style="
                             transition: all 0.1s linear;

--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -1,3 +1,4 @@
+import { actions } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/vue';
 import Vue from 'vue';
 import { componentsHierarchyRootSeparator } from '../../../conf/storybook/utils';
@@ -28,7 +29,11 @@ storiesOf(`${componentsHierarchyRootSeparator}${AVATAR_NAME}`, module)
         template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true"><img src="${image192}"></m-avatar>`
     }))
     .add('Custom slot - animation', () => ({
-        template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true">
+        methods: actions(
+            'click',
+            'touch'
+        ),
+        template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true" @click="click" @touch="touch">
                         <div slot="content" slot-scope={contentVisible} style="
                             transition: all 0.1s linear;
                             width: 100%;

--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -26,7 +26,11 @@ storiesOf(`${componentsHierarchyRootSeparator}${AVATAR_NAME}`, module)
         template: `<m-avatar :size="${MAvatarSize.LARGE}"><m-icon name="m-svg__profile" :size="${MAvatarSize.LARGE}"></m-icon></m-avatar>`
     }))
     .add('Clickable', () => ({
-        template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true"><img src="${image192}"></m-avatar>`
+        methods: actions(
+            'click',
+            'touch'
+        ),
+        template: `<m-avatar :size="${MAvatarSize.LARGE}" :clickable="true" @click="click" @touch="touch"><img src="${image192}"></m-avatar>`
     }))
     .add('Custom slot - animation', () => ({
         methods: actions(

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -66,6 +66,10 @@ export class MAvatar extends Vue {
         return this.hover || this.isTouched;
     }
 
+    get emptyContentSlot(): boolean {
+        return !this.$scopedSlots.content;
+    }
+
     get hover(): boolean {
         return this.isHovered;
     }
@@ -86,7 +90,7 @@ export class MAvatar extends Vue {
 
     onTouchend(): void {
         if (this.clickable) {
-            if (this.isTouched) {
+            if (this.isTouched || this.emptyContentSlot) {
                 this.resetTouch();
                 this.emitTouch();
             } else {

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -66,7 +66,7 @@ export class MAvatar extends Vue {
         return this.hover || this.isTouched;
     }
 
-    get emptyContentSlot(): boolean {
+    get isEmptyContentSlot(): boolean {
         return !this.$scopedSlots.content;
     }
 
@@ -90,7 +90,7 @@ export class MAvatar extends Vue {
 
     onTouchend(): void {
         if (this.clickable) {
-            if (this.isTouched || this.emptyContentSlot) {
+            if (this.isTouched || this.isEmptyContentSlot) {
                 this.resetTouch();
                 this.emitTouch();
             } else {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Auparavant, en mobile, on cliquait sur l'avatar et on affichait son hover. On demandait ensuite un nouveau click pour valider l'événement. 

Par contre, si on veut utiliser l'avatar uniquement comme un bouton, il n'aura pas de contenu dans la slot "content" et on ne veut pas devoir faire un double click. On vérifie donc si la slot est vide.
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1166
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes
<!-- Release notes here... -->
- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
