### PR TITLE
MODUL-1162 - apply stroke in m-link only with 'svg__chevron'

### DIFF
--- a/src/components/error-pages/error-access-denied/__snapshots__/error-access-denied.stories.ts.snap
+++ b/src/components/error-pages/error-access-denied/__snapshots__/error-access-denied.stories.ts.snap
@@ -156,9 +156,9 @@ exports[`Storyshots components|m-error-access-denied links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -190,9 +190,9 @@ exports[`Storyshots components|m-error-access-denied links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                

--- a/src/components/error-pages/error-browser-not-supported/__snapshots__/error-browser-not-supported.stories.ts.snap
+++ b/src/components/error-pages/error-browser-not-supported/__snapshots__/error-browser-not-supported.stories.ts.snap
@@ -252,9 +252,9 @@ exports[`Storyshots components|m-error-browser-not-supported linksMobile 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -286,9 +286,9 @@ exports[`Storyshots components|m-error-browser-not-supported linksMobile 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                

--- a/src/components/error-pages/error-config-not-supported/__snapshots__/error-config-not-supported.stories.ts.snap
+++ b/src/components/error-pages/error-config-not-supported/__snapshots__/error-config-not-supported.stories.ts.snap
@@ -166,9 +166,9 @@ exports[`Storyshots components|m-error-config-not-supported links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -200,9 +200,9 @@ exports[`Storyshots components|m-error-config-not-supported links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                

--- a/src/components/error-pages/error-cookies-not-supported/__snapshots__/error-cookies-not-supported.stories.ts.snap
+++ b/src/components/error-pages/error-cookies-not-supported/__snapshots__/error-cookies-not-supported.stories.ts.snap
@@ -54,9 +54,9 @@ exports[`Storyshots components|m-error-cookies-not-supported default 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -141,9 +141,9 @@ exports[`Storyshots components|m-error-cookies-not-supported hints 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -222,9 +222,9 @@ exports[`Storyshots components|m-error-cookies-not-supported links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -256,9 +256,9 @@ exports[`Storyshots components|m-error-cookies-not-supported links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -340,9 +340,9 @@ exports[`Storyshots components|m-error-cookies-not-supported title 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                

--- a/src/components/error-pages/error-page-not-found/__snapshots__/error-page-not-found.stories.ts.snap
+++ b/src/components/error-pages/error-page-not-found/__snapshots__/error-page-not-found.stories.ts.snap
@@ -54,9 +54,9 @@ exports[`Storyshots components|m-error-page-not-found default 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -141,9 +141,9 @@ exports[`Storyshots components|m-error-page-not-found hints 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -222,9 +222,9 @@ exports[`Storyshots components|m-error-page-not-found links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -256,9 +256,9 @@ exports[`Storyshots components|m-error-page-not-found links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -340,9 +340,9 @@ exports[`Storyshots components|m-error-page-not-found title 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                

--- a/src/components/error-pages/error-technical-difficulty/__snapshots__/error-technical-difficulty.stories.ts.snap
+++ b/src/components/error-pages/error-technical-difficulty/__snapshots__/error-technical-difficulty.stories.ts.snap
@@ -99,9 +99,9 @@ exports[`Storyshots components|m-error-technical-difficulty Error 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -225,9 +225,9 @@ exports[`Storyshots components|m-error-technical-difficulty default 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -351,9 +351,9 @@ exports[`Storyshots components|m-error-technical-difficulty errorDate (5 days be
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -477,9 +477,9 @@ exports[`Storyshots components|m-error-technical-difficulty errorReferenceNumber
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -604,9 +604,9 @@ exports[`Storyshots components|m-error-technical-difficulty hints 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -730,9 +730,9 @@ exports[`Storyshots components|m-error-technical-difficulty links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -764,9 +764,9 @@ exports[`Storyshots components|m-error-technical-difficulty links 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -895,9 +895,9 @@ exports[`Storyshots components|m-error-technical-difficulty showStackTrace 1`] =
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                
@@ -1019,9 +1019,9 @@ exports[`Storyshots components|m-error-technical-difficulty title 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="m-icon m-link__icon"
-              height="12px"
-              width="12px"
+              class="m-icon m-link__icon m--has-large-stroke"
+              height="1em"
+              width="1em"
             >
               <!---->
                

--- a/src/components/link/__snapshots__/link.stories.ts.snap
+++ b/src/components/link/__snapshots__/link.stories.ts.snap
@@ -35,7 +35,7 @@ exports[`Storyshots components|m-link disabled 1`] = `
 </a>
 `;
 
-exports[`Storyshots components|m-link icon 1`] = `
+exports[`Storyshots components|m-link icon-chevron 1`] = `
 <a
   class="m-link m--has-left-icon m--has-content"
   href="#"
@@ -43,7 +43,7 @@ exports[`Storyshots components|m-link icon 1`] = `
 >
   <svg
     aria-hidden="true"
-    class="m-icon m-link__icon"
+    class="m-icon m-link__icon m--has-large-stroke"
     height="12px"
     width="12px"
   >
@@ -74,8 +74,8 @@ exports[`Storyshots components|m-link icon-name 1`] = `
   <svg
     aria-hidden="true"
     class="m-icon m-link__icon"
-    height="12px"
-    width="12px"
+    height="1em"
+    width="1em"
   >
     <!---->
      
@@ -103,7 +103,7 @@ exports[`Storyshots components|m-link icon-position="right" 1`] = `
 >
   <svg
     aria-hidden="true"
-    class="m-icon m-link__icon"
+    class="m-icon m-link__icon m--has-large-stroke"
     height="12px"
     width="12px"
   >
@@ -193,24 +193,12 @@ exports[`Storyshots components|m-link tabindex="1" 1`] = `
 
 exports[`Storyshots components|m-link target 1`] = `
 <a
-  class="m-link m--has-left-icon m--has-content"
+  class="m-link m--has-content"
   href="#"
   tabindex="0"
   target="self"
 >
-  <svg
-    aria-hidden="true"
-    class="m-icon m-link__icon"
-    height="12px"
-    width="12px"
-  >
-    <!---->
-     
-    <use
-      aria-hidden="true"
-      class=""
-    />
-  </svg>
+  <!---->
    
   <span
     class="m-link__text"
@@ -350,7 +338,7 @@ exports[`Storyshots components|m-link/skin="light" default 1`] = `
 </div>
 `;
 
-exports[`Storyshots components|m-link/skin="light" icon 1`] = `
+exports[`Storyshots components|m-link/skin="light" icon-chevron 1`] = `
 <div>
   <a
     class="m-link m--is-skin-light m--has-left-icon m--has-content"
@@ -359,7 +347,7 @@ exports[`Storyshots components|m-link/skin="light" icon 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="m-icon m-link__icon"
+      class="m-icon m-link__icon m--has-large-stroke"
       height="12px"
       width="12px"
     >
@@ -392,8 +380,8 @@ exports[`Storyshots components|m-link/skin="light" icon-name="m-svg__clock" 1`] 
     <svg
       aria-hidden="true"
       class="m-icon m-link__icon"
-      height="12px"
-      width="12px"
+      height="1em"
+      width="1em"
     >
       <!---->
        
@@ -423,7 +411,7 @@ exports[`Storyshots components|m-link/skin="light" icon-position="right" 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="m-icon m-link__icon"
+      class="m-icon m-link__icon m--has-large-stroke"
       height="12px"
       width="12px"
     >
@@ -496,7 +484,7 @@ exports[`Storyshots components|m-link/skin="text" default 1`] = `
 </a>
 `;
 
-exports[`Storyshots components|m-link/skin="text" icon 1`] = `
+exports[`Storyshots components|m-link/skin="text" icon-chevron 1`] = `
 <a
   class="m-link m--is-skin-text m--has-left-icon m--has-content"
   href="#"
@@ -504,7 +492,7 @@ exports[`Storyshots components|m-link/skin="text" icon 1`] = `
 >
   <svg
     aria-hidden="true"
-    class="m-icon m-link__icon"
+    class="m-icon m-link__icon m--has-large-stroke"
     height="12px"
     width="12px"
   >
@@ -528,23 +516,11 @@ exports[`Storyshots components|m-link/skin="text" icon 1`] = `
 
 exports[`Storyshots components|m-link/skin="text" icon-name="m-svg__clock" 1`] = `
 <a
-  class="m-link m--is-skin-text m--has-left-icon m--has-content"
+  class="m-link m--is-skin-text m--has-content"
   href="#"
   tabindex="0"
 >
-  <svg
-    aria-hidden="true"
-    class="m-icon m-link__icon"
-    height="12px"
-    width="12px"
-  >
-    <!---->
-     
-    <use
-      aria-hidden="true"
-      class=""
-    />
-  </svg>
+  <!---->
    
   <span
     class="m-link__text"
@@ -564,7 +540,7 @@ exports[`Storyshots components|m-link/skin="text" icon-position="right" 1`] = `
 >
   <svg
     aria-hidden="true"
-    class="m-icon m-link__icon"
+    class="m-icon m-link__icon m--has-large-stroke"
     height="12px"
     width="12px"
   >

--- a/src/components/link/__snapshots__/link.stories.ts.snap
+++ b/src/components/link/__snapshots__/link.stories.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots components|m-link bullet-point-icon 1`] = `
+<a
+  class="m-link m--has-content"
+  href="#"
+  tabindex="0"
+>
+  <svg
+    aria-hidden="true"
+    class="m-icon m-link__icon m--has-large-stroke"
+    height="12px"
+    width="12px"
+  >
+    <!---->
+     
+    <use
+      aria-hidden="true"
+      class=""
+    />
+  </svg>
+   
+  <span
+    class="m-link__text"
+  >
+    A link
+  </span>
+   
+  <!---->
+</a>
+`;
+
 exports[`Storyshots components|m-link default 1`] = `
 <a
   class="m-link m--has-content"
@@ -24,36 +54,6 @@ exports[`Storyshots components|m-link disabled 1`] = `
   tabindex="-1"
 >
   <!---->
-   
-  <span
-    class="m-link__text"
-  >
-    A link
-  </span>
-   
-  <!---->
-</a>
-`;
-
-exports[`Storyshots components|m-link icon-chevron 1`] = `
-<a
-  class="m-link m--has-left-icon m--has-content"
-  href="#"
-  tabindex="0"
->
-  <svg
-    aria-hidden="true"
-    class="m-icon m-link__icon m--has-large-stroke"
-    height="12px"
-    width="12px"
-  >
-    <!---->
-     
-    <use
-      aria-hidden="true"
-      class=""
-    />
-  </svg>
    
   <span
     class="m-link__text"
@@ -104,8 +104,8 @@ exports[`Storyshots components|m-link icon-position="right" 1`] = `
   <svg
     aria-hidden="true"
     class="m-icon m-link__icon m--has-large-stroke"
-    height="12px"
-    width="12px"
+    height="1em"
+    width="1em"
   >
     <!---->
      
@@ -318,30 +318,10 @@ exports[`Storyshots components|m-link/mode mode="link 1`] = `
 </a>
 `;
 
-exports[`Storyshots components|m-link/skin="light" default 1`] = `
+exports[`Storyshots components|m-link/skin="light" bullet-point-icon 1`] = `
 <div>
   <a
     class="m-link m--is-skin-light m--has-content"
-    href="#"
-    tabindex="0"
-  >
-    <!---->
-     
-    <span
-      class="m-link__text"
-    >
-      A link
-    </span>
-     
-    <!---->
-  </a>
-</div>
-`;
-
-exports[`Storyshots components|m-link/skin="light" icon-chevron 1`] = `
-<div>
-  <a
-    class="m-link m--is-skin-light m--has-left-icon m--has-content"
     href="#"
     tabindex="0"
   >
@@ -358,6 +338,26 @@ exports[`Storyshots components|m-link/skin="light" icon-chevron 1`] = `
         class=""
       />
     </svg>
+     
+    <span
+      class="m-link__text"
+    >
+      A link
+    </span>
+     
+    <!---->
+  </a>
+</div>
+`;
+
+exports[`Storyshots components|m-link/skin="light" default 1`] = `
+<div>
+  <a
+    class="m-link m--is-skin-light m--has-content"
+    href="#"
+    tabindex="0"
+  >
+    <!---->
      
     <span
       class="m-link__text"
@@ -412,8 +412,8 @@ exports[`Storyshots components|m-link/skin="light" icon-position="right" 1`] = `
     <svg
       aria-hidden="true"
       class="m-icon m-link__icon m--has-large-stroke"
-      height="12px"
-      width="12px"
+      height="1em"
+      width="1em"
     >
       <!---->
        
@@ -466,27 +466,9 @@ exports[`Storyshots components|m-link/skin="light" icon-size="20px" 1`] = `
 </div>
 `;
 
-exports[`Storyshots components|m-link/skin="text" default 1`] = `
+exports[`Storyshots components|m-link/skin="text" bullet-point-icon 1`] = `
 <a
   class="m-link m--is-skin-text m--has-content"
-  href="#"
-  tabindex="0"
->
-  <!---->
-   
-  <span
-    class="m-link__text"
-  >
-    A link
-  </span>
-   
-  <!---->
-</a>
-`;
-
-exports[`Storyshots components|m-link/skin="text" icon-chevron 1`] = `
-<a
-  class="m-link m--is-skin-text m--has-left-icon m--has-content"
   href="#"
   tabindex="0"
 >
@@ -503,6 +485,24 @@ exports[`Storyshots components|m-link/skin="text" icon-chevron 1`] = `
       class=""
     />
   </svg>
+   
+  <span
+    class="m-link__text"
+  >
+    A link
+  </span>
+   
+  <!---->
+</a>
+`;
+
+exports[`Storyshots components|m-link/skin="text" default 1`] = `
+<a
+  class="m-link m--is-skin-text m--has-content"
+  href="#"
+  tabindex="0"
+>
+  <!---->
    
   <span
     class="m-link__text"
@@ -541,8 +541,8 @@ exports[`Storyshots components|m-link/skin="text" icon-position="right" 1`] = `
   <svg
     aria-hidden="true"
     class="m-icon m-link__icon m--has-large-stroke"
-    height="12px"
-    width="12px"
+    height="1em"
+    width="1em"
   >
     <!---->
      

--- a/src/components/link/__snapshots__/link.stories.ts.snap
+++ b/src/components/link/__snapshots__/link.stories.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots components|m-link bullet-point-icon 1`] = `
+exports[`Storyshots components|m-link bullet-point 1`] = `
 <a
   class="m-link m--has-content"
   href="#"
@@ -318,7 +318,7 @@ exports[`Storyshots components|m-link/mode mode="link 1`] = `
 </a>
 `;
 
-exports[`Storyshots components|m-link/skin="light" bullet-point-icon 1`] = `
+exports[`Storyshots components|m-link/skin="light" bullet-point 1`] = `
 <div>
   <a
     class="m-link m--is-skin-light m--has-content"
@@ -466,7 +466,7 @@ exports[`Storyshots components|m-link/skin="light" icon-size="20px" 1`] = `
 </div>
 `;
 
-exports[`Storyshots components|m-link/skin="text" bullet-point-icon 1`] = `
+exports[`Storyshots components|m-link/skin="text" bullet-point 1`] = `
 <a
   class="m-link m--is-skin-text m--has-content"
   href="#"

--- a/src/components/link/link.html
+++ b/src/components/link/link.html
@@ -14,10 +14,11 @@
                  :tabindex="disabled ? '-1' : tabindex"
                  ref="router"
                  :event="routerEvent">
-        <m-icon :name="propIconName"
-                :size="iconSize"
+        <m-icon v-if="hasIcon"
                 class="m-link__icon"
-                v-if="hasIcon"
+                :class="{ 'm--has-large-stroke': iconHasLargeStroke }"
+                :name="propIconName"
+                :size="propIconSize"
                 aria-hidden="true"></m-icon>
         <span class="m-link__text">
             <slot></slot>
@@ -43,10 +44,11 @@
        @keyup="onKeyup"
        :tabindex="disabled ? '-1' : tabindex"
        ref="link">
-        <m-icon class="m-link__icon"
+        <m-icon v-if="hasIcon"
+                class="m-link__icon"
+                :class="{ 'm--has-large-stroke': iconHasLargeStroke }"
                 :name="propIconName"
-                :size="iconSize"
-                v-if="hasIcon"
+                :size="propIconSize"
                 aria-hidden="true"></m-icon>
         <span class="m-link__text">
             <slot></slot>

--- a/src/components/link/link.scss
+++ b/src/components/link/link.scss
@@ -89,7 +89,10 @@
         display: inline-flex;
         flex-shrink: 0;
         vertical-align: middle;
-        stroke-width: 2px;
+
+        &.m--has-large-stroke {
+            stroke-width: 2px;
+        }
     }
 
     &__hidden {

--- a/src/components/link/link.stories.ts
+++ b/src/components/link/link.stories.ts
@@ -60,8 +60,8 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
         },
         template: '<m-link :target="target" mode="link" url="#">A link</m-link>'
     }))
-    .add('icon-chevron', () => ({
-        template: '<m-link mode="link" url="#" :icon-chevron="true">A link</m-link>'
+    .add('bullet-point-icon', () => ({
+        template: '<m-link mode="link" url="#" :bullet-point-icon="true">A link</m-link>'
     }))
     .add('icon-size', () => ({
         props: {
@@ -89,7 +89,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
         template: '<m-link :icon-name="iconName" mode="link" url="#" >A link</m-link>'
     }))
     .add('icon-position="right"', () => ({
-        template: '<m-link mode="link" url="#" :icon-chevron="true" icon-position="right">A link</m-link>'
+        template: '<m-link mode="link" url="#" icon-name="m-svg__chevron--right" icon-position="right">A link</m-link>'
     }))
     .add('tabindex="1"', () => ({
         template: '<m-link mode="link" url="#" tabindex="1">A link</m-link>'
@@ -105,14 +105,14 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/skin="light"`, module
                         <m-link mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
-    .add('icon-chevron', () => ({
+    .add('bullet-point-icon', () => ({
         template: `<div style="background: grey;">
-                        <m-link :icon-chevron="true" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link :bullet-point-icon="true" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
     .add('icon-position="right"', () => ({
         template: `<div style="background: grey;">
-                        <m-link :icon-chevron="true" icon-position="right" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link icon-name="m-svg__chevron--right" icon-position="right" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
     .add('icon-name="m-svg__clock"', () => ({
@@ -132,14 +132,14 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/skin="text"`, module)
     .add('default', () => ({
         template: '<m-link mode="link" url="#" skin="text">A link</m-link>'
     }))
-    .add('icon-chevron', () => ({
-        template: '<m-link :icon-chevron="true" mode="link" url="#" skin="text">A link</m-link>'
+    .add('bullet-point-icon', () => ({
+        template: '<m-link :bullet-point-icon="true" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-name="m-svg__clock"', () => ({
         template: '<m-link :icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-position="right"', () => ({
-        template: '<m-link icon-position="right" :icon-chevron="true" mode="link" url="#" skin="text">A link</m-link>'
+        template: '<m-link icon-position="right" icon-name="m-svg__chevron--right" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-size="20px"', () => ({
         template: '<m-link icon-size="20px" icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'

--- a/src/components/link/link.stories.ts
+++ b/src/components/link/link.stories.ts
@@ -50,7 +50,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
     .add('target', () => ({
         props: {
             target: {
-                default: select('iconName', {
+                default: select('target', {
                     'self': '_self',
                     'blank': '_blank',
                     'parent': '_parent',
@@ -58,10 +58,10 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
                 }, 'self')
             }
         },
-        template: '<m-link :target="target" mode="link" url="#" icon-name="iconName">A link</m-link>'
+        template: '<m-link :target="target" mode="link" url="#">A link</m-link>'
     }))
-    .add('icon', () => ({
-        template: '<m-link mode="link" url="#" :icon="true">A link</m-link>'
+    .add('icon-chevron', () => ({
+        template: '<m-link mode="link" url="#" :icon-chevron="true">A link</m-link>'
     }))
     .add('icon-size', () => ({
         props: {
@@ -69,7 +69,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
                 default: text('iconSize', '20px')
             }
         },
-        template: '<m-link :icon="true" mode="link" url="#" :icon-size="iconSize">A link</m-link>'
+        template: '<m-link icon-name="m-svg__calendar" mode="link" url="#" :icon-size="iconSize">A link</m-link>'
     }))
     .add('icon-name', () => ({
         props: {
@@ -89,7 +89,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
         template: '<m-link :icon-name="iconName" mode="link" url="#" >A link</m-link>'
     }))
     .add('icon-position="right"', () => ({
-        template: '<m-link mode="link" url="#" :icon="true" icon-position="right">A link</m-link>'
+        template: '<m-link mode="link" url="#" :icon-chevron="true" icon-position="right">A link</m-link>'
     }))
     .add('tabindex="1"', () => ({
         template: '<m-link mode="link" url="#" tabindex="1">A link</m-link>'
@@ -105,24 +105,24 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/skin="light"`, module
                         <m-link mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
-    .add('icon', () => ({
+    .add('icon-chevron', () => ({
         template: `<div style="background: grey;">
-                        <m-link :icon="true" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link :icon-chevron="true" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
     .add('icon-position="right"', () => ({
         template: `<div style="background: grey;">
-                        <m-link :icon="true" icon-position="right" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link :icon-chevron="true" icon-position="right" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
     .add('icon-name="m-svg__clock"', () => ({
         template: `<div style="background: grey;">
-                        <m-link :icon="true" icon-name="m-svg__clock" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link icon-name="m-svg__clock" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
     .add('icon-size="20px"', () => ({
         template: `<div style="background: grey;">
-                        <m-link :icon="true" icon-size="20px" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link icon-name="m-svg__clock" icon-size="20px" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }));
 
@@ -132,14 +132,14 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/skin="text"`, module)
     .add('default', () => ({
         template: '<m-link mode="link" url="#" skin="text">A link</m-link>'
     }))
-    .add('icon', () => ({
-        template: '<m-link :icon="true" mode="link" url="#" skin="text">A link</m-link>'
+    .add('icon-chevron', () => ({
+        template: '<m-link :icon-chevron="true" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-name="m-svg__clock"', () => ({
-        template: '<m-link :icon="true" icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'
+        template: '<m-link :icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-position="right"', () => ({
-        template: '<m-link icon-position="right" icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'
+        template: '<m-link icon-position="right" :icon-chevron="true" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-size="20px"', () => ({
         template: '<m-link icon-size="20px" icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'
@@ -160,4 +160,3 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/mode`, module)
     .add('mode="button"', () => ({
         template: '<m-link mode="button" url="http://www.google.ca">A link</m-link>'
     }));
-

--- a/src/components/link/link.stories.ts
+++ b/src/components/link/link.stories.ts
@@ -60,8 +60,8 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}`, module)
         },
         template: '<m-link :target="target" mode="link" url="#">A link</m-link>'
     }))
-    .add('bullet-point-icon', () => ({
-        template: '<m-link mode="link" url="#" :bullet-point-icon="true">A link</m-link>'
+    .add('bullet-point', () => ({
+        template: '<m-link mode="link" url="#" :bullet-point="true">A link</m-link>'
     }))
     .add('icon-size', () => ({
         props: {
@@ -105,9 +105,9 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/skin="light"`, module
                         <m-link mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
-    .add('bullet-point-icon', () => ({
+    .add('bullet-point', () => ({
         template: `<div style="background: grey;">
-                        <m-link :bullet-point-icon="true" mode="link" url="#" skin="light">A link</m-link>
+                        <m-link :bullet-point="true" mode="link" url="#" skin="light">A link</m-link>
                    </div>`
     }))
     .add('icon-position="right"', () => ({
@@ -132,8 +132,8 @@ storiesOf(`${componentsHierarchyRootSeparator}${LINK_NAME}/skin="text"`, module)
     .add('default', () => ({
         template: '<m-link mode="link" url="#" skin="text">A link</m-link>'
     }))
-    .add('bullet-point-icon', () => ({
-        template: '<m-link :bullet-point-icon="true" mode="link" url="#" skin="text">A link</m-link>'
+    .add('bullet-point', () => ({
+        template: '<m-link :bullet-point="true" mode="link" url="#" skin="text">A link</m-link>'
     }))
     .add('icon-name="m-svg__clock"', () => ({
         template: '<m-link :icon-name="m-svg__clock" mode="link" url="#" skin="text">A link</m-link>'

--- a/src/components/link/link.ts
+++ b/src/components/link/link.ts
@@ -26,7 +26,7 @@ export enum MLinkSkin {
     Text = 'text'
 }
 
-const ICON_NAME_DEFAULT: string = 'm-svg__chevron--right';
+const ICON_NAME_CHEVRON: string = 'm-svg__chevron--right';
 
 @WithRender
 @Component
@@ -68,6 +68,9 @@ export class MLink extends ModulVue {
     public icon: boolean;
 
     @Prop()
+    public iconChevron: boolean;
+
+    @Prop()
     public iconName: string;
 
     @Prop({
@@ -77,7 +80,7 @@ export class MLink extends ModulVue {
     })
     public iconPosition: MLinkIconPosition;
 
-    @Prop({ default: '12px' })
+    @Prop({ default: '1em' })
     public iconSize: string;
 
     @Prop({ default: '0' })
@@ -116,6 +119,18 @@ export class MLink extends ModulVue {
         return this.mode === MLinkMode.RouterLink;
     }
 
+    public get iconHasLargeStroke(): boolean {
+        switch (this.propIconName) {
+            case 'm-svg__chevron--up':
+            case 'm-svg__chevron--right':
+            case 'm-svg__chevron--down':
+            case 'm-svg__chevron--left':
+                return true;
+            default:
+                return false;
+        }
+    }
+
     private onKeyup(event): void {
         event = event || window.event;
         if (event.keyCode === KeyCode.M_SPACE && this.isButton) {
@@ -147,16 +162,16 @@ export class MLink extends ModulVue {
         return this.hasIcon && this.iconPosition === MLinkIconPosition.Right;
     }
 
-    private get hasIcon(): boolean {
-        return this.iconName !== undefined && this.iconName !== ''
-            ? true
-            : this.icon;
+    public get hasIcon(): boolean {
+        return this.iconChevron || Boolean(this.propIconName);
+    }
+
+    public get propIconSize(): string {
+        return this.iconChevron ? '12px' : this.iconSize;
     }
 
     private get propIconName(): string {
-        return this.iconName !== undefined && this.iconName !== ''
-            ? this.iconName
-            : ICON_NAME_DEFAULT;
+        return this.iconChevron ? ICON_NAME_CHEVRON : this.iconName;
     }
 
     private get propUrl(): string | undefined {

--- a/src/components/link/link.ts
+++ b/src/components/link/link.ts
@@ -65,7 +65,7 @@ export class MLink extends ModulVue {
     public target: string;
 
     @Prop()
-    public bulletPointIcon: boolean;
+    public bulletPoint: boolean;
 
     @Prop()
     public iconName: string;
@@ -152,23 +152,23 @@ export class MLink extends ModulVue {
     }
 
     private get isIconPositionLeft(): boolean {
-        return (this.hasIcon && this.iconPosition === MLinkIconPosition.Left) && !this.bulletPointIcon;
+        return (this.hasIcon && this.iconPosition === MLinkIconPosition.Left) && !this.bulletPoint;
     }
 
     private get isIconPositionRight(): boolean {
-        return this.hasIcon && this.iconPosition === MLinkIconPosition.Right && !this.bulletPointIcon;
+        return this.hasIcon && this.iconPosition === MLinkIconPosition.Right && !this.bulletPoint;
     }
 
     public get hasIcon(): boolean {
-        return Boolean(this.propIconName) || this.bulletPointIcon;
+        return Boolean(this.propIconName) || this.bulletPoint;
     }
 
     public get propIconSize(): string {
-        return this.bulletPointIcon ? '12px' : this.iconSize;
+        return this.bulletPoint ? '12px' : this.iconSize;
     }
 
     private get propIconName(): string {
-        return this.bulletPointIcon ? ICON_NAME_CHEVRON : this.iconName;
+        return this.bulletPoint ? ICON_NAME_CHEVRON : this.iconName;
     }
 
     private get propUrl(): string | undefined {

--- a/src/components/link/link.ts
+++ b/src/components/link/link.ts
@@ -65,10 +65,7 @@ export class MLink extends ModulVue {
     public target: string;
 
     @Prop()
-    public icon: boolean;
-
-    @Prop()
-    public iconChevron: boolean;
+    public bulletPointIcon: boolean;
 
     @Prop()
     public iconName: string;
@@ -155,23 +152,23 @@ export class MLink extends ModulVue {
     }
 
     private get isIconPositionLeft(): boolean {
-        return this.hasIcon && this.iconPosition === MLinkIconPosition.Left;
+        return (this.hasIcon && this.iconPosition === MLinkIconPosition.Left) && !this.bulletPointIcon;
     }
 
     private get isIconPositionRight(): boolean {
-        return this.hasIcon && this.iconPosition === MLinkIconPosition.Right;
+        return this.hasIcon && this.iconPosition === MLinkIconPosition.Right && !this.bulletPointIcon;
     }
 
     public get hasIcon(): boolean {
-        return this.iconChevron || Boolean(this.propIconName);
+        return Boolean(this.propIconName) || this.bulletPointIcon;
     }
 
     public get propIconSize(): string {
-        return this.iconChevron ? '12px' : this.iconSize;
+        return this.bulletPointIcon ? '12px' : this.iconSize;
     }
 
     private get propIconName(): string {
-        return this.iconChevron ? ICON_NAME_CHEVRON : this.iconName;
+        return this.bulletPointIcon ? ICON_NAME_CHEVRON : this.iconName;
     }
 
     private get propUrl(): string | undefined {

--- a/src/components/tooltip/__snapshots__/tooltip.spec.ts.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`tooltip should render correctly when is open 1`] = `
 
 exports[`tooltip should render correctly when mode is link 1`] = `
 <m-popup-stub placement="bottom" openTrigger="click" closeOnBackdrop="true" width="auto" paddingHeader="true" paddingBody="true" paddingFooter="true" lazy="true" class="m-tooltip">
-  <m-link-stub url="/" mode="button" underline="true" skin="default" iconPosition="left" iconSize="12px" tabindex="0" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-tooltip__link">Link</m-link-stub>
+  <m-link-stub url="/" mode="button" underline="true" skin="default" iconPosition="left" iconSize="1em" tabindex="0" id="mTooltip-uuid" aria-haspopup="true" aria-controls="mTooltip-uuid-controls" class="m-tooltip__link">Link</m-link-stub>
   <div id="mTooltip-uuid-controls" aria-labelledby="mTooltip-uuid" class="m-tooltip__body-container m--has-close-button">
     <m-icon-button-stub skin="light" buttonSize="44px" iconName="m-svg__close-clear" iconSize="14px" ripple="true" svg-tile="m-tooltip:close" class="m-tooltip__close-button"></m-icon-button-stub>
     <div class="m-tooltip__body">Tooltip text</div>


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] the stroke in the m-link icon will be applicated only if with the arrow icon (chevron-{down, up, left, right})
<!-- Description here... -->
- [x] https://jira.dti.ulaval.ca/projects/MODUL/issues/MODUL-1162

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
