### PR TITLE
MODUL-1179 - use one level darker for disabled colors

### DIFF
--- a/src/styles/variables/_var-color.scss
+++ b/src/styles/variables/_var-color.scss
@@ -79,8 +79,8 @@ $m-color--active: $m-color--ul-yellow !default;
 // ======================================================================
 //  disabled colors
 // ======================================================================
-$m-color--disabled: $m-color--grey-light !default;
-$m-color--disabled-light: $m-color--grey-lighter !default;
+$m-color--disabled: $m-color--grey !default;
+$m-color--disabled-light: $m-color--grey-light !default;
 
 // ======================================================================
 //  Scrollbar colors


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [x] Provide a small description of the changes introduced by this PR
Disabled colors have been darkened by one level.
<!-- Description here... -->
- [x] Include links to issues
https://jira.dti.ulaval.ca/browse/MODUL-1179
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- Thanks for contributing! -->
