### PR TITLE
Différencier le errorMessage vs errorMessageDeep

### DIFF
--- a/src/utils/form/abstract-control.ts
+++ b/src/utils/form/abstract-control.ts
@@ -79,8 +79,7 @@ export abstract class AbstractControl<T = any> {
     }
 
     /**
-     * Gets the first error message, if any, of one of the children control errors.
-     * The current control errors are excluded.
+     * Gets the first error message, if any, of one of the current control and children control errors.
      */
     public get errorMessageDeep(): string {
         if (this.hasErrorDeep()) {

--- a/src/utils/form/abstract-control.ts
+++ b/src/utils/form/abstract-control.ts
@@ -66,6 +66,10 @@ export abstract class AbstractControl<T = any> {
         return this.errorsDeep.length > 0;
     }
 
+    /**
+     * Gets the first error message, if any, of the current control errors.
+     * Children errors are excluded.
+     */
     public get errorMessage(): string {
         if (this.hasError()) {
             return getString(this.errors[0].message);
@@ -74,6 +78,10 @@ export abstract class AbstractControl<T = any> {
         }
     }
 
+    /**
+     * Gets the first error message, if any, of one of the children control errors.
+     * The current control errors are excluded.
+     */
     public get errorMessageDeep(): string {
         if (this.hasErrorDeep()) {
             return getString(this.errorsDeep[0].message);

--- a/src/utils/form/abstract-control.ts
+++ b/src/utils/form/abstract-control.ts
@@ -67,6 +67,14 @@ export abstract class AbstractControl<T = any> {
     }
 
     public get errorMessage(): string {
+        if (this.hasError()) {
+            return getString(this.errors[0].message);
+        } else {
+            return '';
+        }
+    }
+
+    public get errorMessageDeep(): string {
         if (this.hasErrorDeep()) {
             return getString(this.errorsDeep[0].message);
         } else {


### PR DESCRIPTION
## `@ulaval/modul-components`
# PR Checklist

<!--
Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Update "[ ]" to "[x]" to check a box
Content can be written in English or in French
-->

<!-- REQUIRED -->
- [ ] Provide a small description of the changes introduced by this PR
<!-- Description here... -->
- [ ] Include links to issues
<!-- Links here... -->
- [ ] Openshift deployment requested

<!-- END_REQUIRED -->

<!-- OPTIONAL, remove unused -->
- [ ] Include this section in the release notes

The getter `errorMessage` in `AbstractControl` do not include childs errors anymore, if you need to include all childs errors use `errorMessageDeep`  instead

- [ ] Other info
<!-- Any other relevant information here... -->

<!-- END_OPTIONAL -->

<!-- Thanks for contributing! -->
